### PR TITLE
Precompile builtin/*.sk

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,4 +27,5 @@ jobs:
       - name: Build and test
         run: |
           set -eux
+          env -- LLC=llc-9 CLANG=clang-9 cargo run -- build_corelib
           env -- LLC=llc-9 CLANG=clang-9 cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,12 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap#ca6c84fa8aebfc487430854b53f176c264639cf8"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap_derive 3.0.0-beta.1 (git+https://github.com/clap-rs/clap)",
+ "clap_derive 3.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_str_bytes 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,14 +85,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap#ca6c84fa8aebfc487430854b53f176c264639cf8"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -134,9 +134,9 @@ name = "failure_derive"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -202,14 +202,19 @@ name = "inkwell_internals"
 version = "0.2.0"
 source = "git+https://github.com/TheDan64/inkwell?branch=llvm9-0#bd7d02142fcb4d10d5da3fb193f5e14f90152b3a"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "instant"
 version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -313,9 +318,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -324,14 +329,14 @@ name = "proc-macro-error-attr"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -342,7 +347,7 @@ name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -372,6 +377,11 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,17 +400,47 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.125 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.125 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "shiika"
 version = "0.0.1"
 dependencies = [
  "backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap)",
+ "clap 3.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "inkwell 0.1.0 (git+https://github.com/TheDan64/inkwell?branch=llvm9-0)",
  "llvm-sys 90.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.125 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -415,10 +455,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -428,9 +468,9 @@ name = "synstructure"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -528,8 +568,8 @@ dependencies = [
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap)" = "<none>"
-"checksum clap_derive 3.0.0-beta.1 (git+https://github.com/clap-rs/clap)" = "<none>"
+"checksum clap 3.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+"checksum clap_derive 3.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)" = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
 "checksum cloudabi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 "checksum either 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 "checksum env_logger 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
@@ -544,6 +584,7 @@ dependencies = [
 "checksum inkwell 0.1.0 (git+https://github.com/TheDan64/inkwell?branch=llvm9-0)" = "<none>"
 "checksum inkwell_internals 0.2.0 (git+https://github.com/TheDan64/inkwell?branch=llvm9-0)" = "<none>"
 "checksum instant 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+"checksum itoa 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 "checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
@@ -559,18 +600,22 @@ dependencies = [
 "checksum parking_lot_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 "checksum proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 "checksum proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+"checksum proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 "checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)" = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 "checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 "checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+"checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 1.0.125 (registry+https://github.com/rust-lang/crates.io-index)" = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+"checksum serde_derive 1.0.125 (registry+https://github.com/rust-lang/crates.io-index)" = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+"checksum serde_json 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)" = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 "checksum smallvec 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 "checksum strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-"checksum syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+"checksum syn 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)" = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 "checksum synstructure 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -186,21 +186,21 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=llvm9-0#bd7d02142fcb4d10d5da3fb193f5e14f90152b3a"
+source = "git+https://github.com/TheDan64/inkwell#f768691fccb04fe262a6ccf22c215657dc08de98"
 dependencies = [
  "either 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "inkwell_internals 0.2.0 (git+https://github.com/TheDan64/inkwell?branch=llvm9-0)",
+ "inkwell_internals 0.3.0 (git+https://github.com/TheDan64/inkwell)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "llvm-sys 90.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.2.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=llvm9-0#bd7d02142fcb4d10d5da3fb193f5e14f90152b3a"
+version = "0.3.0"
+source = "git+https://github.com/TheDan64/inkwell#f768691fccb04fe262a6ccf22c215657dc08de98"
 dependencies = [
  "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -237,7 +237,7 @@ name = "llvm-sys"
 version = "90.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -280,7 +280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -436,8 +436,7 @@ dependencies = [
  "either 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "inkwell 0.1.0 (git+https://github.com/TheDan64/inkwell?branch=llvm9-0)",
- "llvm-sys 90.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inkwell 0.1.0 (git+https://github.com/TheDan64/inkwell)",
  "log 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,7 +565,7 @@ dependencies = [
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)" = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+"checksum cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)" = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 3.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 "checksum clap_derive 3.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)" = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
@@ -581,8 +580,8 @@ dependencies = [
 "checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 "checksum humantime 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 "checksum indexmap 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
-"checksum inkwell 0.1.0 (git+https://github.com/TheDan64/inkwell?branch=llvm9-0)" = "<none>"
-"checksum inkwell_internals 0.2.0 (git+https://github.com/TheDan64/inkwell?branch=llvm9-0)" = "<none>"
+"checksum inkwell 0.1.0 (git+https://github.com/TheDan64/inkwell)" = "<none>"
+"checksum inkwell_internals 0.3.0 (git+https://github.com/TheDan64/inkwell)" = "<none>"
 "checksum instant 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 "checksum itoa 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -594,7 +593,7 @@ dependencies = [
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum miniz_oxide 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
 "checksum object 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
-"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+"checksum once_cell 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 "checksum os_str_bytes 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
 "checksum parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 "checksum parking_lot_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ authors = [ "Yutaka HARA <yutaka.hara.gmail.com>" ]
 
 [dependencies]
 backtrace = "0.3"
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "llvm9-0" }
-llvm-sys = "90.2.0"
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm9-0"] }
 failure = "0.1.6"
 clap = { version = "3.0.0-beta.2", features = ["yaml"] }
 either = "1.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ backtrace = "0.3"
 inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "llvm9-0" }
 llvm-sys = "90.2.0"
 failure = "0.1.6"
-clap = { git = "https://github.com/clap-rs/clap", version = "3.0.0-beta.1", features = ["yaml"]}
+clap = { version = "3.0.0-beta.2", features = ["yaml"] }
 either = "1.5.3"
 env_logger = "0.8.2"
 log = "0.4.11"
+serde = { version = "1.0.125", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,10 @@ export CPPFLAGS="-I$(brew --prefix)/opt/llvm@9/include"
 
 ```
 $ cargo build
+$ cargo run -- build_corelib
 ```
+
+The `build_corelib` subcommand compiles core classes (builtin/*.sk) into ./builtin/builtin.bc and ./builtin/exports.json. 
 
 ### Run tests
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -20,3 +20,6 @@ subcommands:
                 help: "Shiika source (*.sk)"
                 required: true
                 index: 1
+    
+    - build_corelib:
+        about: "Build corelib"

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -26,21 +26,26 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         exprs: &'hir HirExpressions,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        debug_assert!(!exprs.exprs.is_empty());
         let mut last_value = None;
-        exprs.exprs.iter().try_for_each(|expr| {
-            let value: inkwell::values::BasicValueEnum = self.gen_expr(ctx, &expr)?;
-            last_value = Some(value);
-            Ok(())
-        })?;
-        Ok(last_value.expect("[BUG] HirExpressions must have at least one expr"))
+        for expr in &exprs.exprs {
+            let value = self.gen_expr(ctx, &expr)?;
+            if value.is_none() {
+                log::warn!("detected unreachable code");
+                return Ok(None)
+            } else {
+                last_value = Some(value);
+            }
+        }
+        Ok(last_value.unwrap())
     }
 
     pub fn gen_expr(
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         expr: &'hir HirExpression,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         match &expr.node {
             HirLogicalNot { expr } => self.gen_logical_not(ctx, &expr),
             HirLogicalAnd { left, right } => self.gen_logical_and(ctx, &left, &right),
@@ -74,10 +79,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 lambda_expr,
                 arg_exprs,
             } => self.gen_lambda_invocation(ctx, lambda_expr, arg_exprs, &expr.ty),
-            HirArgRef { idx } => self.gen_arg_ref(ctx, idx),
+            HirArgRef { idx } => Ok(Some(self.gen_arg_ref(ctx, idx))),
             HirLVarRef { name } => self.gen_lvar_ref(ctx, name),
             HirIVarRef { name, idx, self_ty } => self.gen_ivar_ref(ctx, name, idx, self_ty),
-            HirConstRef { fullname } => Ok(self.gen_const_ref(fullname)),
+            HirConstRef { fullname } => Ok(Some(self.gen_const_ref(fullname))),
             HirLambdaExpr {
                 name,
                 params,
@@ -85,15 +90,15 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 ret_ty,
                 ..
             } => self.gen_lambda_expr(ctx, name, params, captures, ret_ty),
-            HirSelfExpression => self.gen_self_expression(ctx, &expr.ty),
+            HirSelfExpression => Ok(Some(self.gen_self_expression(ctx, &expr.ty))),
             HirArrayLiteral { exprs } => self.gen_array_literal(ctx, exprs),
-            HirFloatLiteral { value } => Ok(self.gen_float_literal(*value)),
-            HirDecimalLiteral { value } => Ok(self.gen_decimal_literal(*value)),
-            HirStringLiteral { idx } => Ok(self.gen_string_literal(idx)),
-            HirBooleanLiteral { value } => Ok(self.gen_boolean_literal(*value)),
+            HirFloatLiteral { value } => Ok(Some(self.gen_float_literal(*value))),
+            HirDecimalLiteral { value } => Ok(Some(self.gen_decimal_literal(*value))),
+            HirStringLiteral { idx } => Ok(Some(self.gen_string_literal(idx))),
+            HirBooleanLiteral { value } => Ok(Some(self.gen_boolean_literal(*value))),
 
             HirLambdaCaptureRef { idx, readonly } => {
-                self.gen_lambda_capture_ref(ctx, idx, !readonly, &expr.ty)
+                Ok(Some(self.gen_lambda_capture_ref(ctx, idx, !readonly, &expr.ty)))
             }
             HirLambdaCaptureWrite { cidx, rhs } => {
                 self.gen_lambda_capture_write(ctx, cidx, rhs, &rhs.ty)
@@ -102,7 +107,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             HirClassLiteral {
                 fullname,
                 str_literal_idx,
-            } => Ok(self.gen_class_literal(fullname, str_literal_idx)),
+            } => Ok(Some(self.gen_class_literal(fullname, str_literal_idx))),
         }
     }
 
@@ -110,12 +115,14 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         expr: &'hir HirExpression,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let b = self.gen_expr(ctx, expr)?;
-        let i = self.unbox_bool(b);
-        let one = self.i1_type.const_int(1, false);
-        let b2 = self.builder.build_int_sub(one, i, "b2");
-        Ok(self.box_bool(b2))
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        if let Some(b) = self.gen_expr(ctx, expr)? {
+            let i = self.unbox_bool(b);
+            let b2 = self.builder.build_not(i, "b2");
+            Ok(Some(self.box_bool(b2)))
+        } else {
+            Ok(None)
+        }
     }
 
     fn gen_logical_and(
@@ -123,20 +130,19 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
         left: &'hir HirExpression,
         right: &'hir HirExpression,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        // REFACTOR: use `and` of LLVM
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let begin_block = self.context.append_basic_block(ctx.function, "AndBegin");
         let more_block = self.context.append_basic_block(ctx.function, "AndMore");
         let merge_block = self.context.append_basic_block(ctx.function, "AndEnd");
         // AndBegin:
         self.builder.build_unconditional_branch(begin_block);
         self.builder.position_at_end(begin_block);
-        let left_value = self.gen_expr(ctx, left)?;
+        let left_value = self.gen_expr(ctx, left)?.unwrap();
         self.gen_conditional_branch(left_value, more_block, merge_block);
         let begin_block_end = self.builder.get_insert_block().unwrap();
         // AndMore:
         self.builder.position_at_end(more_block);
-        let right_value = self.gen_expr(ctx, right)?;
+        let right_value = self.gen_expr(ctx, right)?.unwrap();
         self.builder.build_unconditional_branch(merge_block);
         let more_block_end = self.builder.get_insert_block().unwrap();
         // AndEnd:
@@ -149,7 +155,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             (&left_value, begin_block_end),
             (&right_value, more_block_end),
         ]);
-        Ok(phi_node.as_basic_value())
+        Ok(Some(phi_node.as_basic_value()))
     }
 
     fn gen_logical_or(
@@ -157,19 +163,19 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
         left: &'hir HirExpression,
         right: &'hir HirExpression,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let begin_block = self.context.append_basic_block(ctx.function, "OrBegin");
         let else_block = self.context.append_basic_block(ctx.function, "OrElse");
         let merge_block = self.context.append_basic_block(ctx.function, "OrEnd");
         // OrBegin:
         self.builder.build_unconditional_branch(begin_block);
         self.builder.position_at_end(begin_block);
-        let left_value = self.gen_expr(ctx, left)?;
+        let left_value = self.gen_expr(ctx, left)?.unwrap();
         self.gen_conditional_branch(left_value, merge_block, else_block);
         let begin_block_end = self.builder.get_insert_block().unwrap();
         // OrElse:
         self.builder.position_at_end(else_block);
-        let right_value = self.gen_expr(ctx, right)?;
+        let right_value = self.gen_expr(ctx, right)?.unwrap();
         self.builder.build_unconditional_branch(merge_block);
         let else_block_end = self.builder.get_insert_block().unwrap();
         // OrEnd:
@@ -182,7 +188,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             (&left_value, begin_block_end),
             (&right_value, else_block_end),
         ]);
-        Ok(phi_node.as_basic_value())
+        Ok(Some(phi_node.as_basic_value()))
     }
 
     fn gen_if_expr(
@@ -192,7 +198,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         cond_expr: &'hir HirExpression,
         then_exprs: &'hir HirExpressions,
         else_exprs: &'hir HirExpressions,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let begin_block = self.context.append_basic_block(ctx.function, "IfBegin");
         let then_block = self.context.append_basic_block(ctx.function, "IfThen");
         let else_block = self.context.append_basic_block(ctx.function, "IfElse");
@@ -200,37 +206,39 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         // IfBegin:
         self.builder.build_unconditional_branch(begin_block);
         self.builder.position_at_end(begin_block);
-        let cond_value = self.gen_expr(ctx, cond_expr)?;
+        let cond_value = self.gen_expr(ctx, cond_expr)?.unwrap();
         self.gen_conditional_branch(cond_value, then_block, else_block);
         // IfThen:
         self.builder.position_at_end(then_block);
         let then_value = self.gen_exprs(ctx, then_exprs)?;
-        if then_exprs.ty.is_never_type() {
-            self.builder.build_unreachable();
-        } else {
+        if then_value.is_some() {
             self.builder.build_unconditional_branch(merge_block);
         }
         let then_block_end = self.builder.get_insert_block().unwrap();
         // IfElse:
         self.builder.position_at_end(else_block);
         let else_value = self.gen_exprs(ctx, else_exprs)?;
-        if else_exprs.ty.is_never_type() {
-            self.builder.build_unreachable();
-        } else {
+        if else_value.is_some() {
             self.builder.build_unconditional_branch(merge_block);
         }
         let else_block_end = self.builder.get_insert_block().unwrap();
-        // IfEnd:
-        self.builder.position_at_end(merge_block);
 
-        if then_exprs.ty.is_never_type() {
-            Ok(else_value)
-        } else if else_exprs.ty.is_never_type() {
-            Ok(then_value)
+        // IfEnd:
+        if then_value.is_none() && else_value.is_none() {
+            Ok(None)
         } else {
-            let phi_node = self.builder.build_phi(self.llvm_type(ty), "ifResult");
-            phi_node.add_incoming(&[(&then_value, then_block_end), (&else_value, else_block_end)]);
-            Ok(phi_node.as_basic_value())
+            self.builder.position_at_end(merge_block);
+            if then_value.is_none() {
+                Ok(else_value)
+            } else if else_value.is_none() {
+                Ok(then_value)
+            } else {
+                let phi_node = self.builder.build_phi(self.llvm_type(ty), "ifResult");
+                let v1 = then_value.unwrap();
+                let v2 = else_value.unwrap();
+                phi_node.add_incoming(&[(&v1, then_block_end), (&v2, else_block_end)]);
+                Ok(Some(phi_node.as_basic_value()))
+            }
         }
     }
 
@@ -239,12 +247,12 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
         cond_expr: &'hir HirExpression,
         body_exprs: &'hir HirExpressions,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let begin_block = self.context.append_basic_block(ctx.function, "WhileBegin");
         self.builder.build_unconditional_branch(begin_block);
         // WhileBegin:
         self.builder.position_at_end(begin_block);
-        let cond_value = self.gen_expr(ctx, cond_expr)?;
+        let cond_value = self.gen_expr(ctx, cond_expr)?.unwrap();
         let body_block = self.context.append_basic_block(ctx.function, "WhileBody");
         let end_block = self.context.append_basic_block(ctx.function, "WhileEnd");
         self.gen_conditional_branch(cond_value, body_block, end_block);
@@ -260,20 +268,19 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         // WhileEnd:
         self.builder.position_at_end(*rc2);
-        Ok(self.gen_const_ref(&const_fullname("::Void")))
+        Ok(Some(self.gen_const_ref(&const_fullname("::Void"))))
     }
 
     fn gen_break_expr(
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         from: &HirBreakFrom,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let dummy_value = self.i1_type.const_int(0, false).as_basic_value_enum();
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         match from {
             HirBreakFrom::While => match &ctx.current_loop_end {
                 Some(b) => {
                     self.builder.build_unconditional_branch(*Rc::clone(b));
-                    Ok(dummy_value)
+                    Ok(None)
                 }
                 None => Err(error::bug("break outside of a loop")),
             },
@@ -287,7 +294,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 // Jump to the end of the llvm func
                 self.builder
                     .build_unconditional_branch(*Rc::clone(&ctx.current_func_end));
-                Ok(dummy_value)
+                Ok(None)
             }
         }
     }
@@ -296,15 +303,14 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         arg: &'hir HirExpression,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let value = self.gen_expr(ctx, arg)?;
-        let dummy_value = self.i1_type.const_int(0, false).as_basic_value_enum();
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        let value = self.gen_expr(ctx, arg)?.unwrap();
         // Jump to the end of the llvm func
         self.builder
             .build_unconditional_branch(*Rc::clone(&ctx.current_func_end));
         let block_end = self.builder.get_insert_block().unwrap();
         ctx.returns.push((value, block_end));
-        Ok(dummy_value)
+        Ok(None)
     }
 
     fn gen_lvar_assign(
@@ -312,14 +318,14 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
         name: &str,
         rhs: &'hir HirExpression,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let value = self.gen_expr(ctx, rhs)?;
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        let value = self.gen_expr(ctx, rhs)?.unwrap();
         let ptr = ctx
             .lvars
             .get(name)
             .unwrap_or_else(|| panic!("[BUG] lvar `{}' not alloca'ed", name));
         self.builder.build_store(*ptr, value);
-        Ok(value)
+        Ok(Some(value))
     }
 
     fn gen_ivar_assign(
@@ -329,11 +335,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         idx: &usize,
         rhs: &'hir HirExpression,
         self_ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let object = self.gen_self_expression(ctx, self_ty)?;
-        let value = self.gen_expr(ctx, rhs)?;
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        let object = self.gen_self_expression(ctx, self_ty);
+        let value = self.gen_expr(ctx, rhs)?.unwrap();
         self.build_ivar_store(&object, *idx, value, name);
-        Ok(value)
+        Ok(Some(value))
     }
 
     fn gen_const_assign(
@@ -341,15 +347,15 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
         fullname: &ConstFullname,
         rhs: &'hir HirExpression,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let value = self.gen_expr(ctx, rhs)?;
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        let value = self.gen_expr(ctx, rhs)?.unwrap();
         let ptr = self
             .module
             .get_global(&fullname.0)
             .unwrap_or_else(|| panic!("[BUG] global for Constant `{}' not created", fullname.0))
             .as_pointer_value();
         self.builder.build_store(ptr, value);
-        Ok(value)
+        Ok(Some(value))
     }
 
     /// Generate method call
@@ -360,14 +366,14 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         receiver_expr: &'hir HirExpression,
         arg_exprs: &'hir [HirExpression],
         ret_ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         // Prepare arguments
         let method_name = &method_fullname.first_name;
-        let receiver_value = self.gen_expr(ctx, receiver_expr)?;
-        let arg_values = arg_exprs
-            .iter()
-            .map(|arg_expr| self.gen_expr(ctx, arg_expr))
-            .collect::<Result<Vec<_>, _>>()?;
+        let receiver_value = self.gen_expr(ctx, receiver_expr)?.unwrap();
+        let mut arg_values = vec![];
+        for arg_expr in arg_exprs {
+            arg_values.push(self.gen_expr(ctx, arg_expr)?.unwrap());
+        }
 
         // Create basic block
         let start_block = self
@@ -375,9 +381,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .append_basic_block(ctx.function, &format!("Invoke_{}", method_fullname));
         self.builder.build_unconditional_branch(start_block);
         self.builder.position_at_end(start_block);
-        let end_block = self
-            .context
-            .append_basic_block(ctx.function, &format!("Invoke_{}_end", method_fullname));
 
         // Get the llvm function from vtable
         let (idx, size) = self.lookup_vtable(&receiver_expr.ty, &method_name)?;
@@ -395,10 +398,18 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .into_pointer_value();
 
         // Invoke the llvm function
-        let result = self.gen_llvm_function_call(func, receiver_value, arg_values)?;
-        self.builder.build_unconditional_branch(end_block);
-        self.builder.position_at_end(end_block);
-        Ok(result)
+        let result = self.gen_llvm_function_call(func, receiver_value, arg_values);
+        if ret_ty.is_never_type() {
+            self.builder.build_unreachable();
+            Ok(None)
+        } else {
+            let end_block = self
+                .context
+                .append_basic_block(ctx.function, &format!("Invoke_{}_end", method_fullname));
+            self.builder.build_unconditional_branch(end_block);
+            self.builder.position_at_end(end_block);
+            Ok(Some(result))
+        }
     }
 
     /// Get the idx and size of vtable
@@ -422,14 +433,14 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         lambda_expr: &'hir HirExpression,
         arg_exprs: &'hir [HirExpression],
         ret_ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let lambda_obj = self.gen_expr(ctx, lambda_expr)?;
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        let lambda_obj = self.gen_expr(ctx, lambda_expr)?.unwrap();
         let n_args = arg_exprs.len();
 
         // Prepare arguments
         let mut args = vec![lambda_obj];
         for e in arg_exprs {
-            args.push(self.gen_expr(ctx, e)?);
+            args.push(self.gen_expr(ctx, e)?.unwrap());
         }
 
         // Create basic block
@@ -474,13 +485,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 "Int#==",
                 exit_status,
                 vec![self.box_int(&self.i64_type.const_int(EXIT_BREAK, false))],
-            )?;
+            );
             self.gen_conditional_branch(eq, *ctx.current_func_end, end_block);
         } else {
             self.builder.build_unconditional_branch(end_block);
         }
         self.builder.position_at_end(end_block);
-        Ok(result)
+        Ok(Some(result))
     }
 
     /// Generate llvm function call
@@ -489,18 +500,17 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         func_name: &str,
         receiver_value: inkwell::values::BasicValueEnum<'run>,
         arg_values: Vec<inkwell::values::BasicValueEnum<'run>>,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> inkwell::values::BasicValueEnum<'run> {
         let function = self.get_llvm_func(func_name);
         self.gen_llvm_function_call(function, receiver_value, arg_values)
     }
 
-    // REFACTOR: why returns Result?
     fn gen_llvm_function_call<F>(
         &self,
         function: F,
         receiver_value: inkwell::values::BasicValueEnum<'run>,
         mut arg_values: Vec<inkwell::values::BasicValueEnum<'run>>,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error>
+    ) -> inkwell::values::BasicValueEnum<'run>
     where
         F: Into<
             either::Either<
@@ -517,8 +527,8 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .try_as_basic_value()
             .left()
         {
-            Some(result_value) => Ok(result_value),
-            None => Ok(self.gen_const_ref(&const_fullname("::Void"))),
+            Some(result_value) => result_value,
+            None => self.gen_const_ref(&const_fullname("::Void")),
         }
     }
 
@@ -527,10 +537,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         idx: &usize,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> inkwell::values::BasicValueEnum<'run> {
         match ctx.function_origin {
             FunctionOrigin::Method => {
-                Ok(ctx.function.get_nth_param((*idx as u32) + 1).unwrap()) // +1 for the first %self
+                ctx.function.get_nth_param((*idx as u32) + 1).unwrap() // +1 for the first %self
             }
             FunctionOrigin::Lambda => {
                 // Bitcast is needed because lambda params are always `%Object*`
@@ -545,8 +555,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                         ))
                     });
                 let llvm_type = self.llvm_type(&ctx.function_params.unwrap()[*idx].ty);
-                let value = self.builder.build_bitcast(obj, llvm_type, "value");
-                Ok(value)
+                self.builder.build_bitcast(obj, llvm_type, "value")
             }
             _ => panic!("[BUG] arg ref in invalid place"),
         }
@@ -556,9 +565,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         name: &str,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let ptr = ctx.lvars.get(name).expect("[BUG] lvar not alloca'ed");
-        Ok(self.builder.build_load(*ptr, name))
+        Ok(Some(self.builder.build_load(*ptr, name)))
     }
 
     fn gen_ivar_ref(
@@ -567,9 +576,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         name: &str,
         idx: &usize,
         self_ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let object = self.gen_self_expression(ctx, self_ty)?;
-        Ok(self.build_ivar_load(object, *idx, name))
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        let object = self.gen_self_expression(ctx, self_ty);
+        Ok(Some(self.build_ivar_load(object, *idx, name)))
     }
 
     pub fn gen_const_ref(&self, fullname: &ConstFullname) -> inkwell::values::BasicValueEnum<'run> {
@@ -587,7 +596,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         params: &[MethodParam],
         captures: &'hir [HirLambdaCapture],
         ret_ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let fn_x_type = &ty::raw(&format!("Fn{}", params.len()));
         let obj_type = ty::raw("Object");
         let mut arg_types = (1..=params.len()).map(|_| &obj_type).collect::<Vec<_>>();
@@ -604,12 +613,12 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .as_basic_value_enum();
         let fnptr_i8 = self.builder.build_bitcast(fnptr, self.i8ptr_type, "");
         let sk_ptr = self.box_i8ptr(fnptr_i8.into_pointer_value());
-        let the_self = self.gen_self_expression(ctx, &ty::raw("Object"))?;
-        let arg_values = vec![sk_ptr, the_self, self.gen_lambda_captures(ctx, captures)?];
-        self.gen_llvm_func_call(&format!("Meta:{}#new", cls_name), meta, arg_values)
+        let the_self = self.gen_self_expression(ctx, &ty::raw("Object"));
+        let arg_values = vec![sk_ptr, the_self, self._gen_lambda_captures(ctx, captures)?];
+        Ok(Some(self.gen_llvm_func_call(&format!("Meta:{}#new", cls_name), meta, arg_values)))
     }
 
-    fn gen_lambda_captures(
+    fn _gen_lambda_captures(
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         captures: &'hir [HirLambdaCapture],
@@ -618,7 +627,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             "Meta:Array#new",
             self.gen_const_ref(&const_fullname("::Array")),
             vec![],
-        )?;
+        );
         for cap in captures {
             let item = match cap {
                 HirLambdaCapture::CaptureLVar { name } => {
@@ -627,11 +636,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 }
                 HirLambdaCapture::CaptureArg { idx } => {
                     // Args are captured by value
-                    self.gen_arg_ref(ctx, idx)?
+                    self.gen_arg_ref(ctx, idx)
                 }
                 HirLambdaCapture::CaptureFwd { cidx, ty } => {
                     let deref = false; // When forwarding, pass the item as is
-                    self.gen_lambda_capture_ref(ctx, cidx, deref, ty)?
+                    self.gen_lambda_capture_ref(ctx, cidx, deref, ty)
                 }
             };
             let obj = self.builder.build_bitcast(
@@ -639,7 +648,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 self.llvm_type(&ty::raw("Object")),
                 "capture_item",
             );
-            self.gen_llvm_func_call("Array#push", ary, vec![obj])?;
+            self.gen_llvm_func_call("Array#push", ary, vec![obj]);
         }
         Ok(ary)
     }
@@ -649,7 +658,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> inkwell::values::BasicValueEnum<'run> {
         let the_main = if ctx.function.get_name().to_str().unwrap() == "user_main" {
             self.the_main.unwrap()
         } else if ctx.function_origin == FunctionOrigin::Lambda {
@@ -659,9 +668,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             // The first arg of llvm function is `self`
             ctx.function.get_first_param().unwrap()
         };
-        Ok(self
+        self
             .builder
-            .build_bitcast(the_main, self.llvm_type(ty), "the_main"))
+            .build_bitcast(the_main, self.llvm_type(ty), "the_main")
     }
 
     /// Generate code for creating an array
@@ -669,20 +678,20 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         exprs: &'hir [HirExpression],
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let ary = self.gen_llvm_func_call(
             "Meta:Array#new",
             self.gen_const_ref(&const_fullname("::Array")),
             vec![],
-        )?;
+        );
         for expr in exprs {
-            let item = self.gen_expr(ctx, expr)?;
+            let item = self.gen_expr(ctx, expr)?.unwrap();
             let obj = self
                 .builder
                 .build_bitcast(item, self.llvm_type(&ty::raw("Object")), "obj");
-            self.gen_llvm_func_call("Array#push", ary, vec![obj])?;
+            self.gen_llvm_func_call("Array#push", ary, vec![obj]);
         }
-        Ok(ary)
+        Ok(Some(ary))
     }
 
     fn gen_float_literal(&self, value: f64) -> inkwell::values::BasicValueEnum<'run> {
@@ -712,7 +721,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let arg_values = vec![self.box_i8ptr(glob_i8), self.box_int(&bytesize)];
 
         self.gen_llvm_function_call(func, receiver_value, arg_values)
-            .unwrap()
     }
 
     fn gen_boolean_literal(&self, value: bool) -> inkwell::values::BasicValueEnum<'run> {
@@ -744,7 +752,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         idx_in_captures: &usize,
         deref: bool,
         ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> inkwell::values::BasicValueEnum<'run> {
         let block = self
             .context
             .append_basic_block(ctx.function, &format!("CaptureRef_{}th", idx_in_captures));
@@ -756,7 +764,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             "Array#[]",
             captures,
             vec![self.gen_decimal_literal(*idx_in_captures as i64)],
-        )?;
+        );
         let ret = if deref {
             // `item` is a pointer
             let ptr_ty = self.llvm_type(ty).ptr_type(AddressSpace::Generic);
@@ -776,7 +784,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         );
         self.builder.build_unconditional_branch(block);
         self.builder.position_at_end(block);
-        Ok(ret)
+        ret
     }
 
     fn gen_lambda_capture_write(
@@ -785,7 +793,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         idx_in_captures: &usize,
         rhs: &'hir HirExpression,
         ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let block = self
             .context
             .append_basic_block(ctx.function, &format!("CaptureWrite_{}th", idx_in_captures));
@@ -797,13 +805,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             "Array#[]",
             captures,
             vec![self.gen_decimal_literal(*idx_in_captures as i64)],
-        )?;
+        );
         let ptr_type = self.llvm_type(ty).ptr_type(AddressSpace::Generic);
         let ptr = self
             .builder
             .build_bitcast(ptr_, ptr_type, "ptr")
             .into_pointer_value();
-        let value = self.gen_expr(ctx, rhs)?;
+        let value = self.gen_expr(ctx, rhs)?.unwrap();
         self.builder.build_store(ptr, value);
 
         let block = self.context.append_basic_block(
@@ -812,7 +820,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         );
         self.builder.build_unconditional_branch(block);
         self.builder.position_at_end(block);
-        Ok(value)
+        Ok(Some(value))
     }
 
     fn _gen_get_lambda_captures(
@@ -828,13 +836,16 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
         expr: &'hir HirExpression,
         ty: &TermTy,
-    ) -> Result<inkwell::values::BasicValueEnum<'run>, Error> {
-        let obj = self.gen_expr(ctx, expr)?;
-        if expr.ty.equals_to(&ty) {
-            // No bitcast needed
-            Ok(obj)
+    ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
+        if let Some(obj) = self.gen_expr(ctx, expr)? {
+            if expr.ty.equals_to(&ty) {
+                // No bitcast needed
+                Ok(Some(obj))
+            } else {
+                Ok(Some(self.builder.build_bitcast(obj, self.llvm_type(ty), "as")))
+            }
         } else {
-            Ok(self.builder.build_bitcast(obj, self.llvm_type(ty), "as"))
+            Ok(None)
         }
     }
 

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -224,10 +224,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let else_block_end = self.builder.get_insert_block().unwrap();
 
         // IfEnd:
+        self.builder.position_at_end(merge_block);
         if then_value.is_none() && else_value.is_none() {
+            self.builder.build_unreachable();
             Ok(None)
         } else {
-            self.builder.position_at_end(merge_block);
             if then_value.is_none() {
                 Ok(else_value)
             } else if else_value.is_none() {

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -98,13 +98,15 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         self.gen_boxing_funcs();
         self.gen_method_funcs(&hir.sk_methods);
         self.gen_vtables();
-        self.impl_boxing_funcs();
         self.gen_methods(&hir.sk_methods)?;
         self.gen_const_inits(&hir.const_inits)?;
         self.gen_lambda_funcs(&hir)?;
         if self.generate_main {
             self.gen_user_main(&hir.main_exprs, &hir.main_lvars)?;
             self.gen_main()?;
+        } else {
+            // generating builtin
+            self.impl_boxing_funcs();
         }
         Ok(())
     }

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -7,7 +7,7 @@ use crate::code_gen::code_gen_context::*;
 use crate::code_gen::utils::llvm_vtable_name;
 use crate::error::Error;
 use crate::hir::*;
-use crate::library::ImportedItems;
+use crate::library::LibraryExports;
 use crate::mir;
 use crate::mir::*;
 use crate::names::*;
@@ -90,7 +90,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         }
     }
 
-    pub fn gen_program(&mut self, hir: &'hir Hir, imports: &ImportedItems) -> Result<(), Error> {
+    pub fn gen_program(&mut self, hir: &'hir Hir, imports: &LibraryExports) -> Result<(), Error> {
         self.gen_declares();
         self.gen_imports(imports);
         self.gen_class_structs(&hir.sk_classes);
@@ -177,7 +177,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
     }
 
     /// Generate information to use imported items
-    fn gen_imports(&mut self, imports: &ImportedItems) {
+    fn gen_imports(&mut self, imports: &LibraryExports) {
         self.gen_import_classes(&imports.sk_classes);
         self.gen_import_vtables(&imports.vtables);
         self.gen_import_constants(&imports.constants);

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -108,7 +108,6 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         self.gen_vtables();
         self.gen_methods(&hir.sk_methods)?;
         self.gen_const_inits(&hir.const_inits)?;
-        self.gen_lambda_funcs(&hir)?;
         if self.generate_main {
             self.gen_init_constants(&hir.const_inits, &imports.constants);
             self.gen_user_main(&hir.main_exprs, &hir.main_lvars)?;
@@ -118,6 +117,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             self.impl_boxing_funcs();
             self.gen_init_void();
         }
+        self.gen_lambda_funcs(&hir)?;
         Ok(())
     }
 

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -8,6 +8,7 @@ use crate::code_gen::utils::llvm_vtable_name;
 use crate::error;
 use crate::error::Error;
 use crate::hir::*;
+use crate::library::ImportedItems;
 use crate::mir;
 use crate::mir::*;
 use crate::names::*;
@@ -51,7 +52,7 @@ pub fn run(mir: &Mir, outpath: &str, generate_main: bool) -> Result<(), Error> {
     let module = context.create_module("main");
     let builder = context.create_builder();
     let mut code_gen = CodeGen::new(&mir, &context, &module, &builder, &generate_main);
-    code_gen.gen_program(&mir.hir, &mir.imported_classes)?;
+    code_gen.gen_program(&mir.hir, &mir.imports)?;
     code_gen
         .module
         .print_to_file(outpath)
@@ -86,14 +87,10 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         }
     }
 
-    pub fn gen_program(
-        &mut self,
-        hir: &'hir Hir,
-        imported_classes: &SkClasses,
-    ) -> Result<(), Error> {
+    pub fn gen_program(&mut self, hir: &'hir Hir, imports: &ImportedItems) -> Result<(), Error> {
         self.gen_declares();
-        self.gen_import_classes(imported_classes);
-        self.gen_import_constants(&hir.imported_constants);
+        self.gen_import_classes(&imports.sk_classes);
+        self.gen_import_constants(&imports.constants);
         self.gen_class_structs(&hir.sk_classes);
         self.gen_string_literals(&hir.str_literals);
         self.gen_constant_ptrs(&hir.constants);

--- a/src/corelib/mod.rs
+++ b/src/corelib/mod.rs
@@ -175,6 +175,7 @@ fn make_classes(
                     .map(|x| (x.signature.first_name().clone(), x.signature.clone()))
                     .collect(),
                 const_is_obj: (name == "Void"),
+                foreign: false,
             },
         );
         sk_methods.insert(class_fullname(&name), imethods);
@@ -199,6 +200,7 @@ fn make_classes(
                         .map(|x| (x.signature.first_name().clone(), x.signature.clone()))
                         .collect(),
                     const_is_obj: false,
+                    foreign: false,
                 },
             );
             sk_methods.insert(metaclass_fullname(&name), cmethods);

--- a/src/corelib/mod.rs
+++ b/src/corelib/mod.rs
@@ -11,18 +11,21 @@ mod shiika_internal_memory;
 mod shiika_internal_ptr;
 mod void;
 use crate::hir::*;
-use crate::library::ImportedItems;
 use crate::names::*;
 use crate::parser;
 use crate::ty;
 use std::collections::HashMap;
 
-pub fn create() -> ImportedItems {
+pub struct Corelib {
+    pub sk_classes: SkClasses,
+    pub sk_methods: SkMethods,
+}
+
+pub fn create() -> Corelib {
     let (sk_classes, sk_methods) = make_classes(rust_body_items());
-    ImportedItems {
+    Corelib {
         sk_classes,
         sk_methods,
-        constants: Default::default(),
     }
 }
 

--- a/src/corelib/mod.rs
+++ b/src/corelib/mod.rs
@@ -11,32 +11,18 @@ mod shiika_internal_memory;
 mod shiika_internal_ptr;
 mod void;
 use crate::hir::*;
+use crate::library::ImportedItems;
 use crate::names::*;
 use crate::parser;
 use crate::ty;
 use std::collections::HashMap;
 
-pub struct Corelib {
-    pub sk_classes: HashMap<ClassFullname, SkClass>,
-    pub sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
-}
-
-impl Corelib {
-    /// Create empty Corelib (for tests)
-    pub fn empty() -> Corelib {
-        Corelib {
-            sk_classes: HashMap::new(),
-            sk_methods: HashMap::new(),
-        }
-    }
-
-    pub fn create() -> Corelib {
-        let items = rust_body_items();
-        let (sk_classes, sk_methods) = make_classes(items);
-        Corelib {
-            sk_classes,
-            sk_methods,
-        }
+pub fn create() -> ImportedItems {
+    let (sk_classes, sk_methods) = make_classes(rust_body_items());
+    ImportedItems {
+        sk_classes,
+        sk_methods,
+        constants: Default::default(),
     }
 }
 

--- a/src/hir/accessors.rs
+++ b/src/hir/accessors.rs
@@ -2,7 +2,7 @@ use crate::code_gen::CodeGen;
 use crate::hir::hir_maker::HirMaker;
 use crate::hir::*;
 
-impl HirMaker {
+impl<'hir_maker> HirMaker<'hir_maker> {
     /// Define getters and setters (unless there is a method of the same name)
     pub(super) fn define_accessors(
         &mut self,

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -44,15 +44,7 @@ impl ClassDict {
 
     pub fn index_corelib(&mut self, corelib: HashMap<ClassFullname, SkClass>) {
         corelib.into_iter().for_each(|(_, c)| {
-            self.add_class(SkClass {
-                fullname: c.fullname,
-                typarams: c.typarams,
-                superclass_fullname: c.superclass_fullname,
-                instance_ty: c.instance_ty,
-                ivars: c.ivars,
-                method_sigs: c.method_sigs,
-                const_is_obj: c.const_is_obj,
-            })
+            self.add_class(c)
         });
     }
 
@@ -188,6 +180,7 @@ impl ClassDict {
             ivars: HashMap::new(), // will be set when processing `#initialize`
             method_sigs: instance_methods,
             const_is_obj: false,
+            foreign: false,
         });
 
         // Crete metaclass (which is a subclass of `Class`)
@@ -201,6 +194,7 @@ impl ClassDict {
             ivars: meta_ivars,
             method_sigs: class_methods,
             const_is_obj: false,
+            foreign: false,
         });
         Ok(())
     }

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -19,7 +19,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             Some(super_cls) => super_cls.ivars.clone(),
             None => HashMap::new(),
         };
-        let class = self.get_class_mut(&classname, "ClassDict::define_ivars");
+        let class = self.get_class_mut(&classname);
         debug_assert!(class.ivars.is_empty());
         class.ivars = super_ivars;
         own_ivars.into_iter().for_each(|(k, v)| {
@@ -161,8 +161,8 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         class_methods.insert(new_sig.fullname.first_name.clone(), new_sig);
         if !self.class_exists(&super_name.0) {
             return Err(error::name_error(&format!(
-                "unknown superclass: {:?}",
-                super_name
+                "superclass {:?} of {:?} does not exist",
+                super_name, fullname,
             )));
         }
 
@@ -178,7 +178,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         });
 
         // Crete metaclass (which is a subclass of `Class`)
-        let the_class = self.get_class(&class_fullname("Class"), "index_class");
+        let the_class = self.get_class(&class_fullname("Class"));
         let meta_ivars = the_class.ivars.clone();
         self.add_class(SkClass {
             fullname: fullname.meta_name(),

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -141,6 +141,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         Ok((instance_methods, class_methods))
     }
 
+    /// Register a class and its metaclass to self
     fn add_new_class(
         &mut self,
         fullname: &ClassFullname,

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 type MethodSignatures = HashMap<MethodFirstname, MethodSignature>;
 
-impl ClassDict {
+impl<'hir_maker> ClassDict<'hir_maker> {
     /// Define ivars of a class
     pub fn define_ivars(
         &mut self,
@@ -40,12 +40,6 @@ impl ClassDict {
         sk_class
             .method_sigs
             .insert(sig.fullname.first_name.clone(), sig);
-    }
-
-    pub fn index_corelib(&mut self, corelib: HashMap<ClassFullname, SkClass>) {
-        corelib.into_iter().for_each(|(_, c)| {
-            self.add_class(c)
-        });
     }
 
     pub fn index_program(&mut self, toplevel_defs: &[&ast::Definition]) -> Result<(), Error> {

--- a/src/hir/class_dict/mod.rs
+++ b/src/hir/class_dict/mod.rs
@@ -19,10 +19,12 @@ pub struct ClassDict<'hir_maker> {
 
 pub fn create<'hir_maker>(
     ast: &ast::Program,
+    // Corelib classes (REFACTOR: corelib should provide methods only)
+    initial_sk_classes: SkClasses,
     imported_classes: &'hir_maker SkClasses,
 ) -> Result<ClassDict<'hir_maker>, Error> {
     let mut dict = ClassDict {
-        sk_classes: Default::default(),
+        sk_classes: initial_sk_classes,
         imported_classes: imported_classes,
     };
     let defs = ast

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -12,8 +12,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         class_fullname: &ClassFullname,
         method_name: &MethodFirstname,
     ) -> Option<&MethodSignature> {
-        self.sk_classes
-            .get(class_fullname)
+        self.find_class(class_fullname)
             .and_then(|class| class.method_sigs.get(method_name))
     }
 
@@ -80,7 +79,9 @@ impl<'hir_maker> ClassDict<'hir_maker> {
 
     /// Find a class
     pub fn find_class(&self, class_fullname: &ClassFullname) -> Option<&SkClass> {
-        self.sk_classes.get(class_fullname)
+        self.sk_classes
+            .get(class_fullname)
+            .or_else(|| self.imported_classes.get(class_fullname))
     }
 
     /// Find a class. Panic if not found

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -12,7 +12,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         class_fullname: &ClassFullname,
         method_name: &MethodFirstname,
     ) -> Option<&MethodSignature> {
-        self.find_class(class_fullname)
+        self.lookup_class(class_fullname)
             .and_then(|class| class.method_sigs.get(method_name))
     }
 
@@ -30,10 +30,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
                 Ok((base_sig.specialize(None, Some(method_tyargs)), found_cls))
             }
             TyBody::TySpe { type_args, .. } | TyBody::TySpeMeta { type_args, .. } => {
-                let base_cls = &self
-                    .find_class(&class.base_class_name())
-                    .expect("[BUG] base_cls not found")
-                    .instance_ty;
+                let base_cls = &self.get_class(&class.base_class_name()).instance_ty;
                 let (base_sig, found_cls) = self.lookup_method_(base_cls, base_cls, method_name)?;
                 Ok((
                     base_sig.specialize(Some(&type_args), Some(method_tyargs)),
@@ -58,7 +55,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             Ok((sig.clone(), class.fullname.clone()))
         } else {
             // Look up in superclass
-            let sk_class = self.find_class(&class.fullname).unwrap_or_else(|| {
+            let sk_class = self.lookup_class(&class.fullname).unwrap_or_else(|| {
                 panic!(
                     "[BUG] lookup_method: asked to find `{}' but class `{}' not found",
                     &method_name.0, &class.fullname.0
@@ -77,50 +74,44 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         }
     }
 
-    /// Find a class
-    pub fn find_class(&self, class_fullname: &ClassFullname) -> Option<&SkClass> {
+    /// Return the class of the specified name, if any
+    fn lookup_class(&self, class_fullname: &ClassFullname) -> Option<&SkClass> {
         self.sk_classes
             .get(class_fullname)
             .or_else(|| self.imported_classes.get(class_fullname))
     }
 
     /// Find a class. Panic if not found
-    pub fn get_class(&self, class_fullname: &ClassFullname, dbg_name: &str) -> &SkClass {
-        self.find_class(class_fullname).unwrap_or_else(|| {
-            panic!(
-                "[BUG] {}: class `{}' not found",
-                &dbg_name, &class_fullname.0
-            )
-        })
+    pub fn get_class(&self, class_fullname: &ClassFullname) -> &SkClass {
+        self.lookup_class(class_fullname)
+            .unwrap_or_else(|| panic!("[BUG] class `{}' not found", &class_fullname.0))
     }
 
     /// Find a class. Panic if not found
-    pub fn get_class_mut(
-        &mut self,
-        class_fullname: &ClassFullname,
-        dbg_name: &str,
-    ) -> &mut SkClass {
-        self.sk_classes.get_mut(&class_fullname).unwrap_or_else(|| {
-            panic!(
-                "[BUG] {}: class `{}' not found",
-                &dbg_name, &class_fullname.0
-            )
-        })
+    pub fn get_class_mut(&mut self, class_fullname: &ClassFullname) -> &mut SkClass {
+        if let Some(c) = self.sk_classes.get_mut(class_fullname) {
+            c
+        } else {
+            if self.imported_classes.contains_key(class_fullname) {
+                panic!("[BUG] cannot get_mut imported class `{}'", class_fullname)
+            } else {
+                panic!("[BUG] class `{}' not found", class_fullname)
+            }
+        }
     }
 
     /// Return true if there is a class of the name
-    pub fn class_exists(&self, class_fullname: &str) -> bool {
-        self.sk_classes
-            .contains_key(&ClassFullname(class_fullname.to_string()))
+    pub fn class_exists(&self, fullname: &str) -> bool {
+        self.lookup_class(&class_fullname(fullname)).is_some()
     }
 
     /// Find the superclass
     /// Return None if the class is `Object`
     pub fn get_superclass(&self, classname: &ClassFullname) -> Option<&SkClass> {
-        let cls = self.get_class(&classname, "ClassDict::get_superclass");
+        let cls = self.get_class(&classname);
         cls.superclass_fullname
             .as_ref()
-            .map(|super_name| self.get_class(&super_name, "ClassDict::get_superclass"))
+            .map(|super_name| self.get_class(&super_name))
     }
 
     /// Return supertype of `ty`

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -5,7 +5,7 @@ use crate::hir::*;
 use crate::names::*;
 use crate::ty::*;
 
-impl ClassDict {
+impl<'hir_maker> ClassDict<'hir_maker> {
     /// Find a method from class name and first name
     pub fn find_method(
         &self,

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -54,7 +54,7 @@ impl LVarInfo {
     }
 }
 
-impl HirMaker {
+impl<'hir_maker> HirMaker<'hir_maker> {
     pub(super) fn convert_exprs(
         &mut self,
         exprs: &[AstExpression],

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -773,10 +773,9 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             .collect::<Vec<_>>();
         let cls = self
             .class_dict
-            .find_class(&class_fullname(
+            .get_class(&class_fullname(
                 "Meta:".to_string() + &name.names.join("::"),
             ))
-            .unwrap()
             .specialized_meta(&tyargs);
         let ty = cls.instance_ty.clone();
         self.class_dict.add_class(cls);

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -703,6 +703,8 @@ impl HirMaker {
         let fullname = name.to_const_fullname();
         if let Some(found) = self.constants.get(&fullname) {
             return Some((found, fullname));
+        } else if let Some(found) = self.imported_constants.get(&fullname) {
+            return Some((found, fullname));
         }
 
         let fullname = name.under_namespace(&self.ctx.namespace());

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -5,6 +5,7 @@ use crate::hir::class_dict::ClassDict;
 use crate::hir::hir_maker_context::*;
 use crate::hir::method_dict::MethodDict;
 use crate::hir::*;
+use crate::library::ImportedItems;
 use crate::names;
 use crate::type_checking;
 
@@ -25,13 +26,13 @@ pub struct HirMaker {
     pub(super) lambda_ct: usize,
 }
 
-pub fn make_hir(ast: ast::Program, corelib: Corelib) -> Result<Hir, Error> {
-    let class_dict = class_dict::create(&ast, corelib.sk_classes)?;
+pub fn make_hir(ast: ast::Program, imports: ImportedItems) -> Result<Hir, Error> {
+    let class_dict = class_dict::create(&ast, imports.sk_classes)?;
     let mut hir = convert_program(class_dict, ast)?;
 
     // While corelib classes are included in `class_dict`,
     // corelib methods are not. Here we need to add them manually
-    hir.add_methods(corelib.sk_methods);
+    hir.add_methods(imports.sk_methods);
 
     Ok(hir)
 }

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -5,7 +5,7 @@ use crate::hir::class_dict::ClassDict;
 use crate::hir::hir_maker_context::*;
 use crate::hir::method_dict::MethodDict;
 use crate::hir::*;
-use crate::library::ImportedItems;
+use crate::library::LibraryExports;
 use crate::names;
 use crate::type_checking;
 
@@ -32,7 +32,7 @@ pub struct HirMaker<'hir_maker> {
 pub fn make_hir(
     ast: ast::Program,
     corelib: Option<Corelib>,
-    imports: &ImportedItems,
+    imports: &LibraryExports,
 ) -> Result<Hir, Error> {
     let (core_classes, core_methods) = if let Some(c) = corelib {
         (c.sk_classes, c.sk_methods)

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -34,14 +34,17 @@ pub fn make_hir(
     corelib: Option<Corelib>,
     imports: &ImportedItems,
 ) -> Result<Hir, Error> {
-    let class_dict = class_dict::create(&ast, &imports.sk_classes)?;
+    let (core_classes, core_methods) = if let Some(c) = corelib {
+        (c.sk_classes, c.sk_methods)
+    } else {
+        (Default::default(), Default::default())
+    };
+    let class_dict = class_dict::create(&ast, core_classes, &imports.sk_classes)?;
     let mut hir = convert_program(class_dict, &imports.constants, ast)?;
 
     // While corelib classes are included in `class_dict`,
     // corelib methods are not. Here we need to add them manually
-    if let Some(Corelib { sk_methods, .. }) = corelib {
-        hir.add_methods(sk_methods);
-    }
+    hir.add_methods(core_methods);
 
     Ok(hir)
 }

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -348,7 +348,7 @@ pub fn extract_lvars(lvars: &mut HashMap<String, CtxLVar>) -> HirLVars {
         .collect::<Vec<_>>()
 }
 
-impl HirMaker {
+impl<'hir_maker> HirMaker<'hir_maker> {
     /// Returns type parameter of the current class
     pub(super) fn current_class_typarams(&self) -> Vec<String> {
         if let Some(class_ctx) = self.ctx.classes.last() {

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -12,10 +12,11 @@ pub use crate::hir::class_dict::ClassDict;
 pub use crate::hir::signature::MethodParam;
 pub use crate::hir::signature::MethodSignature;
 pub use crate::hir::sk_class::SkClass;
-use crate::library::ImportedItems;
+use crate::library::LibraryExports;
 use crate::names::*;
 use crate::ty;
 use crate::ty::*;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub type SkClasses = HashMap<ClassFullname, SkClass>;
@@ -35,7 +36,7 @@ pub struct Hir {
 pub fn build(
     ast: ast::Program,
     corelib: Option<Corelib>,
-    imports: &ImportedItems,
+    imports: &LibraryExports,
 ) -> Result<Hir, crate::error::Error> {
     hir_maker::make_hir(ast, corelib, imports)
 }
@@ -55,7 +56,7 @@ impl Hir {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct SkIVar {
     pub idx: usize,
     pub name: String, // Includes `@`

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -7,6 +7,7 @@ mod method_dict;
 pub mod signature;
 pub mod sk_class;
 use crate::ast;
+use crate::corelib::Corelib;
 pub use crate::hir::class_dict::ClassDict;
 pub use crate::hir::signature::MethodParam;
 pub use crate::hir::signature::MethodSignature;
@@ -24,7 +25,6 @@ pub struct Hir {
     pub sk_classes: HashMap<ClassFullname, SkClass>,
     pub sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
     pub constants: HashMap<ConstFullname, TermTy>,
-    pub imported_constants: HashMap<ConstFullname, TermTy>,
     pub str_literals: Vec<String>,
     pub const_inits: Vec<HirExpression>,
     pub main_exprs: HirExpressions,
@@ -32,8 +32,12 @@ pub struct Hir {
     pub main_lvars: HirLVars,
 }
 
-pub fn build(ast: ast::Program, imports: ImportedItems) -> Result<Hir, crate::error::Error> {
-    hir_maker::make_hir(ast, imports)
+pub fn build(
+    ast: ast::Program,
+    corelib: Option<Corelib>,
+    imports: &ImportedItems,
+) -> Result<Hir, crate::error::Error> {
+    hir_maker::make_hir(ast, corelib, imports)
 }
 
 impl Hir {
@@ -76,6 +80,8 @@ pub struct SkMethod {
     pub body: SkMethodBody,
     pub lvars: HirLVars,
 }
+
+pub type SkMethods = HashMap<ClassFullname, Vec<SkMethod>>;
 
 pub enum SkMethodBody {
     ShiikaMethodBody { exprs: HirExpressions },

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -17,11 +17,14 @@ use crate::ty;
 use crate::ty::*;
 use std::collections::HashMap;
 
+pub type SkClasses = HashMap<ClassFullname, SkClass>;
+
 #[derive(Debug)]
 pub struct Hir {
     pub sk_classes: HashMap<ClassFullname, SkClass>,
     pub sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
     pub constants: HashMap<ConstFullname, TermTy>,
+    pub imported_constants: HashMap<ConstFullname, TermTy>,
     pub str_literals: Vec<String>,
     pub const_inits: Vec<HirExpression>,
     pub main_exprs: HirExpressions,

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -7,11 +7,11 @@ mod method_dict;
 pub mod signature;
 pub mod sk_class;
 use crate::ast;
-use crate::corelib::Corelib;
 pub use crate::hir::class_dict::ClassDict;
 pub use crate::hir::signature::MethodParam;
 pub use crate::hir::signature::MethodSignature;
 pub use crate::hir::sk_class::SkClass;
+use crate::library::ImportedItems;
 use crate::names::*;
 use crate::ty;
 use crate::ty::*;
@@ -29,8 +29,8 @@ pub struct Hir {
     pub main_lvars: HirLVars,
 }
 
-pub fn build(ast: ast::Program, corelib: Corelib) -> Result<Hir, crate::error::Error> {
-    hir_maker::make_hir(ast, corelib)
+pub fn build(ast: ast::Program, imports: ImportedItems) -> Result<Hir, crate::error::Error> {
+    hir_maker::make_hir(ast, imports)
 }
 
 impl Hir {

--- a/src/hir/signature.rs
+++ b/src/hir/signature.rs
@@ -2,8 +2,9 @@ use crate::ast;
 use crate::names::*;
 use crate::ty;
 use crate::ty::*;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MethodSignature {
     pub fullname: MethodFullname,
     pub ret_ty: TermTy,
@@ -35,7 +36,7 @@ impl MethodSignature {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MethodParam {
     pub name: String,
     pub ty: TermTy,

--- a/src/hir/sk_class.rs
+++ b/src/hir/sk_class.rs
@@ -15,6 +15,8 @@ pub struct SkClass {
     pub method_sigs: HashMap<MethodFirstname, MethodSignature>,
     /// eg. `Void` is an instance, not the class
     pub const_is_obj: bool,
+    /// true if this class is an imported one
+    pub foreign: bool,
 }
 
 impl SkClass {
@@ -59,6 +61,7 @@ impl SkClass {
             ivars: self.ivars.clone(),
             method_sigs,
             const_is_obj: self.const_is_obj,
+            foreign: false,
         }
     }
 }

--- a/src/hir/sk_class.rs
+++ b/src/hir/sk_class.rs
@@ -2,10 +2,11 @@ use crate::hir::signature::MethodSignature;
 use crate::names::*;
 use crate::ty;
 use crate::ty::*;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// A Shiika class, possibly generic
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct SkClass {
     pub fullname: ClassFullname,
     pub typarams: Vec<TyParam>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-// #![feature(nll)]  // QUESTION: Do we still need this?
 pub mod ast;
 pub mod code_gen;
 pub mod corelib;
 pub mod error;
 pub mod hir;
+pub mod library;
 pub mod mir;
 pub mod names;
 pub mod parser;

--- a/src/library.rs
+++ b/src/library.rs
@@ -5,82 +5,20 @@ use crate::ty::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Default)]
-pub struct ImportedItems {
-    pub sk_classes: HashMap<ClassFullname, SkClass>,
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct LibraryExports {
+    pub sk_classes: SkClasses,
     pub vtables: VTables,
     pub constants: HashMap<ConstFullname, TermTy>,
 }
 
-impl ImportedItems {
-    pub fn empty() -> ImportedItems {
-        Default::default()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LibraryExports {
-    classes: Vec<ClassInfo>,
-    vtables: VTables,
-    constants: HashMap<ConstFullname, TermTy>,
-}
-
 impl LibraryExports {
     pub fn new(mir: &Mir) -> LibraryExports {
-        let classes = mir.hir.sk_classes.values().map(ClassInfo::new).collect();
         LibraryExports {
-            classes,
-            vtables: mir.vtables.clone(), // PERF: how not to clone?
+            // PERF: how to generate json without cloning?
+            sk_classes: mir.hir.sk_classes.clone(),
+            vtables: mir.vtables.clone(),
             constants: mir.hir.constants.clone(),
-        }
-    }
-
-    pub fn into_imported_items(self) -> ImportedItems {
-        let mut sk_classes = HashMap::new();
-        for cls_info in self.classes {
-            let class = cls_info.extract();
-            sk_classes.insert(class.fullname.clone(), class);
-        }
-        ImportedItems {
-            sk_classes,
-            vtables: self.vtables,
-            constants: self.constants,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct ClassInfo {
-    name: ClassFullname,
-    typarams: Vec<TyParam>,
-    superclass_fullname: Option<ClassFullname>,
-    instance_ty: TermTy,
-    method_sigs: HashMap<MethodFirstname, MethodSignature>,
-    const_is_obj: bool,
-}
-
-impl ClassInfo {
-    fn new(sk_class: &SkClass) -> ClassInfo {
-        ClassInfo {
-            name: sk_class.fullname.clone(),
-            typarams: sk_class.typarams.clone(),
-            superclass_fullname: sk_class.superclass_fullname.clone(),
-            instance_ty: sk_class.instance_ty.clone(),
-            method_sigs: sk_class.method_sigs.clone(),
-            const_is_obj: sk_class.const_is_obj,
-        }
-    }
-
-    fn extract(self) -> SkClass {
-        SkClass {
-            fullname: self.name,
-            typarams: self.typarams,
-            superclass_fullname: self.superclass_fullname,
-            instance_ty: self.instance_ty,
-            ivars: Default::default(),
-            method_sigs: self.method_sigs,
-            const_is_obj: self.const_is_obj,
-            foreign: true,
         }
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -70,6 +70,7 @@ impl ClassInfo {
             ivars: Default::default(),
             method_sigs: self.method_sigs,
             const_is_obj: self.const_is_obj,
+            foreign: true,
         }
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,0 +1,75 @@
+use crate::hir::*;
+use crate::names::*;
+use crate::ty::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub struct ImportedItems {
+    pub sk_classes: HashMap<ClassFullname, SkClass>,
+    pub sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
+    pub constants: HashMap<ConstFullname, TermTy>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LibraryExports {
+    classes: Vec<ClassInfo>,
+    constants: HashMap<ConstFullname, TermTy>,
+}
+
+impl LibraryExports {
+    pub fn new(hir: &Hir) -> LibraryExports {
+        let classes = hir.sk_classes.values().map(ClassInfo::new).collect();
+        LibraryExports {
+            classes,
+            constants: hir.constants.clone(),
+        }
+    }
+
+    pub fn into_imported_items(self) -> ImportedItems {
+        let mut sk_classes = HashMap::new();
+        for cls_info in self.classes {
+            let class = cls_info.extract();
+            sk_classes.insert(class.fullname.clone(), class);
+        }
+        ImportedItems {
+            sk_classes,
+            sk_methods: Default::default(),
+            constants: self.constants,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ClassInfo {
+    name: ClassFullname,
+    typarams: Vec<TyParam>,
+    superclass_fullname: Option<ClassFullname>,
+    instance_ty: TermTy,
+    method_sigs: HashMap<MethodFirstname, MethodSignature>,
+    const_is_obj: bool,
+}
+
+impl ClassInfo {
+    fn new(sk_class: &SkClass) -> ClassInfo {
+        ClassInfo {
+            name: sk_class.fullname.clone(),
+            typarams: sk_class.typarams.clone(),
+            superclass_fullname: sk_class.superclass_fullname.clone(),
+            instance_ty: sk_class.instance_ty.clone(),
+            method_sigs: sk_class.method_sigs.clone(),
+            const_is_obj: sk_class.const_is_obj,
+        }
+    }
+
+    fn extract(self) -> SkClass {
+        SkClass {
+            fullname: self.name,
+            typarams: self.typarams,
+            superclass_fullname: self.superclass_fullname,
+            instance_ty: self.instance_ty,
+            ivars: Default::default(),
+            method_sigs: self.method_sigs,
+            const_is_obj: self.const_is_obj,
+        }
+    }
+}

--- a/src/library.rs
+++ b/src/library.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 #[derive(Debug, Default)]
 pub struct ImportedItems {
     pub sk_classes: HashMap<ClassFullname, SkClass>,
-    pub sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
+    pub vtables: VTables,
     pub constants: HashMap<ConstFullname, TermTy>,
 }
 
@@ -21,21 +21,16 @@ impl ImportedItems {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LibraryExports {
     classes: Vec<ClassInfo>,
-    vtable_size: HashMap<ClassFullname, usize>,
+    vtables: VTables,
     constants: HashMap<ConstFullname, TermTy>,
 }
 
 impl LibraryExports {
     pub fn new(mir: &Mir) -> LibraryExports {
         let classes = mir.hir.sk_classes.values().map(ClassInfo::new).collect();
-        let vtable_size = mir
-            .vtables
-            .iter()
-            .map(|(name, vtable)| (name.clone(), vtable.size()))
-            .collect::<HashMap<_, _>>();
         LibraryExports {
             classes,
-            vtable_size,
+            vtables: mir.vtables.clone(), // PERF: how not to clone?
             constants: mir.hir.constants.clone(),
         }
     }
@@ -48,7 +43,7 @@ impl LibraryExports {
         }
         ImportedItems {
             sk_classes,
-            sk_methods: Default::default(),
+            vtables: self.vtables,
             constants: self.constants,
         }
     }

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,27 +1,42 @@
 use crate::hir::*;
+use crate::mir::*;
 use crate::names::*;
 use crate::ty::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[derive(Debug, Default)]
 pub struct ImportedItems {
     pub sk_classes: HashMap<ClassFullname, SkClass>,
     pub sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
     pub constants: HashMap<ConstFullname, TermTy>,
 }
 
+impl ImportedItems {
+    pub fn empty() -> ImportedItems {
+        Default::default()
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LibraryExports {
     classes: Vec<ClassInfo>,
+    vtable_size: HashMap<ClassFullname, usize>,
     constants: HashMap<ConstFullname, TermTy>,
 }
 
 impl LibraryExports {
-    pub fn new(hir: &Hir) -> LibraryExports {
-        let classes = hir.sk_classes.values().map(ClassInfo::new).collect();
+    pub fn new(mir: &Mir) -> LibraryExports {
+        let classes = mir.hir.sk_classes.values().map(ClassInfo::new).collect();
+        let vtable_size = mir
+            .vtables
+            .iter()
+            .map(|(name, vtable)| (name.clone(), vtable.size()))
+            .collect::<HashMap<_, _>>();
         LibraryExports {
             classes,
-            constants: hir.constants.clone(),
+            vtable_size,
+            constants: mir.hir.constants.clone(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    if matches.subcommand_matches("build_corelib").is_some() {
+        build_corelib();
+    }
+
     Ok(())
 }
 
@@ -36,6 +40,12 @@ fn compile(filepath: &str) -> bool {
 
 fn run(filepath: &str) {
     runner::run(filepath).unwrap_or_else(|err| {
+        print_err(err);
+    });
+}
+
+fn build_corelib() {
+    runner::build_corelib().unwrap_or_else(|err| {
         print_err(err);
     });
 }

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1,36 +1,20 @@
 pub mod vtable;
-use crate::hir::{Hir, SkClasses};
+use crate::hir::Hir;
+use crate::library::ImportedItems;
 pub use crate::mir::vtable::VTables;
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Mir {
     pub hir: Hir,
     pub vtables: VTables,
-    pub imported_classes: SkClasses,
+    pub imports: ImportedItems,
 }
 
-pub fn build(orig_hir: Hir) -> Mir {
-    let vtables = VTables::build(&orig_hir.sk_classes);
-    let (hir, imported_classes) = extract_imported_classes(orig_hir);
+pub fn build(hir: Hir, imports: ImportedItems) -> Mir {
+    let vtables = VTables::build(&hir.sk_classes);
     Mir {
         hir,
         vtables,
-        imported_classes,
+        imports,
     }
-}
-
-/// Remove imported classes from hir.sk_classes
-fn extract_imported_classes(mut hir: Hir) -> (Hir, SkClasses) {
-    let mut sk_classes = HashMap::new();
-    let mut imported_classes = HashMap::new();
-    for (name, class) in hir.sk_classes {
-        if class.foreign {
-            imported_classes.insert(name, class);
-        } else {
-            sk_classes.insert(name, class);
-        }
-    }
-    hir.sk_classes = sk_classes;
-    (hir, imported_classes)
 }

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1,5 +1,5 @@
 pub mod vtable;
-use crate::hir::{Hir, SkClass};
+use crate::hir::{Hir, SkClasses};
 pub use crate::mir::vtable::VTables;
 use std::collections::HashMap;
 
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 pub struct Mir {
     pub hir: Hir,
     pub vtables: VTables,
-    pub imported_classes: Vec<SkClass>,
+    pub imported_classes: SkClasses,
 }
 
 pub fn build(orig_hir: Hir) -> Mir {
@@ -21,12 +21,12 @@ pub fn build(orig_hir: Hir) -> Mir {
 }
 
 /// Remove imported classes from hir.sk_classes
-fn extract_imported_classes(mut hir: Hir) -> (Hir, Vec<SkClass>) {
+fn extract_imported_classes(mut hir: Hir) -> (Hir, SkClasses) {
     let mut sk_classes = HashMap::new();
-    let mut imported_classes = vec![];
+    let mut imported_classes = HashMap::new();
     for (name, class) in hir.sk_classes {
         if class.foreign {
-            imported_classes.push(class);
+            imported_classes.insert(name, class);
         } else {
             sk_classes.insert(name, class);
         }

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1,14 +1,36 @@
 pub mod vtable;
-use crate::hir::Hir;
+use crate::hir::{Hir, SkClass};
 pub use crate::mir::vtable::VTables;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Mir {
     pub hir: Hir,
     pub vtables: VTables,
+    pub imported_classes: Vec<SkClass>,
 }
 
-pub fn build(hir: Hir) -> Mir {
-    let vtables = VTables::build(&hir.sk_classes);
-    Mir { hir, vtables }
+pub fn build(orig_hir: Hir) -> Mir {
+    let vtables = VTables::build(&orig_hir.sk_classes);
+    let (hir, imported_classes) = extract_imported_classes(orig_hir);
+    Mir {
+        hir,
+        vtables,
+        imported_classes,
+    }
+}
+
+/// Remove imported classes from hir.sk_classes
+fn extract_imported_classes(mut hir: Hir) -> (Hir, Vec<SkClass>) {
+    let mut sk_classes = HashMap::new();
+    let mut imported_classes = vec![];
+    for (name, class) in hir.sk_classes {
+        if class.foreign {
+            imported_classes.push(class);
+        } else {
+            sk_classes.insert(name, class);
+        }
+    }
+    hir.sk_classes = sk_classes;
+    (hir, imported_classes)
 }

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -11,7 +11,7 @@ pub struct Mir {
 }
 
 pub fn build(hir: Hir, imports: ImportedItems) -> Mir {
-    let vtables = VTables::build(&hir.sk_classes);
+    let vtables = VTables::build(&hir.sk_classes, &imports);
     Mir {
         hir,
         vtables,

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1,16 +1,16 @@
 pub mod vtable;
 use crate::hir::Hir;
-use crate::library::ImportedItems;
+use crate::library::LibraryExports;
 pub use crate::mir::vtable::VTables;
 
 #[derive(Debug)]
 pub struct Mir {
     pub hir: Hir,
     pub vtables: VTables,
-    pub imports: ImportedItems,
+    pub imports: LibraryExports,
 }
 
-pub fn build(hir: Hir, imports: ImportedItems) -> Mir {
+pub fn build(hir: Hir, imports: LibraryExports) -> Mir {
     let vtables = VTables::build(&hir.sk_classes, &imports);
     Mir {
         hir,

--- a/src/mir/vtable.rs
+++ b/src/mir/vtable.rs
@@ -106,14 +106,22 @@ impl VTables {
     }
 
     /// Return the index of the method when invoking it on the object
-    pub fn method_idx(&self, obj_ty: &TermTy, method_name: &MethodFirstname) -> (&usize, usize) {
-        let vtable = must_be_some(
-            self.vtables.get(&obj_ty.vtable_name()),
-            format!("[BUG] method_idx: vtable of {} not found", &obj_ty.fullname),
-        );
-        (vtable.get(&method_name), vtable.size())
+    pub fn method_idx(
+        &self,
+        obj_ty: &TermTy,
+        method_name: &MethodFirstname,
+    ) -> Result<(&usize, usize), Error> {
+        if let Some(vtable) = self.vtables.get(&obj_ty.vtable_name()) {
+            Ok((vtable.get(&method_name), vtable.size()))
+        } else {
+            Err(bug(format!(
+                "[BUG] method_idx: vtable of {} not found",
+                &obj_ty.fullname
+            )))
+        }
     }
 
+    /// Returns iterator over each vtable
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, ClassFullname, VTable> {
         self.vtables.iter()
     }

--- a/src/mir/vtable.rs
+++ b/src/mir/vtable.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
 use crate::hir::*;
-use crate::library::ImportedItems;
+use crate::library::LibraryExports;
 use crate::names::*;
 use crate::ty::*;
 use serde::{Deserialize, Serialize};
@@ -77,7 +77,7 @@ pub struct VTables {
 
 impl VTables {
     /// Build vtables of the classes
-    pub fn build(sk_classes: &SkClasses, imports: &ImportedItems) -> VTables {
+    pub fn build(sk_classes: &SkClasses, imports: &LibraryExports) -> VTables {
         let mut vtables = HashMap::new();
         let mut queue = sk_classes.keys().collect::<VecDeque<_>>();
         let null_vtable = VTable::null();

--- a/src/mir/vtable.rs
+++ b/src/mir/vtable.rs
@@ -2,10 +2,11 @@ use crate::error::*;
 use crate::hir::sk_class::SkClass;
 use crate::names::*;
 use crate::ty::*;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct VTable {
     /// List of methods, ordered by index
     fullnames: Vec<MethodFullname>,
@@ -67,7 +68,7 @@ impl VTable {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct VTables {
     vtables: HashMap<ClassFullname, VTable>,
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,5 +1,6 @@
 use crate::ty;
 use crate::ty::*;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ClassFirstname(pub String);
@@ -18,7 +19,7 @@ pub fn class_firstname(s: &str) -> ClassFirstname {
     ClassFirstname(s.to_string())
 }
 
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
 pub struct ClassFullname(pub String);
 
 impl std::fmt::Display for ClassFullname {
@@ -71,7 +72,7 @@ impl ClassFullname {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
 pub struct MethodFirstname(pub String);
 
 impl std::fmt::Display for MethodFirstname {
@@ -90,7 +91,7 @@ impl MethodFirstname {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
 pub struct MethodFullname {
     pub full_name: String,
     pub first_name: MethodFirstname,
@@ -135,7 +136,7 @@ pub fn const_firstname(s: &str) -> ConstFirstname {
     ConstFirstname(s.to_string())
 }
 
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
 pub struct ConstFullname(pub String);
 
 impl std::fmt::Display for ConstFullname {

--- a/src/names.rs
+++ b/src/names.rs
@@ -70,6 +70,10 @@ impl ClassFullname {
             ClassFullname("Meta:".to_string() + &self.0)
         }
     }
+
+    pub fn method_fullname(&self, method_firstname: &MethodFirstname) -> MethodFullname {
+        method_fullname(self, &method_firstname.0)
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -27,7 +27,7 @@ pub fn compile<P: AsRef<Path>>(filepath: P) -> Result<(), Error> {
     Ok(())
 }
 
-fn load_builtin_exports() -> Result<library::ImportedItems, Error> {
+fn load_builtin_exports() -> Result<library::LibraryExports, Error> {
     let mut f = fs::File::open("builtin/exports.json")
         .map_err(|e| runner_error("builtin exports not found", Box::new(e)))?;
     let mut contents = String::new();
@@ -35,7 +35,7 @@ fn load_builtin_exports() -> Result<library::ImportedItems, Error> {
         .map_err(|e| runner_error("failed to read builtin exports", Box::new(e)))?;
     let exports: library::LibraryExports = serde_json::from_str(&contents)
         .map_err(|e| runner_error("builtin exports is broken", Box::new(e)))?;
-    Ok(exports.into_imported_items())
+    Ok(exports)
 }
 
 pub fn build_corelib() -> Result<(), Error> {
@@ -44,7 +44,7 @@ pub fn build_corelib() -> Result<(), Error> {
     log::debug!("created ast");
     let corelib = crate::corelib::create();
     log::debug!("loaded corelib");
-    let imports = library::ImportedItems::empty();
+    let imports = Default::default();
     let hir = crate::hir::build(ast, Some(corelib), &imports)?;
     log::debug!("created hir");
     let mir = crate::mir::build(hir, imports);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -22,7 +22,9 @@ pub fn compile<P: AsRef<Path>>(filepath: P) -> Result<(), Error> {
     log::debug!("created hir");
     let mir = crate::mir::build(hir, imports);
     log::debug!("created mir");
-    crate::code_gen::run(&mir, &(path + ".bc"), true)?;
+    let bc_path = path.clone() + ".bc";
+    let ll_path = path + ".ll";
+    crate::code_gen::run(&mir, &bc_path, Some(&ll_path), true)?;
     log::debug!("created .bc");
     Ok(())
 }
@@ -50,7 +52,7 @@ pub fn build_corelib() -> Result<(), Error> {
     let mir = crate::mir::build(hir, imports);
     log::debug!("created mir");
     let exports = library::LibraryExports::new(&mir);
-    crate::code_gen::run(&mir, "builtin/builtin.bc", false)?;
+    crate::code_gen::run(&mir, "builtin/builtin.bc", Some("builtin/builtin.ll"), false)?;
     log::debug!("created .bc");
 
     let json = serde_json::to_string_pretty(&exports).unwrap();

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -1,4 +1,6 @@
 use crate::hir::class_dict::ClassDict;
+use serde::{Deserialize, Serialize};
+
 /// Shiika types
 ///
 /// ```text
@@ -18,7 +20,7 @@ use crate::names::*;
 use crate::ty;
 
 // Types for a term (types of Shiika values)
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Serialize, Deserialize)]
 pub struct TermTy {
     pub fullname: ClassFullname,
     pub body: TyBody,
@@ -73,7 +75,7 @@ fn _dbg_type_args(type_args: &[TermTy]) -> String {
         .join(", ")
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum TyBody {
     // Types corresponds to non-generic class
     // eg. "Int", "String", "Object"
@@ -108,7 +110,7 @@ pub enum TyBody {
     },
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum TyParamKind {
     /// eg. `class A<B>`
     Class,
@@ -433,7 +435,7 @@ pub fn typaram(name: impl Into<String>, kind: TyParamKind, idx: usize) -> TermTy
 
 /// A type parameter
 /// In the future, may have something like +T/-T or in/out
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct TyParam {
     pub name: String,
 }


### PR DESCRIPTION
fix #279 

This PR caches compilation of builtin/*.sk into builtin/builtin.bc and builtin/exports.json. 

builtin.bc contains LLVM bitcode and will be linked to main program with `clang` command.

exports.json contains information needed to compile the main program without reading builtin/*.sk. (JSON is used just for debugging purpose and is not intended to be modified in hand. We can change it to some binary format for better performance in the future.)

