### PR TITLE
Implementing enum part.1

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -42,6 +42,7 @@ pub enum Definition {
 #[derive(Debug, PartialEq)]
 pub struct EnumCase {
     pub name: ClassFirstname,
+    pub typarams: Vec<String>,
     pub params: Vec<Param>,
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,6 +20,11 @@ pub enum Definition {
         super_name: ClassFullname,
         defs: Vec<Definition>,
     },
+    EnumDefinition {
+        name: ClassFirstname,
+        typarams: Vec<String>,
+        cases: Vec<EnumCase>,
+    },
     InstanceMethodDefinition {
         sig: AstMethodSignature,
         body_exprs: Vec<AstExpression>,
@@ -32,6 +37,12 @@ pub enum Definition {
         name: String,
         expr: AstExpression,
     },
+}
+
+#[derive(Debug, PartialEq)]
+pub struct EnumCase {
+    pub name: ClassFirstname,
+    pub params: Vec<Param>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -121,6 +121,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
     }
 
     fn process_toplevel_def(&mut self, def: &ast::Definition) -> Result<(), Error> {
+        let namespace = Namespace::root();
         match def {
             // Extract instance/class methods
             ast::Definition::ClassDefinition {
@@ -129,9 +130,13 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 defs,
                 ..
             } => {
-                let namespace = Namespace::root();
                 self.process_class_def(&namespace, name, typarams.clone(), defs)?;
             }
+            ast::Definition::EnumDefinition {
+                name,
+                typarams,
+                cases,
+            } => self.process_enum_def(&namespace, name, typarams.clone(), cases)?,
             ast::Definition::ConstDefinition { name, expr } => {
                 self.register_toplevel_const(name, expr)?;
             }
@@ -179,6 +184,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         self.method_dict
             .add_method(&meta_name, self.create_new(&fullname)?);
 
+        // Process inner defs
         let inner_namespace = namespace.add(firstname);
         for def in defs {
             match def {
@@ -208,9 +214,12 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                     defs,
                     typarams,
                     ..
-                } => {
-                    self.process_class_def(&inner_namespace, name, typarams.clone(), defs)?;
-                }
+                } => self.process_class_def(&inner_namespace, name, typarams.clone(), defs)?,
+                ast::Definition::EnumDefinition {
+                    name,
+                    typarams,
+                    cases,
+                } => self.process_enum_def(&inner_namespace, name, typarams.clone(), cases)?,
             }
         }
         self.ctx.classes.pop();
@@ -397,5 +406,30 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             },
             method_ctx.iivars,
         ))
+    }
+
+    /// Process a enum definition
+    fn process_enum_def(
+        &mut self,
+        _namespace: &Namespace,
+        _firstname: &ClassFirstname,
+        _typarams: Vec<String>,
+        _cases: &[ast::EnumCase],
+    ) -> Result<(), Error> {
+        // TODO: self._register_enum_case_class
+        Ok(())
+    }
+
+    fn _register_enum_case_class(
+        &mut self,
+        _namespace: &Namespace,
+        _typarams: Vec<String>,
+        _case: &EnumCase,
+    ) {
+        // TODO: Register class constant of self
+        // TODO: Register #initialize
+        // TODO: Register ivars
+        // TODO: Register accessors
+        // Register .new
     }
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -344,6 +344,8 @@ impl<'a> Lexer<'a> {
         let s = &self.src[begin..next_cur.pos];
         let (token, state) = match s {
             "class" => (Token::KwClass, LexerState::ExprBegin),
+            "enum" => (Token::KwEnum, LexerState::ExprBegin),
+            "case" => (Token::KwCase, LexerState::ExprBegin),
             "end" => (Token::KwEnd, LexerState::ExprEnd),
             "def" => (Token::KwDef, LexerState::ExprBegin),
             "var" => (Token::KwVar, LexerState::ExprBegin),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -73,7 +73,11 @@ impl<'a> Parser<'a> {
                 Token::KwClass => {
                     items.push(ast::TopLevelItem::Def(self.parse_class_definition()?));
                 }
+                Token::KwEnum => {
+                    items.push(ast::TopLevelItem::Def(self.parse_enum_definition()?));
+                }
                 Token::KwDef => {
+                    // REFACTOR: Raise error here (rather than on ClassDict::index_program)
                     items.push(ast::TopLevelItem::Def(self.parse_method_definition()?));
                 }
                 Token::Eof | Token::KwEnd => break,

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -69,6 +69,8 @@ pub enum Token {
     SetMethod,    //  []=
     // Keywords
     KwClass,
+    KwEnum,
+    KwCase,
     KwEnd,
     KwDef,
     KwVar,
@@ -193,6 +195,8 @@ impl Token {
             Token::SetMethod => false,    //  []=
             // Keywords
             Token::KwClass => false,
+            Token::KwEnum => false,
+            Token::KwCase => false,
             Token::KwEnd => false,
             Token::KwDef => false,
             Token::KwVar => false,


### PR DESCRIPTION
This PR adds `enum` keyword.  refs #142 

Its semantics are not completed yet. However I'd like to merge this now because I found #115 is needed for enums (for example, `class Maybe::Some<T> : class Maybe<T>`.)