### PR TITLE
impl. `return` in block

### DIFF
--- a/builtin/_lambda.sk
+++ b/builtin/_lambda.sk
@@ -1,6 +1,7 @@
 class Fn
   EXIT_NORMAL = 0
   EXIT_BREAK = 1
+  EXIT_RETURN = 2
 
   def initialize(
     @func: Shiika::Internal::Ptr,

--- a/builtin/_lambda.sk
+++ b/builtin/_lambda.sk
@@ -1,14 +1,9 @@
 class Fn
-  EXIT_NORMAL = 0
-  EXIT_BREAK = 1
-  EXIT_RETURN = 2
-
   def initialize(
     @func: Shiika::Internal::Ptr,
     @the_self: Object,
     @captures: Array<Shiika::Internal::Ptr>,
   )
-    @exit_status = EXIT_NORMAL
   end
 end
 

--- a/doc/spec/src/expressions.md
+++ b/doc/spec/src/expressions.md
@@ -199,7 +199,10 @@ Type of a while expressions is `Void`.
 1. Find the nearest `while`/fn/block
 1. If the found one is `while`, escape from the `while`
 1. If the found one is fn, compile-time error
-1. If the found one is block, escape from the method that given the block
+1. If the found one is a block passed to a method:
+  1. If the return type of the block is not `Void`, compile-time error
+  1. If the return type of the method is not `Void`, compile-time error
+  1. Otherwise, escape from the method
 1. If none found, compile-time error
 
 Example

--- a/src/code_gen/code_gen_context.rs
+++ b/src/code_gen/code_gen_context.rs
@@ -18,7 +18,7 @@ pub struct CodeGenContext<'hir: 'run, 'run> {
     /// End of the current llvm function. Only used for lambdas
     pub current_func_end: Rc<inkwell::basic_block::BasicBlock<'run>>,
     /// Arguments of `return` found in this context
-    pub returns: Vec<(inkwell::values::BasicValueEnum<'run>, inkwell::basic_block::BasicBlock<'run>)>,
+    pub returns: Vec<(Option<inkwell::values::BasicValueEnum<'run>>, inkwell::basic_block::BasicBlock<'run>)>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -10,28 +10,6 @@ use crate::ty::*;
 use inkwell::values::*;
 use std::rc::Rc;
 
-// REFACTOR: Move to mod.rs
-/// Number of items preceed actual arguments
-pub const METHOD_FUNC_ARG_HEADER_LEN: u32 = 2;
-/// Index of the receiver object in arguments of llvm func for Shiika method
-pub const METHOD_FUNC_ARG_SELF_IDX: u32 = 0;
-/// Number of items preceed actual arguments
-pub const LAMBDA_FUNC_ARG_HEADER_LEN: u32 = 2;
-/// Index of the FnX object in arguments of llvm func for Shiika lambda
-const LAMBDA_FUNC_ARG_FN_X_IDX: u32 = 0;
-/// Index of exit_status (of both method and lambda llvm func)
-const FUNC_ARG_EXIT_STATUS_INDEX: u32 = 1;
-/// Index of @func of FnX
-const FN_X_FUNC_IDX: usize = 0;
-/// Index of @the_self of FnX
-const FN_X_THE_SELF_IDX: usize = 1;
-/// Index of @captures of FnX
-const FN_X_CAPTURES_IDX: usize = 2;
-/// Value of exit_status indicates a block is terminated with `break`
-const EXIT_BREAK_IN_BLOCK: u64 = 1;
-/// Value of exit_status indicates a block is terminated with `return`
-const EXIT_RETURN_IN_BLOCK: u64 = 2;
-
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     pub fn gen_exprs(
         &self,

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -227,9 +227,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(merge_block);
 
         if then_exprs.ty.is_never_type() {
-            Ok(then_value)
-        } else if else_exprs.ty.is_never_type() {
             Ok(else_value)
+        } else if else_exprs.ty.is_never_type() {
+            Ok(then_value)
         } else {
             let phi_node = self.builder.build_phi(self.llvm_type(ty), "ifResult");
             phi_node.add_incoming(&[(&then_value, then_block_end), (&else_value, else_block_end)]);

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -26,10 +26,10 @@ const FN_X_FUNC_IDX: usize = 0;
 const FN_X_THE_SELF_IDX: usize = 1;
 /// Index of @captures of FnX
 const FN_X_CAPTURES_IDX: usize = 2;
-/// Fn::EXIT_BREAK
-const EXIT_BREAK: u64 = 1;
-/// Fn::EXIT_RETURN
-const EXIT_RETURN: u64 = 2;
+/// Value of exit_status indicates a block is terminated with `break`
+const EXIT_BREAK_IN_BLOCK: u64 = 1;
+/// Value of exit_status indicates a block is terminated with `return`
+const EXIT_RETURN_IN_BLOCK: u64 = 2;
 
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     pub fn gen_exprs(
@@ -282,7 +282,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 debug_assert!(ctx.function_origin == FunctionOrigin::Lambda);
                 // Set exit_status
                 let exit_status = ctx.function.get_nth_param(LAMBDA_FUNC_ARG_EXIT_STATUS_INDEX).unwrap();
-                let i = self.i64_type.const_int(EXIT_BREAK as u64, false);
+                let i = self.i64_type.const_int(EXIT_BREAK_IN_BLOCK as u64, false);
                 self.build_ivar_store(&exit_status, 0, i.into(), "exit_status");
 
                 // Jump to the end of the llvm func
@@ -304,7 +304,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             debug_assert!(ctx.function_origin == FunctionOrigin::Lambda);
             // Set exit_status
             let exit_status = ctx.function.get_nth_param(LAMBDA_FUNC_ARG_EXIT_STATUS_INDEX).unwrap();
-            let i = self.i64_type.const_int(EXIT_RETURN as u64, false);
+            let i = self.i64_type.const_int(EXIT_RETURN_IN_BLOCK as u64, false);
             self.build_ivar_store(&exit_status, 0, i.into(), "exit_status");
         } else {
             let value = self.gen_expr(ctx, arg)?;
@@ -470,7 +470,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             let eq = self.gen_llvm_func_call(
                 "Int#==",
                 exit_status,
-                vec![self.box_int(&self.i64_type.const_int(EXIT_BREAK, false))],
+                vec![self.box_int(&self.i64_type.const_int(EXIT_BREAK_IN_BLOCK, false))],
             )?;
             self.gen_conditional_branch(eq, *ctx.current_func_end, end_block);
         } else {

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -281,6 +281,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 let i = self.box_int(&self.i64_type.const_int(EXIT_BREAK, false));
                 self.build_ivar_store(&fn_x, FN_X_EXIT_STATUS_IDX, i, "@exit_status");
 
+                // Set exit_status
+                let exit_status = ctx.function.get_nth_param(LAMBDA_FUNC_ARG_EXIT_STATUS_INDEX).unwrap();
+                let i = self.i64_type.const_int(EXIT_BREAK as u64, false);
+                self.build_ivar_store(&exit_status, 0, i.into(), "exit_status");
+
                 // Jump to the end of the llvm func
                 self.builder
                     .build_unconditional_branch(*Rc::clone(&ctx.current_func_end));
@@ -303,6 +308,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             let i = self.box_int(&self.i64_type.const_int(EXIT_RETURN, false));
             self.build_ivar_store(&fn_x, FN_X_EXIT_STATUS_IDX, i, "@exit_status");
             self.builder.build_unconditional_branch(*ctx.current_func_end);
+            // Set exit_status
+            let exit_status = ctx.function.get_nth_param(LAMBDA_FUNC_ARG_EXIT_STATUS_INDEX).unwrap();
+            let i = self.i64_type.const_int(EXIT_RETURN as u64, false);
+            self.build_ivar_store(&exit_status, 0, i.into(), "exit_status");
         } else {
             let value = self.gen_expr(ctx, arg)?;
             // Jump to the end of the llvm func

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 /// Number of items preceed actual arguments
 pub const METHOD_FUNC_ARG_HEADER_LEN: u32 = 1;
 /// Index of the receiver object in arguments of llvm func for Shiika method
-const METHOD_FUNC_ARG_SELF_IDX: u32 = 0;
+pub const METHOD_FUNC_ARG_SELF_IDX: u32 = 0;
 /// Number of items preceed actual arguments
 pub const LAMBDA_FUNC_ARG_HEADER_LEN: u32 = 2;
 /// Index of the FnX object in arguments of llvm func for Shiika lambda

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -11,13 +11,15 @@ use inkwell::values::*;
 use std::rc::Rc;
 
 /// Number of items preceed actual arguments
-const METHOD_FUNC_ARG_HEADER_LEN: u32 = 1;
+pub const METHOD_FUNC_ARG_HEADER_LEN: u32 = 1;
 /// Index of the receiver object in arguments of llvm func for Shiika method
 const METHOD_FUNC_ARG_SELF_IDX: u32 = 0;
 /// Number of items preceed actual arguments
-const LAMBDA_FUNC_ARG_HEADER_LEN: u32 = 1;
+pub const LAMBDA_FUNC_ARG_HEADER_LEN: u32 = 2;
 /// Index of the FnX object in arguments of llvm func for Shiika lambda
 const LAMBDA_FUNC_ARG_FN_X_IDX: u32 = 0;
+/// Index of exit_status
+const LAMBDA_FUNC_ARG_EXIT_STATUS_INDEX: u32 = 1;
 /// Index of @the_self of FnX
 const FN_X_THE_SELF_IDX: usize = 1;
 /// Index of @captures of FnX
@@ -526,9 +528,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ret_ty: &TermTy,
     ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
         let fn_x_type = &ty::raw(&format!("Fn{}", params.len()));
+        let exit_status_type = &ty::raw("Int");
         let obj_type = ty::raw("Object");
         let mut arg_types = (1..=params.len()).map(|_| &obj_type).collect::<Vec<_>>();
         arg_types.insert(0, &fn_x_type);
+        arg_types.insert(1, &exit_status_type);
         let func_type = self.llvm_func_type(None, &arg_types, &ret_ty);
         self.module.add_function(&func_name, func_type, None);
 

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -75,7 +75,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                     self.gen_lambda_funcs_in_expr(expr)?;
                 }
             }
-            HirLambdaInvocation { lambda_expr, arg_exprs } => {
+            HirLambdaInvocation { lambda_expr, arg_exprs, .. } => {
                 self.gen_lambda_funcs_in_expr(lambda_expr)?;
                 for expr in arg_exprs {
                     self.gen_lambda_funcs_in_expr(expr)?;

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -462,14 +462,21 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
         // Set param names
         for (i, param) in function.get_param_iter().enumerate() {
-            let name = if i == 0 {
-                if is_lambda {
-                    "fn_x"
-                } else {
-                    "self"
+            let name = match i {
+                0 => if is_lambda { "fn_x" } else { "self" },
+                _ => {
+                    if is_lambda && i == 1 {
+                        "exit_status"
+                    }
+                    else {
+                        let header_len = if is_lambda {
+                            gen_exprs::LAMBDA_FUNC_ARG_HEADER_LEN
+                        } else {
+                            gen_exprs::METHOD_FUNC_ARG_HEADER_LEN
+                        };
+                        &params[i - (header_len as usize)].name
+                    }
                 }
-            } else {
-                &params[i - 1].name
             };
             inkwell_set_name(param, name);
         }

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -630,7 +630,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         Rc<inkwell::basic_block::BasicBlock<'run>>,
         CodeGenContext<'hir, 'run>,
     ) {
-        let end_block = self.context.append_basic_block(function, "End");
+        let end_block = self.context.append_basic_block(function, "LlvmFuncEnd");
         let ref_end_block1 = Rc::new(end_block);
         let ref_end_block2 = Rc::clone(&ref_end_block1);
         let ctx = CodeGenContext::new(function, ref_end_block1, origin, function_params, lvars);

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -194,14 +194,16 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     pub fn lambda_llvm_func_type(
         &self,
         n_params: usize,
+        param_tys: &[&TermTy],
         ret_ty: &TermTy,
     ) -> inkwell::types::FunctionType<'ictx> {
-        let fn_x_ty = ty::raw(&format!("Fn{}", n_params));
-        let exit_status_ty = ty::raw("Int");
-        let obj_ty = ty::raw("Object");
-        let header = [&fn_x_ty, &exit_status_ty];
-        let rest = [&obj_ty].repeat(n_params);
-        let params = header.iter().chain(rest.iter()).map(|ty| self.llvm_type(ty)).collect::<Vec<_>>();
+        let header = [
+            &ty::raw(&format!("Fn{}", n_params)), // self
+            &ty::raw("Int"), // exit_status
+            &ty::raw("Shiika::Internal::Ptr"), // fwdret
+        ];
+        let rest = param_tys.iter();
+        let params = header.iter().chain(rest).map(|ty| self.llvm_type(ty)).collect::<Vec<_>>();
         self.llvm_func_type(&params, &ret_ty)
     }
 

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -16,6 +16,16 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.build_return(Some(&v));
     }
 
+    /// Get the `nth` parameter (0-oriign) of the method llvm function
+    pub fn get_method_param(&self, function: &inkwell::values::FunctionValue<'run>, nth: usize) -> inkwell::values::BasicValueEnum<'run> {
+        function.get_params()[gen_exprs::METHOD_FUNC_ARG_HEADER_LEN as usize + nth]
+    }
+
+    /// Get the receiver of the method llvm function
+    pub fn get_method_receiver(&self, function: &inkwell::values::FunctionValue<'run>) -> inkwell::values::BasicValueEnum<'run> {
+        function.get_params()[gen_exprs::METHOD_FUNC_ARG_SELF_IDX as usize]
+    }
+
     /// Load value of an instance variable
     pub fn build_ivar_load(
         &self,

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -180,8 +180,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         param_tys: Vec<&TermTy>,
         ret_ty: &TermTy,
     ) -> inkwell::types::FunctionType<'ictx> {
-        let exit_status_type = ty::raw("Int");
-        let header = [self_ty, &exit_status_type];
+        let header = [
+            self_ty,
+            &ty::raw("Int"), // exit_status
+            &ty::raw("Shiika::Internal::Ptr"), // fwdret
+        ];
         let rest = param_tys.iter();
         let params = header.iter().chain(rest).map(|ty| self.llvm_type(ty)).collect::<Vec<_>>();
         self.llvm_func_type(&params, &ret_ty)

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -18,12 +18,12 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Get the `nth` parameter (0-oriign) of the method llvm function
     pub fn get_method_param(&self, function: &inkwell::values::FunctionValue<'run>, nth: usize) -> inkwell::values::BasicValueEnum<'run> {
-        function.get_params()[gen_exprs::METHOD_FUNC_ARG_HEADER_LEN as usize + nth]
+        function.get_params()[METHOD_FUNC_ARG_HEADER_LEN as usize + nth]
     }
 
     /// Get the receiver of the method llvm function
     pub fn get_method_receiver(&self, function: &inkwell::values::FunctionValue<'run>) -> inkwell::values::BasicValueEnum<'run> {
-        function.get_params()[gen_exprs::METHOD_FUNC_ARG_SELF_IDX as usize]
+        function.get_params()[METHOD_FUNC_ARG_SELF_IDX as usize]
     }
 
     /// Load value of an instance variable

--- a/src/corelib/array.rs
+++ b/src/corelib/array.rs
@@ -10,8 +10,7 @@ pub fn create_methods() -> Vec<SkMethod> {
         "Array",
         "_corelib_array_get(ptr: Shiika::Internal::Ptr) -> T",
         |code_gen, function| {
-            let sk_ptr = function.get_params()[1];
-            let i8ptr = code_gen.unbox_i8ptr(sk_ptr);
+            let i8ptr = code_gen.unbox_i8ptr(code_gen.get_method_param(function, 0));
             // Object = T's upper bound
             let obj_ptr_type = code_gen.llvm_type(&ty::raw("Object")).into_pointer_type();
             let obj_ptrptr_type = obj_ptr_type.ptr_type(inkwell::AddressSpace::Generic);

--- a/src/corelib/float.rs
+++ b/src/corelib/float.rs
@@ -9,10 +9,8 @@ macro_rules! create_comparison_method {
             "Float",
             format!("{}(other: Float) -> Bool", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
-                let val1 = code_gen.unbox_float(this);
-                let that = function.get_params()[1];
-                let val2 = code_gen.unbox_float(that);
+                let val1 = code_gen.unbox_float(code_gen.get_method_receiver(function));
+                let val2 = code_gen.unbox_float(code_gen.get_method_param(function, 0));
                 $body;
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_bool(result);
@@ -29,10 +27,8 @@ macro_rules! create_arithmetic_method {
             "Float",
             format!("{}(other: Float) -> Float", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
-                let val1 = code_gen.unbox_float(this);
-                let that = function.get_params()[1];
-                let val2 = code_gen.unbox_float(that);
+                let val1 = code_gen.unbox_float(code_gen.get_method_receiver(function));
+                let val2 = code_gen.unbox_float(code_gen.get_method_param(function, 0));
                 $body;
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_float(&result);
@@ -167,8 +163,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             }
         ),
         create_method("Float", "abs -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
-            let x = code_gen.unbox_float(this);
+            let x = code_gen.unbox_float(code_gen.get_method_receiver(function));
             let func = code_gen.module.get_function("fabs").unwrap();
             let result = code_gen
                 .builder
@@ -181,8 +176,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Float", "floor -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
-            let x = code_gen.unbox_float(this);
+            let x = code_gen.unbox_float(code_gen.get_method_receiver(function));
             let func = code_gen.module.get_function("floor").unwrap();
             let result = code_gen
                 .builder
@@ -195,8 +189,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Float", "to_i() -> Int", |code_gen, function| {
-            let this = function.get_params()[0];
-            let float = code_gen.unbox_float(this);
+            let float = code_gen.unbox_float(code_gen.get_method_receiver(function));
             let int = code_gen
                 .builder
                 .build_float_to_signed_int(float, code_gen.i64_type, "int");
@@ -205,8 +198,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Float", "-@ -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
-            let float = code_gen.unbox_float(this);
+            let float = code_gen.unbox_float(code_gen.get_method_receiver(function));
             let zero = code_gen.f64_type.const_float(0.0);
             let result = code_gen.builder.build_float_sub(zero, float, "result");
             let sk_result = code_gen.box_float(&result);

--- a/src/corelib/fn_x.rs
+++ b/src/corelib/fn_x.rs
@@ -20,17 +20,19 @@ macro_rules! create_fn_call {
             &format!("call({}) -> T", args_str),
             |code_gen, function| {
                 let fn_obj = function.get_params()[0];
+                let exit_status = code_gen.box_int(&code_gen.i64_type.const_int(0 as u64, false));
                 let sk_ptr = code_gen.build_ivar_load(fn_obj, FN_X_FUNC_IDX, "@func");
 
-                let mut args = vec![fn_obj];
+                let mut args = vec![fn_obj, exit_status];
                 for k in 1..=$i {
                     args.push(function.get_params()[k]);
                 }
 
                 // Create the type of lambda_xx()
                 let fn_x_type = code_gen.llvm_type(&ty::raw(&format!("Fn{}", $i)));
+                let exit_status_type = code_gen.llvm_type(&ty::raw("Int"));
                 let obj_type = code_gen.llvm_type(&ty::raw("Object"));
-                let mut arg_types = vec![fn_x_type.into()];
+                let mut arg_types = vec![fn_x_type.into(), exit_status_type.into()];
                 for _ in 1..=$i {
                     arg_types.push(obj_type.into());
                 }

--- a/src/corelib/int.rs
+++ b/src/corelib/int.rs
@@ -9,10 +9,8 @@ macro_rules! create_comparison_method {
             "Int",
             format!("{}(other: Int) -> Bool", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
-                let val1 = code_gen.unbox_int(this);
-                let that = function.get_params()[1];
-                let val2 = code_gen.unbox_int(that);
+                let val1 = code_gen.unbox_int(code_gen.get_method_receiver(function));
+                let val2 = code_gen.unbox_int(code_gen.get_method_param(function, 0));
                 $body;
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_bool(result);
@@ -29,10 +27,8 @@ macro_rules! create_arithmetic_method {
             "Int",
             format!("{}(other: Int) -> Int", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
-                let val1 = code_gen.unbox_int(this);
-                let that = function.get_params()[1];
-                let val2 = code_gen.unbox_int(that);
+                let val1 = code_gen.unbox_int(code_gen.get_method_receiver(function));
+                let val2 = code_gen.unbox_int(code_gen.get_method_param(function, 0));
                 $body;
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_int(&result);
@@ -220,8 +216,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             }
         ),
         create_method("Int", "to_f() -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
-            let int = code_gen.unbox_int(this);
+            let int = code_gen.unbox_int(code_gen.get_method_receiver(function));
             let float = code_gen
                 .builder
                 .build_signed_int_to_float(int, code_gen.f64_type, "float");
@@ -230,8 +225,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Int", "-@ -> Int", |code_gen, function| {
-            let sk_int = function.get_params()[0];
-            let this = code_gen.unbox_int(sk_int);
+            let this = code_gen.unbox_int(code_gen.get_method_receiver(function));
             let zero = code_gen.i64_type.const_int(0, false);
             let result = code_gen.builder.build_int_sub(zero, this, "result");
             let sk_result = code_gen.box_int(&result);

--- a/src/corelib/math.rs
+++ b/src/corelib/math.rs
@@ -7,7 +7,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Math",
             "sin(x: Float) -> Float",
             |code_gen, function| {
-                let arg = function.get_params()[1];
+                let arg = code_gen.get_method_param(function, 0);
                 let x = code_gen.unbox_float(arg);
                 let func = code_gen.module.get_function("sin").unwrap();
                 let result = code_gen
@@ -25,7 +25,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Math",
             "cos(x: Float) -> Float",
             |code_gen, function| {
-                let arg = function.get_params()[1];
+                let arg = code_gen.get_method_param(function, 0);
                 let x = code_gen.unbox_float(arg);
                 let func = code_gen.module.get_function("cos").unwrap();
                 let result = code_gen
@@ -43,7 +43,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Math",
             "sqrt(x: Float) -> Float",
             |code_gen, function| {
-                let arg = function.get_params()[1];
+                let arg = code_gen.get_method_param(function, 0);
                 let x = code_gen.unbox_float(arg);
                 let func = code_gen.module.get_function("sqrt").unwrap();
                 let result = code_gen

--- a/src/corelib/object.rs
+++ b/src/corelib/object.rs
@@ -9,8 +9,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Object", "putd(n: Int) -> Void", |code_gen, function| {
-            let sk_int = function.get_params()[1];
-            let n = code_gen.unbox_int(sk_int);
+            let n = code_gen.unbox_int(code_gen.get_method_param(function, 0));
             let printf = code_gen.module.get_function("printf").unwrap();
             let tmpl = code_gen
                 .module
@@ -30,8 +29,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Object", "putf(n: Float) -> Void", |code_gen, function| {
-            let arg = function.get_params()[1];
-            let n = code_gen.unbox_float(arg);
+            let n = code_gen.unbox_float(code_gen.get_method_param(function, 0));
             let printf = code_gen.module.get_function("printf").unwrap();
             let tmpl = code_gen
                 .module
@@ -51,7 +49,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Object", "puts(s: String) -> Void", |code_gen, function| {
-            let sk_str = function.get_params()[1];
+            let sk_str = code_gen.get_method_param(function, 0);
             let sk_ptr = code_gen.build_ivar_load(sk_str, 0, "@sk_ptr");
             let ptr = code_gen.unbox_i8ptr(sk_ptr);
             let func = code_gen.module.get_function("puts").unwrap();
@@ -63,8 +61,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             "Object",
             "exit(status: Int) -> Never",
             |code_gen, function| {
-                let sk_int = function.get_params()[1];
-                let int64 = code_gen.unbox_int(sk_int);
+                let int64 = code_gen.unbox_int(code_gen.get_method_param(function, 0));
                 let int32 = code_gen
                     .builder
                     .build_int_truncate(int64, code_gen.i32_type, "int32");
@@ -72,7 +69,7 @@ pub fn create_methods() -> Vec<SkMethod> {
                 code_gen
                     .builder
                     .build_call(func, &[int32.as_basic_value_enum()], "");
-                code_gen.builder.build_return(None);
+                code_gen.builder.build_unreachable();
                 Ok(())
             },
         ),

--- a/src/corelib/shiika_internal_memory.rs
+++ b/src/corelib/shiika_internal_memory.rs
@@ -8,7 +8,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Shiika::Internal::Memory",
             "gc_malloc(n_bytes: Int) -> Shiika::Internal::Ptr",
             |code_gen, function| {
-                let sk_int = function.get_params()[1];
+                let sk_int = code_gen.get_method_param(function, 0);
                 let n_bytes = code_gen.unbox_int(sk_int);
                 let n_bytes_64 =
                     code_gen
@@ -30,9 +30,8 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Shiika::Internal::Memory",
             "gc_realloc(ptr: Shiika::Internal::Ptr, n_bytes: Int) -> Shiika::Internal::Ptr",
             |code_gen, function| {
-                let ptr = code_gen.unbox_i8ptr(function.get_params()[1]);
-                let sk_int = function.get_params()[2];
-                let n_bytes = code_gen.unbox_int(sk_int);
+                let ptr = code_gen.unbox_i8ptr(code_gen.get_method_param(function, 0));
+                let n_bytes = code_gen.unbox_int(code_gen.get_method_param(function, 1));
                 let n_bytes_64 =
                     code_gen
                         .builder
@@ -57,9 +56,9 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Shiika::Internal::Memory",
             "memcpy(dst: Shiika::Internal::Ptr, src: Shiika::Internal::Ptr, n_bytes: Int) -> Void",
             |code_gen, function| {
-                let dst = code_gen.unbox_i8ptr(function.get_params()[1]);
-                let src = code_gen.unbox_i8ptr(function.get_params()[2]);
-                let n_bytes = code_gen.unbox_int(function.get_params()[3]);
+                let dst = code_gen.unbox_i8ptr(code_gen.get_method_param(function, 0));
+                let src = code_gen.unbox_i8ptr(code_gen.get_method_param(function, 1));
+                let n_bytes = code_gen.unbox_int(code_gen.get_method_param(function, 2));
                 let n_bytes_64 =
                     code_gen
                         .builder

--- a/src/hir/accessors.rs
+++ b/src/hir/accessors.rs
@@ -49,8 +49,9 @@ fn create_getter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
     };
     let name = ivar.name.clone(); // Clone to embed into the closure
     let idx = ivar.idx;
+    // REFACTOR: hir should not access to code_gen...
     let getter_body = move |code_gen: &CodeGen, function: &inkwell::values::FunctionValue| {
-        let this = function.get_params()[0];
+        let this = code_gen.get_method_receiver(function);
         let val = code_gen.build_ivar_load(this, idx, &name);
         code_gen.builder.build_return(Some(&val));
         Ok(())
@@ -80,8 +81,8 @@ fn create_setter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
     let ivar_name = ivar.name.clone(); // Clone to embed into the closure
     let idx = ivar.idx;
     let setter_body = move |code_gen: &CodeGen, function: &inkwell::values::FunctionValue| {
-        let this = function.get_params()[0];
-        let val = function.get_params()[1];
+        let this = code_gen.get_method_receiver(function);
+        let val = code_gen.get_method_param(function, 0);
         code_gen.build_ivar_store(&this, idx, val, &ivar_name);
         code_gen.builder.build_return(Some(&val));
         Ok(())

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -482,8 +482,6 @@ impl HirMaker {
         exprs: &[AstExpression],
         is_fn: &bool,
     ) -> Result<HirExpression, Error> {
-        self.lambda_ct += 1;
-        let lambda_id = self.lambda_ct;
         let hir_params = signature::convert_params(
             params,
             &self.current_class_typarams(),
@@ -502,14 +500,21 @@ impl HirMaker {
 
         let mut lambda_ctx = self.ctx.lambdas.pop().unwrap();
         Ok(Hir::lambda_expr(
-            lambda_ty(&hir_params, &hir_exprs.ty), // ty
-            format!("lambda_{}", lambda_id),       // name
+            lambda_ty(&hir_params, &hir_exprs.ty),
+            self._create_lambda_name(),
             hir_params,
             hir_exprs,
             self._resolve_lambda_captures(lambda_ctx.captures), // hir_captures
             extract_lvars(&mut lambda_ctx.lvars),               // lvars
             lambda_ctx.has_break,
         ))
+    }
+
+    /// Returns a newly created name for a lambda
+    fn _create_lambda_name(&mut self) -> String {
+        self.lambda_ct += 1;
+        let lambda_id = self.lambda_ct;
+        format!("lambda_{}_in_{}", lambda_id, self.ctx.describe_current_place())
     }
 
     /// Resolve LambdaCapture into HirExpression

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -185,9 +185,13 @@ impl HirMaker {
             type_checking::check_if_clauses_ty(&then_hirs.ty, &else_hirs.ty)?;
         }
 
-        let if_ty = if then_hirs.ty.is_never_type() {
+        let if_ty = if then_hirs.ty.is_never_type() && else_hirs.ty.is_never_type() {
+            ty::raw("Never")
+        } else if then_hirs.ty.is_never_type() {
             else_hirs.ty.clone()
-        } else if then_hirs.ty.is_void_type() {
+        } else if else_hirs.ty.is_never_type() {
+            then_hirs.ty.clone()
+        } else if then_hirs.ty.is_void_type() || else_hirs.ty.is_void_type() {
             ty::raw("Void")
         } else {
             then_hirs.ty.clone()

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -393,7 +393,8 @@ impl HirMaker {
         if receiver_expr.is_none() {
             if let Some(lvar) = self._lookup_var(&method_name.0) {
                 if let Some(ret_ty) = lvar.ty().fn_x_info() {
-                    return Ok(Hir::lambda_invocation(ret_ty, lvar.ref_expr(), arg_hirs));
+                    let breakable = ret_ty.is_void_type() && self.ctx.in_a_void_method();
+                    return Ok(Hir::lambda_invocation(ret_ty, lvar.ref_expr(), arg_hirs, breakable));
                 }
             }
         }

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -145,10 +145,16 @@ impl HirMakerContext {
         }
     }
 
-    /// Returns true if current context is a fn
+    /// Whether current context is a fn
     pub fn current_is_fn(&self) -> bool {
         self.current == CtxKind::Lambda &&
             self.lambdas.last().unwrap().is_fn
+    }
+
+    /// Whether current context is a method whose ret_ty is Void
+    pub fn in_a_void_method(&self) -> bool {
+        self.current == CtxKind::Method &&
+            self.method.as_ref().unwrap().signature.ret_ty.is_void_type()
     }
 
     /// Set `c` to `self.current` and the original value to `c`

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -157,6 +157,19 @@ impl HirMakerContext {
             self.method.as_ref().unwrap().signature.ret_ty.is_void_type()
     }
 
+    /// Returns a debugging string like "toplevel", "Class1", "Class1#method1", etc.
+    pub fn describe_current_place(&self) -> String {
+        if let Some(method_ctx) = &self.method {
+            method_ctx.signature.fullname.to_string().clone()
+        } else {
+            match self.current {
+                CtxKind::Toplevel => "toplevel".to_string(),
+                CtxKind::Class => self.classes.last().unwrap().namespace.0.clone(),
+                _ => panic!("must not happen"),
+            }
+        }
+    }
+
     /// Set `c` to `self.current` and the original value to `c`
     pub fn swap_current(&mut self, c: &mut CtxKind) {
         std::mem::swap(c, &mut self.current);

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -268,7 +268,7 @@ pub enum HirBreakFrom {
 }
 
 /// Denotes what a `return` escapes from
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum HirReturnFrom {
     Fn,
     Block,

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -182,6 +182,7 @@ pub enum HirExpressionBase {
     HirLambdaInvocation {
         lambda_expr: Box<HirExpression>,
         arg_exprs: Vec<HirExpression>,
+        breakable: bool,
     },
     HirArgRef {
         idx: usize,
@@ -412,12 +413,14 @@ impl Hir {
         result_ty: TermTy,
         varref_expr: HirExpression,
         arg_hirs: Vec<HirExpression>,
+        breakable: bool,
     ) -> HirExpression {
         HirExpression {
             ty: result_ty,
             node: HirExpressionBase::HirLambdaInvocation {
                 lambda_expr: Box::new(varref_expr),
                 arg_exprs: arg_hirs,
+                breakable,
             },
         }
     }

--- a/tests/sk/loops_and_conditionals.sk
+++ b/tests/sk/loops_and_conditionals.sk
@@ -55,12 +55,12 @@ class A
     return 1
   end
 
-#  def self.return_from_block -> Int
-#    [1, 2, 3].each do |i: Int|
-#      return 99 # Jumps to the end of the lambda, then
-#    end         # jumps to the end of `each`, and then
-#    return 0    # jumps to the end of the method
-#  end
+  def self.return_from_block -> Int
+    [1, 2, 3].each do |i: Int|
+      return 99 # Jumps to the end of the lambda, then
+    end         # jumps to the end of `each`, and then
+    return 0    # jumps to the end of the method
+  end
 
   def self.return_from_fn -> Int
     f = fn(){ return 1; 2 } # Jumps to the end of this fn
@@ -71,7 +71,7 @@ A.wo_arg
 A.wo_arg_end
 unless A.w_arg == 2; puts "ng w_arg" end
 unless A.w_arg_end == 1; puts "ng w_arg_end" end
-#unless A.return_from_block == 99; puts "ng return_from_block" end
+unless A.return_from_block == 99; puts "ng return_from_block" end
 unless A.return_from_fn == 1; puts "ng return_from_fn" end
 
 puts "ok"


### PR DESCRIPTION
This `return 99` should escape from the method, not only the block.
```
  def self.return_from_block -> Int
    [1, 2, 3].each do |i: Int|
      return 99 # Jumps to the end of the lambda, then
    end         # jumps to the end of `each`, and then
    return 0    # jumps to the end of the method
  end
```

fix #242

- [ ] codegen: Make LLVM functions return values (Shiika value + exit_status)
  - Add llvm struct type
  - Change method return value
  - Fix how to get the resulting value of a method call
- [ ] codegen: 
  - Escape with exit_status=RETURN when invoked lambda results in exit_status=RETURN
  - Escape current method if a mehtod call results in exit_status=RETURN 
- [ ] codegen: Remove exit_status from FnX
  - Fix return value of llvm function of lambda
  - Fix invocation of lambda
- [x] Add test