### PR TITLE
feat!: Remove typarams from enum case

### DIFF
--- a/builtin/error.sk
+++ b/builtin/error.sk
@@ -1,0 +1,6 @@
+# Represents an error
+class Error
+  def initialize(@msg: String); end
+
+  # def backtrace
+end

--- a/builtin/maybe.sk
+++ b/builtin/maybe.sk
@@ -1,5 +1,5 @@
 enum Maybe<V>
-  case Some<V>(value: V)
+  case Some(value: V)
   case None
 end
 #Some = Maybe::Some

--- a/builtin/result.sk
+++ b/builtin/result.sk
@@ -1,0 +1,4 @@
+enum Result<V, E>
+  case Ok(value: V)
+  case Err(err: E)
+end

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -42,7 +42,6 @@ pub enum Definition {
 #[derive(Debug, PartialEq)]
 pub struct EnumCase {
     pub name: ClassFirstname,
-    pub typarams: Vec<String>,
     pub params: Vec<Param>,
 }
 

--- a/src/parser/definition_parser.rs
+++ b/src/parser/definition_parser.rs
@@ -192,7 +192,6 @@ impl<'a> Parser<'a> {
                 ))
             }
         }
-        let typarams = self.parse_opt_typarams()?;
         let params = match self.current_token() {
             Token::Separator => vec![],
             Token::LParen => {
@@ -210,7 +209,6 @@ impl<'a> Parser<'a> {
         };
         Ok(ast::EnumCase {
             name,
-            typarams,
             params,
         })
     }

--- a/tests/sk/enum.sk
+++ b/tests/sk/enum.sk
@@ -5,4 +5,7 @@ f(a)
 f(b)
 unless a.value == 1; puts "ng Some#value"; end
 
+o = Result::Ok<Int, Error>.new(0)
+e = Result::Err<Int, Error>.new(Error.new("fail"))
+
 puts "ok"


### PR DESCRIPTION
In the case of `Result`, `Ok` and `Err` both have two type parameters
`V` and `E`. Then writing them in hand is just redundant.