### PR TITLE
Resolve relative const

### DIFF
--- a/builtin/hash.sk
+++ b/builtin/hash.sk
@@ -11,13 +11,74 @@ end
 class Hash<K, V>
   N_TABLES = 1000
 
-  def initialize
-    @tables = Array<Hash_Table<K, V>>.new
-    N_TABLES.times{|_: Int| @tables.push(Hash_Table<K, V>.new) }
+  class Table<K, V>
+    def initialize
+      @pairs = Array<Pair<K, V>>.new
+    end
+
+    # Set the value of specified key.
+    def []=(key: K, value: V)
+      var done = false
+      @pairs.each do |pair: Pair<K, V>|
+        if pair.fst == key
+          pair.snd = value
+          done = true
+        end
+      end
+      unless done
+        @pairs.push(Pair<K, V>.new(key, value))
+      end
+    end
+
+    # Get the value of specified key.
+    # If that key does not exist, the behavior is undefined (TODO: Return Option<V>)
+    def [](key: K) -> V
+      var ret = @pairs.first.snd
+      @pairs.each do |pair: Pair<K, V>|
+        if pair.fst == key
+          ret = pair.snd
+        end
+      end
+      ret
+    end
+
+    # Return true if `self` has `key` (compared with `==`)
+    def has_key(key: K) -> Bool
+      var ret = false
+      @pairs.each do |pair: Pair<K, V>|
+        if pair.fst == key
+          ret = true
+        end
+      end
+      ret
+    end
+
+    # Return list of the keys
+    def keys -> Array<K>
+      ret = Array<K>.new
+      @pairs.each do |pair: Pair<K, V>|
+        ret.push(pair.fst)
+      end
+      ret
+    end
+
+    # Return list of the values
+    def values -> Array<V>
+      ret = Array<V>.new
+      @pairs.each do |pair: Pair<K, V>|
+        ret.push(pair.snd)
+      end
+      ret
+    end
   end
 
-  # Return the `Hash_Table` which contains the `key`
-  def _table(key: K) -> Hash_Table<K, V>
+  def initialize
+    @tables = Array<Hash::Table<K, V>>.new
+    N_TABLES.times{|_: Int| @tables.push(Hash::Table<K, V>.new) }
+  end
+
+  # Return the `Hash::Table` which contains the `key`
+  def _table(key: K) -> Hash::Table<K, V>
     @tables[key.hash % @tables.length]
   end
 
@@ -40,7 +101,7 @@ class Hash<K, V>
   # Return list of the keys
   def keys -> Array<K>
     ret = Array<K>.new
-    @tables.each do |table: Hash_Table<K, V>|
+    @tables.each do |table: Hash::Table<K, V>|
       ret.append(table.keys)
     end
     ret
@@ -49,70 +110,8 @@ class Hash<K, V>
   # Return list of the values
   def values -> Array<V>
     ret = Array<V>.new
-    @tables.each do |table: Hash_Table<K, V>|
+    @tables.each do |table: Hash::Table<K, V>|
       ret.append(table.values)
-    end
-    ret
-  end
-end
-
-# TODO: Move to Hash::Table (#221)
-class Hash_Table<K, V>
-  def initialize
-    @pairs = Array<Pair<K, V>>.new
-  end
-
-  # Set the value of specified key.
-  def []=(key: K, value: V)
-    var done = false
-    @pairs.each do |pair: Pair<K, V>|
-      if pair.fst == key
-        pair.snd = value
-        done = true
-      end
-    end
-    unless done
-      @pairs.push(Pair<K, V>.new(key, value))
-    end
-  end
-
-  # Get the value of specified key.
-  # If that key does not exist, the behavior is undefined (TODO: Return Option<V>)
-  def [](key: K) -> V
-    var ret = @pairs.first.snd
-    @pairs.each do |pair: Pair<K, V>|
-      if pair.fst == key
-        ret = pair.snd
-      end
-    end
-    ret
-  end
-
-  # Return true if `self` has `key` (compared with `==`)
-  def has_key(key: K) -> Bool
-    var ret = false
-    @pairs.each do |pair: Pair<K, V>|
-      if pair.fst == key
-        ret = true
-      end
-    end
-    ret
-  end
-
-  # Return list of the keys
-  def keys -> Array<K>
-    ret = Array<K>.new
-    @pairs.each do |pair: Pair<K, V>|
-      ret.push(pair.fst)
-    end
-    ret
-  end
-
-  # Return list of the values
-  def values -> Array<V>
-    ret = Array<V>.new
-    @pairs.each do |pair: Pair<K, V>|
-      ret.push(pair.snd)
     end
     ret
   end

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -29,7 +29,7 @@ pub enum Definition {
         body_exprs: Vec<AstExpression>,
     },
     ConstDefinition {
-        name: ConstFirstname,
+        name: String,
         expr: AstExpression,
     },
 }

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -270,7 +270,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         // WhileEnd:
         self.builder.position_at_end(*rc2);
-        Ok(Some(self.gen_const_ref(&const_fullname("::Void"))))
+        Ok(Some(self.gen_const_ref(&toplevel_const("Void"))))
     }
 
     fn gen_break_expr(
@@ -530,7 +530,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .left()
         {
             Some(result_value) => result_value,
-            None => self.gen_const_ref(&const_fullname("::Void")),
+            None => self.gen_const_ref(&toplevel_const("Void")),
         }
     }
 
@@ -605,7 +605,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         // eg. Fn1.new(fnptr, the_self, captures)
         let cls_name = format!("Fn{}", params.len());
-        let meta = self.gen_const_ref(&const_fullname(&("::".to_string() + &cls_name)));
+        let meta = self.gen_const_ref(&toplevel_const(&cls_name));
         let fnptr = self
             .get_llvm_func(&func_name)
             .as_global_value()
@@ -624,7 +624,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     ) -> inkwell::values::BasicValueEnum<'run> {
         let ary = self.gen_llvm_func_call(
             "Meta:Array#new",
-            self.gen_const_ref(&const_fullname("::Array")),
+            self.gen_const_ref(&toplevel_const("Array")),
             vec![],
         );
         for cap in captures {
@@ -679,7 +679,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         let ary = self.gen_llvm_func_call(
             "Meta:Array#new",
-            self.gen_const_ref(&const_fullname("::Array")),
+            self.gen_const_ref(&toplevel_const("Array")),
             vec![],
         );
         for expr in exprs {
@@ -703,7 +703,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Create a string object
     fn gen_string_literal(&self, idx: &usize) -> inkwell::values::BasicValueEnum<'run> {
         let func = self.get_llvm_func(&"Meta:String#new");
-        let receiver_value = self.gen_const_ref(&const_fullname("::String"));
+        let receiver_value = self.gen_const_ref(&toplevel_const("String"));
         let global = self
             .module
             .get_global(&format!("str_{}", idx))

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -293,7 +293,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
     fn gen_init_void(&mut self) {
         // define void @"init_::XX"
-        let fullname = const_fullname("::Void");
+        let fullname = toplevel_const("::Void");
         let fn_type = self.void_type.fn_type(&[], false);
         let function = self
             .module

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -119,7 +119,6 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         } else {
             // generating builtin
             self.impl_boxing_funcs();
-            self.gen_init_void();
         }
         self.gen_lambda_funcs(&hir)?;
         Ok(())
@@ -275,8 +274,10 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
         // call void @"init_::XX"()
         for fullname in imported_constants.keys() {
-            let func = self.get_llvm_func(&format!("init_{}", fullname.0));
-            self.builder.build_call(func, &[], "");
+            if !fullname.is_internal() {
+                let func = self.get_llvm_func(&format!("init_{}", fullname.0));
+                self.builder.build_call(func, &[], "");
+            }
         }
         for expr in const_inits {
             match &expr.node {
@@ -288,26 +289,6 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             }
         }
 
-        self.builder.build_return(None);
-    }
-
-    fn gen_init_void(&mut self) {
-        // define void @"init_::XX"
-        let fullname = toplevel_const("Void");
-        let fn_type = self.void_type.fn_type(&[], false);
-        let function = self
-            .module
-            .add_function(&format!("init_{}", fullname.0), fn_type, None);
-        let basic_block = self.context.append_basic_block(function, "");
-        self.builder.position_at_end(basic_block);
-        // Create ::Void
-        let ptr = self
-            .module
-            .get_global(&"::Void")
-            .unwrap()
-            .as_pointer_value();
-        let value = self.allocate_sk_obj(&class_fullname("Void"), "void_obj");
-        self.builder.build_store(ptr, value);
         self.builder.build_return(None);
     }
 
@@ -449,8 +430,8 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         }
     }
 
+    /// Define `void @"init_::XX"`
     fn gen_const_inits(&self, const_inits: &'hir [HirExpression]) -> Result<(), Error> {
-        // define void @"init_::XX"
         for expr in const_inits {
             match &expr.node {
                 HirExpressionBase::HirConstAssign { fullname, .. } => {

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -293,7 +293,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
     fn gen_init_void(&mut self) {
         // define void @"init_::XX"
-        let fullname = toplevel_const("::Void");
+        let fullname = toplevel_const("Void");
         let fn_type = self.void_type.fn_type(&[], false);
         let function = self
             .module

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -12,7 +12,7 @@ const OBJ_VTABLE_IDX: usize = 0;
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Build IR to return ::Void
     pub fn build_return_void(&self) {
-        let v = self.gen_const_ref(&const_fullname("::Void"));
+        let v = self.gen_const_ref(&toplevel_const("Void"));
         self.builder.build_return(Some(&v));
     }
 

--- a/src/hir/class_dict/mod.rs
+++ b/src/hir/class_dict/mod.rs
@@ -60,4 +60,15 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             sig.params
         }
     }
+
+    /// Returns information for creating class constants
+    pub fn constant_list(&self) -> Vec<(String, bool)> {
+        self.sk_classes.iter().filter_map(|(name, class)| {
+            if name.is_meta() {
+                None
+            } else {
+                Some((name.0.clone(), class.const_is_obj))
+            }
+        }).collect()
+    }
 }

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -55,12 +55,12 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             Ok((sig.clone(), class.fullname.clone()))
         } else {
             // Look up in superclass
-            let sk_class = self.lookup_class(&class.fullname).unwrap_or_else(|| {
-                panic!(
-                    "[BUG] lookup_method: asked to find `{}' but class `{}' not found",
+            let sk_class = self.lookup_class(&class.fullname).ok_or_else(|| {
+                error::bug(&format!(
+                    "lookup_method: asked to find `{}' but class `{}' not found",
                     &method_name.0, &class.fullname.0
-                )
-            });
+                    ))
+            })?;
             if let Some(super_name) = &sk_class.superclass_fullname {
                 // TODO #115: super may not be a ty::raw
                 let super_class = ty::raw(&super_name.0);

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -385,7 +385,8 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         names: &[String],
         rhs: &AstExpression,
     ) -> Result<HirExpression, Error> {
-        let fullname = const_fullname(&format!("::{}", &names.join("::")));
+        // TODO: forbid `A::B = 1`
+        let fullname = toplevel_const(&names.join("::"));
         let hir_expr = self.convert_expr(rhs)?;
         self.constants.insert(fullname.clone(), hir_expr.ty.clone());
         Ok(Hir::const_assign(fullname, hir_expr))
@@ -419,7 +420,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         };
         let mut method_tyargs = vec![];
         for const_name in type_args {
-            method_tyargs.push(self._resolve_method_tyarg(const_name));
+            method_tyargs.push(self._resolve_method_tyarg(const_name)?);
         }
         let (sig, found_class_name) =
             self.class_dict
@@ -432,10 +433,9 @@ impl<'hir_maker> HirMaker<'hir_maker> {
     ///     ary.map<Array<T>>(f)
     ///             ~~~~~~~~
     ///             => TermTy(Array<TyParamRef(T)>)
-    fn _resolve_method_tyarg(&self, name: &ConstName) -> TermTy {
-        let class_typarams = self.current_class_typarams();
-        let method_typarams = self.current_method_typarams();
-        name.to_ty(&class_typarams, &method_typarams)
+    fn _resolve_method_tyarg(&self, name: &ConstName) -> Result<TermTy, Error> {
+        let (ty, _) = self._resolve_const(name)?;
+        Ok(ty)
     }
 
     /// Check the arguments and create HirMethodCall
@@ -691,71 +691,91 @@ impl<'hir_maker> HirMaker<'hir_maker> {
 
     /// Resolve constant name
     fn convert_const_ref(&mut self, name: &ConstName) -> Result<HirExpression, Error> {
-        if let Some((ty, fullname)) = self._lookup_const(name) {
-            return Ok(Hir::const_ref(ty.clone(), fullname));
+        let (ty, resolved) = self._resolve_const(name)?;
+        let full = resolved.to_const_fullname();
+        if self._lookup_const(&full).is_some() {
+            Ok(Hir::const_ref(ty, full))
+        } else {
+            debug_assert!(resolved.has_type_args());
+            let class_ty = self._create_class_const(&resolved);
+            Ok(Hir::const_ref(class_ty, full))
         }
-        // Check if it refers to a class
-        self._check_class_exists(name)?;
-        let class_ty = self._create_class_const(name);
-        Ok(Hir::const_ref(class_ty, name.to_const_fullname()))
+    }
+
+    /// Resolve const name (which may be a class)
+    fn _resolve_const(&self, name: &ConstName) -> Result<(TermTy, ResolvedConstName), Error> {
+        self.__resolve_const(name, false)
+    }
+
+    /// Resolve const name which *must be* a class
+    fn _resolve_class_const(&self, name: &ConstName) -> Result<(TermTy, ResolvedConstName), Error> {
+        self.__resolve_const(name, true)
     }
 
     /// Lookup a constant from current scope
-    fn _lookup_const(&self, name: &ConstName) -> Option<(&TermTy, ConstFullname)> {
-        let fullname = name.to_const_fullname();
-        if let Some(found) = self.constants.get(&fullname) {
-            return Some((found, fullname));
-        } else if let Some(found) = self.imported_constants.get(&fullname) {
-            return Some((found, fullname));
+    fn __resolve_const(&self, name: &ConstName, class_only: bool) -> Result<(TermTy, ResolvedConstName), Error> {
+        let (base_ty, base_resolved) = self.__resolve_simple_const(&name.names)?;
+        // Given `A<B>`, `A` and `B` must be a class
+        if (name.has_type_args() && !base_ty.is_metaclass()) || class_only {
+            return Err(error::program_error(&format!(
+                    "`{}' is not a class", base_resolved)));
         }
-
-        let fullname = name.under_namespace(&self.ctx.namespace());
-        self.constants.get(&fullname).map(|found| (found, fullname))
+        let mut arg_types = vec![];
+        let mut args_resolved = vec![];
+        for tyarg in &name.args {
+            let (ty, resolved) = self._resolve_class_const(tyarg)?;
+            arg_types.push(ty);
+            args_resolved.push(resolved);
+        }
+        let ty = ty::spe(&base_resolved.string(), arg_types);
+        let resolved = base_resolved.with_type_args(args_resolved);
+        Ok((ty, resolved))
     }
 
-    /// Check `name` refers proper class name
-    /// eg. For `A<B<C>>`, check A, B and C exists
-    fn _check_class_exists(&self, name: &ConstName) -> Result<(), Error> {
-        if !self.class_dict.class_exists(&name.names.join("::")) {
-            return Err(error::program_error(&format!(
-                "constant `{:?}' was not found",
-                name.names.join("::")
-            )));
-        }
-        if name.args.is_empty() {
-            return Ok(());
-        }
-        let mut typarams = self.current_class_typarams();
-        typarams.append(&mut self.current_method_typarams());
-        for arg in &name.args {
-            if typarams.contains(&arg.string()) {
-                // ok.
-            } else {
-                self._check_class_exists(arg)?;
+    /// Resolve a constant name without tyargs
+    fn __resolve_simple_const(&self, names: &[String]) -> Result<(TermTy, ResolvedConstName), Error> {
+        if names.len() == 1 {
+            // Check if it is a typaram ref
+            let name = names.first().unwrap();
+            if let Some(ty) = self.ctx.lookup_typaram(name) {
+                return Ok((ty, typaram_as_resolved_const_name(name)))
             }
         }
-        Ok(())
+        for namespace in self.ctx.const_scopes() {
+            let resolved = resolved_const_name(namespace, names.to_vec());
+            let full = resolved.to_const_fullname();
+            if let Some(ty) = self._lookup_const(&full) {
+                return Ok((ty, resolved))
+            }
+        }
+        Err(error::program_error(&format!(
+                    "constant `{:?}' was not found",
+                    names.join("::")
+        )))
     }
 
-    /// Register constant of a class object
+    /// Check if a constant is registered
+    fn _lookup_const(&self, full: &ConstFullname) -> Option<TermTy> {
+        self.constants.get(full).or_else(||
+        self.imported_constants.get(full))
+            .map(|ty| ty.clone())
+    }
+
+    /// Register constant of a class object (especially, specialized class)
     /// Return class_ty
-    // TODO: why not create the constant on class definition?
-    fn _create_class_const(&mut self, name: &ConstName) -> TermTy {
-        let ty = if name.args.is_empty() {
-            name.to_ty(&[], &[]).meta_ty()
-        } else {
-            // If the const is `A<B>`, also create its type `Meta:A<B>`
-            self._create_specialized_meta_class(name)
-        };
+    fn _create_class_const(&mut self, name: &ResolvedConstName) -> TermTy {
+        debug_assert!(name.has_type_args());
+        // For `A<B>`, create its type `Meta:A<B>`
+        let ty = self._create_specialized_meta_class(name);
         let idx = self.register_string_literal(&name.string());
-        let expr = Hir::class_literal(ty.clone(), name, idx);
+        let expr = Hir::class_literal(ty.clone(), name.to_class_fullname(), idx);
         self.register_const_full(name.to_const_fullname(), expr);
         ty
     }
 
     /// Create `Meta:A<B>` when there is a const `A<B>`
     /// Return class_ty
-    fn _create_specialized_meta_class(&mut self, name: &ConstName) -> TermTy {
+    fn _create_specialized_meta_class(&mut self, name: &ResolvedConstName) -> TermTy {
         let mut ivars = HashMap::new();
         ivars.insert(
             "name".to_string(),

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -379,14 +379,16 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         }
     }
 
+    /// Constant assignment (only occurs in the toplevel)
     fn convert_const_assign(
         &mut self,
         names: &[String],
         rhs: &AstExpression,
     ) -> Result<HirExpression, Error> {
-        let name = const_firstname(&names.join("::")); // TODO: pass entire `names` rather than ConstFirstname?
-        let fullname = self.register_const(&name, &rhs)?;
-        Ok(Hir::const_assign(fullname, self.convert_expr(rhs)?))
+        let fullname = const_fullname(&format!("::{}", &names.join("::")));
+        let hir_expr = self.convert_expr(rhs)?;
+        self.constants.insert(fullname.clone(), hir_expr.ty.clone());
+        Ok(Hir::const_assign(fullname, hir_expr))
     }
 
     fn convert_method_call(

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -795,12 +795,13 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         if const_is_obj { // eg. "Void"
             // The class
             let meta_name = const_is_obj_class_internal_const_name(name);
-            let expr = Hir::class_literal(ty.meta_ty(), name.to_class_fullname(), str_idx);
-            self.register_const_full(meta_name.to_const_fullname(), expr);
+            let meta_const_name = meta_name.to_const_fullname();
+            let cls_obj = Hir::class_literal(ty.meta_ty(), name.to_class_fullname(), str_idx);
+            let meta_const_assign = self.register_internal_const(meta_const_name.clone(), cls_obj);
             // The instance
             let expr = Hir::method_call(
                 ty.clone(),
-                Hir::const_ref(ty.clone(), meta_name.to_const_fullname()),
+                meta_const_assign,
                 method_fullname(&metaclass_fullname(&name.string()), "new"),
                 vec![]);
             self.register_const_full(name.to_const_fullname(), expr);

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -89,7 +89,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         std::mem::swap(&mut const_inits, &mut self.const_inits);
 
         // Register void
-        constants.insert(const_fullname("::Void"), ty::raw("Void"));
+        constants.insert(toplevel_const("Void"), ty::raw("Void"));
 
         Hir {
             sk_classes,
@@ -311,8 +311,8 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         expr: &AstExpression,
     ) -> Result<(), Error> {
         let hir_expr = self.convert_expr(expr)?;
-        self.constants.insert(const_fullname(name), hir_expr.ty.clone());
-        let op = Hir::const_assign(const_fullname(name), hir_expr);
+        self.constants.insert(toplevel_const(name), hir_expr.ty.clone());
+        let op = Hir::const_assign(toplevel_const(name), hir_expr);
         self.const_inits.push(op);
         Ok(())
     }

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -333,6 +333,17 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         self.const_inits.push(op);
     }
 
+    /// Register a special constant
+    pub(super) fn register_internal_const(
+        &mut self,
+        fullname: ConstFullname,
+        hir_expr: HirExpression,
+    ) -> HirExpression {
+        debug_assert!(!self.constants.contains_key(&fullname));
+        self.constants.insert(fullname.clone(), hir_expr.ty.clone());
+        Hir::const_assign(fullname.clone(), hir_expr)
+    }
+
     fn convert_method_def(
         &mut self,
         class_fullname: &ClassFullname,

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -155,7 +155,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         self.ctx.swap_current(&mut current);
         self.ctx
             .classes
-            .push(ClassCtx::new(fullname.clone(), typarams));
+            .push(ClassCtx::new(fullname.to_namespace(), typarams));
 
         // Register constants before processing #initialize
         self._process_const_defs_in_class(defs, fullname)?;
@@ -241,7 +241,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         for def in defs {
             if let ast::Definition::ConstDefinition { name, expr } = def {
                 // FIXME: works for A::B but not for A::B::C
-                let full = const_fullname(&format!("::{}::{}", fullname.0, name));
+                let full = const_fullname(&fullname.to_const_fullname(), name);
                 let hir_expr = self.convert_expr(expr)?;
                 self.register_const_full(full, hir_expr);
             }

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -159,6 +159,9 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             .classes
             .push(ClassCtx::new(namespace.add(firstname), typarams));
 
+        // Register class constant of self
+        self._create_class_const(&resolved_const_name(namespace.clone(), vec![firstname.0.clone()]));
+
         // Register constants before processing #initialize
         self._process_const_defs_in_class(defs, &fullname)?;
 

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -406,11 +406,11 @@ impl<'a> Iterator for NamespaceIter<'a> {
                 self.cur = None;
                 Some(Namespace::root())
             }
-            // Classes -> end.
+            // Classes -> Toplevel
             Some(CtxKind::Class) => {
                 let class_ctx = self.ctx.classes.get(self.idx).unwrap();
                 if self.idx == 0 {
-                    self.cur = None;
+                    self.cur = Some(CtxKind::Toplevel);
                 } else {
                     self.idx -= 1;
                 }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -139,7 +139,7 @@ impl HirExpressions {
 }
 /// Make a HirExpression to refer `::Void`
 fn void_const_ref() -> HirExpression {
-    Hir::const_ref(ty::raw("Void"), const_fullname("::Void"))
+    Hir::const_ref(ty::raw("Void"), toplevel_const("Void"))
 }
 
 #[derive(Debug)]

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -546,11 +546,11 @@ impl Hir {
         }
     }
 
-    pub fn class_literal(ty: TermTy, name: &ConstName, str_literal_idx: usize) -> HirExpression {
+    pub fn class_literal(ty: TermTy, fullname: ClassFullname, str_literal_idx: usize) -> HirExpression {
         HirExpression {
             ty,
             node: HirExpressionBase::HirClassLiteral {
-                fullname: name.to_class_fullname(),
+                fullname,
                 str_literal_idx,
             },
         }

--- a/src/names.rs
+++ b/src/names.rs
@@ -78,11 +78,6 @@ impl ClassFullname {
     pub fn to_const_fullname(&self) -> ConstFullname {
         toplevel_const(&self.0)
     }
-
-    // FIXME: a ClassFullname cannot be converted into Namespace. To be refactored
-    pub fn to_namespace(&self) -> Namespace {
-        Namespace::new(vec![self.0.clone()])
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
@@ -167,6 +162,18 @@ impl Namespace {
     /// Returns a toplevel namespace
     pub fn root() -> Namespace {
         Namespace::new(vec![])
+    }
+
+    /// Add `name` to the end of `self`
+    pub fn add(&self, name: &ClassFirstname) -> Namespace {
+        let mut v = self.0.clone();
+        v.push(name.0.clone());
+        Namespace::new(v)
+    }
+
+    /// Join Namespace and ClassFirstname
+    pub fn class_fullname(&self, name: &ClassFirstname) -> ClassFullname {
+        class_fullname(self.to_string() + &name.0)
     }
 
     /// Returns string representation of self

--- a/src/names.rs
+++ b/src/names.rs
@@ -29,7 +29,9 @@ impl std::fmt::Display for ClassFullname {
 }
 
 pub fn class_fullname(s: impl Into<String>) -> ClassFullname {
-    ClassFullname(s.into())
+    let name = s.into();
+    debug_assert!(!name.starts_with("::"));
+    ClassFullname(name)
 }
 
 pub fn metaclass_fullname(base: &str) -> ClassFullname {
@@ -173,7 +175,12 @@ impl Namespace {
 
     /// Join Namespace and ClassFirstname
     pub fn class_fullname(&self, name: &ClassFirstname) -> ClassFullname {
-        class_fullname(self.to_string() + &name.0)
+        let n = self.to_string();
+        if n.is_empty() {
+            class_fullname(&name.0)
+        } else {
+            class_fullname(format!("{}::{}", n, &name.0))
+        }
     }
 
     /// Returns string representation of self

--- a/src/names.rs
+++ b/src/names.rs
@@ -167,6 +167,11 @@ impl Namespace {
         Namespace::new(vec![])
     }
 
+    /// Returns the hidden namespace
+    pub fn internal() -> Namespace {
+        Namespace::new(vec!["<internal>".to_string()])
+    }
+
     /// Add `name` to the end of `self`
     pub fn add(&self, name: &ClassFirstname) -> Namespace {
         let mut v = self.0.clone();
@@ -323,4 +328,11 @@ pub fn resolved_const_name(namespace: Namespace, names: Vec<String>) -> Resolved
 // ad hoc. Not sure I'm doing right
 pub fn typaram_as_resolved_const_name(name: impl Into<String>) -> ResolvedConstName {
     resolved_const_name(Namespace::root(), vec![name.into()])
+}
+
+// The constant `::Void` is an *instance* of the class `Void`. However we need
+// the class object for `::Void.class`; Returns name for this internal constant
+pub fn const_is_obj_class_internal_const_name(name: &ResolvedConstName) -> ResolvedConstName {
+    debug_assert!(!name.has_type_args());
+    resolved_const_name(Namespace::internal(), name.names.clone())
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -130,10 +130,13 @@ impl std::fmt::Display for ConstFullname {
     }
 }
 
-pub fn const_fullname(s: &str) -> ConstFullname {
-    debug_assert!(s.starts_with("::"));
-    debug_assert!(!s.starts_with("::::"));
-    ConstFullname(s.to_string())
+pub fn const_fullname(namespace: &ConstFullname, first_name: &str) -> ConstFullname {
+    ConstFullname(format!("{}::{}", namespace.0, first_name))
+}
+
+pub fn toplevel_const(first_name: &str) -> ConstFullname {
+    debug_assert!(!first_name.starts_with("::"));
+    ConstFullname(format!("::{}", first_name))
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/names.rs
+++ b/src/names.rs
@@ -121,25 +121,6 @@ impl MethodFullname {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
-pub struct ConstFirstname(pub String);
-
-impl std::fmt::Display for ConstFirstname {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl ConstFirstname {
-    pub fn add_namespace(&self, namespace: &str) -> ConstFullname {
-        const_fullname(&("::".to_string() + namespace + "::" + &self.0))
-    }
-}
-
-pub fn const_firstname(s: &str) -> ConstFirstname {
-    ConstFirstname(s.to_string())
-}
-
 #[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize)]
 pub struct ConstFullname(pub String);
 

--- a/src/names.rs
+++ b/src/names.rs
@@ -31,6 +31,7 @@ impl std::fmt::Display for ClassFullname {
 pub fn class_fullname(s: impl Into<String>) -> ClassFullname {
     let name = s.into();
     debug_assert!(!name.starts_with("::"));
+    debug_assert!(!name.starts_with("Meta:Meta:"));
     ClassFullname(name)
 }
 
@@ -252,6 +253,10 @@ impl std::fmt::Display for ResolvedConstName {
 }
 
 impl ResolvedConstName {
+    pub fn unsafe_create(s: String) -> ResolvedConstName {
+        ResolvedConstName { names: vec![s], args: vec![] }
+    }
+
     /// Returns if generic
     pub fn has_type_args(&self) -> bool {
         !self.args.is_empty()

--- a/src/names.rs
+++ b/src/names.rs
@@ -146,6 +146,13 @@ pub fn toplevel_const(first_name: &str) -> ConstFullname {
     ConstFullname(format!("::{}", first_name))
 }
 
+impl ConstFullname {
+    /// Returns true if this const is not visible in Shiika level
+    pub fn is_internal(&self) -> bool {
+        self.0.contains("<internal>")
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Namespace(pub Vec<String>);
 

--- a/src/parser/definition_parser.rs
+++ b/src/parser/definition_parser.rs
@@ -436,7 +436,7 @@ impl<'a> Parser<'a> {
         let name;
         match self.current_token() {
             Token::UpperWord(s) => {
-                name = const_firstname(s);
+                name = s.to_string()
             }
             _ => panic!("must be called on an UpperWord"),
         }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -377,6 +377,7 @@ pub fn class() -> TermTy {
 }
 
 pub fn spe(base_name: &str, type_args: Vec<TermTy>) -> TermTy {
+    debug_assert!(!type_args.is_empty());
     let tyarg_names = type_args
         .iter()
         .map(|x| x.fullname.0.to_string())

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -64,6 +64,11 @@ impl TermTy {
             _ => self.fullname.0.clone(),
         }
     }
+
+    /// Returns if value of this type is class
+    pub fn is_metaclass(&self) -> bool {
+        matches!(&self.body, TyMeta { .. } | TyGenMeta { .. } | TySpeMeta { .. } | TyClass)
+    }
 }
 
 /// Format `type_args` with .dbg_str

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -69,6 +69,11 @@ impl TermTy {
     pub fn is_metaclass(&self) -> bool {
         matches!(&self.body, TyMeta { .. } | TyGenMeta { .. } | TySpeMeta { .. } | TyClass)
     }
+
+    /// Returns if this is TyParamRef
+    pub fn is_typaram_ref(&self) -> bool {
+        matches!(&self.body, TyParamRef { .. })
+    }
 }
 
 /// Format `type_args` with .dbg_str
@@ -173,6 +178,15 @@ impl TermTy {
             } => ty::spe_meta(&base_name, type_args.clone()),
             TySpeMeta { .. } => ty::class(),
             _ => panic!("TODO"),
+        }
+    }
+
+    pub fn instance_ty(&self) -> TermTy {
+        match &self.body {
+            TyMeta { base_fullname } => ty::raw(base_fullname),
+            TyClass => ty::class(),
+            TySpeMeta { base_name, type_args } => ty::spe(base_name, type_args.to_vec()),
+            _ => panic!("undefined: {:?}", self),
         }
     }
 

--- a/tests/sk/constants.sk
+++ b/tests/sk/constants.sk
@@ -1,0 +1,14 @@
+class A
+  class B
+  end
+
+  # TODO class C : B
+  class C
+    def foo
+      B.new  #=> should be resolved to A::B
+      Array<B>.new
+    end
+  end
+end
+
+puts "ok"


### PR DESCRIPTION
Implemented constant name resolution. For example this program no more raises error
```
class A
  class B; end
  def foo
    B.new
  end
end
```

refs #221 