### PR TITLE
impl. type name lookup in signatures and superclass

### DIFF
--- a/builtin/never.sk
+++ b/builtin/never.sk
@@ -1,0 +1,2 @@
+class Never
+end

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -50,20 +50,14 @@ pub struct AstMethodSignature {
     pub name: MethodFirstname,
     pub typarams: Vec<String>,
     pub params: Vec<Param>,
-    pub ret_typ: Typ,
+    pub ret_typ: Option<ConstName>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Param {
     pub name: String,
-    pub typ: Typ,
+    pub typ: ConstName,
     pub is_iparam: bool, // eg. `def initialize(@a: Int)`
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct Typ {
-    pub name: String,
-    pub typ_args: Vec<Typ>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/corelib/mod.rs
+++ b/src/corelib/mod.rs
@@ -92,6 +92,14 @@ fn rust_body_items() -> Vec<ClassItem> {
             vec![],
         ),
         (
+            "String".to_string(),
+            Some(Superclass::simple("Object")),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        ),
+        (
             "Void".to_string(),
             Some(Superclass::simple("Object")),
             void::create_methods(),

--- a/src/corelib/mod.rs
+++ b/src/corelib/mod.rs
@@ -5,7 +5,6 @@ mod float;
 mod fn_x;
 mod int;
 mod math;
-mod never;
 mod object;
 mod shiika_internal_memory;
 mod shiika_internal_ptr;
@@ -92,25 +91,9 @@ fn rust_body_items() -> Vec<ClassItem> {
             vec![],
         ),
         (
-            "String".to_string(),
-            Some(Superclass::simple("Object")),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-        ),
-        (
             "Void".to_string(),
             Some(Superclass::simple("Object")),
             void::create_methods(),
-            vec![],
-            HashMap::new(),
-            vec![],
-        ),
-        (
-            "Never".to_string(),
-            Some(Superclass::simple("Object")),
-            never::create_methods(),
             vec![],
             HashMap::new(),
             vec![],

--- a/src/hir/class_dict/class_index.rs
+++ b/src/hir/class_dict/class_index.rs
@@ -1,0 +1,95 @@
+use crate::ast;
+use crate::hir::*;
+use crate::names::*;
+use std::collections::HashMap;
+
+/// Set of pair of class name and its typaram names
+pub type ClassIndex = HashMap<ClassFullname, Vec<TyParam>>;
+
+/// Collect class names in the program
+pub fn create(
+    toplevel_defs: &[&ast::Definition],
+    initial_sk_classes: &SkClasses,
+    imported_classes: &SkClasses,
+) -> ClassIndex {
+    let mut cindex = HashMap::new();
+    index_sk_classes(&mut cindex, initial_sk_classes);
+    index_sk_classes(&mut cindex, imported_classes);
+    index_toplevel_defs(&mut cindex, toplevel_defs);
+    cindex
+}
+
+fn index_sk_classes(cindex: &mut ClassIndex, sk_classes: &SkClasses) {
+    for (name, class) in sk_classes {
+        cindex.insert(name.clone(), class.typarams.clone());
+    }
+}
+
+fn index_toplevel_defs(cindex: &mut ClassIndex, toplevel_defs: &[&ast::Definition]) {
+    let namespace = Namespace::root();
+    for def in toplevel_defs {
+        match def {
+            ast::Definition::ClassDefinition {
+                name,
+                typarams,
+                defs,
+                ..
+            } => index_class(cindex, &namespace, &name, &typarams, &defs),
+            ast::Definition::EnumDefinition {
+                name,
+                typarams,
+                cases,
+            } => index_enum(cindex, &namespace, &name, &typarams, &cases),
+            _ => (),
+        }
+    }
+}
+
+fn index_class(
+    cindex: &mut ClassIndex,
+    namespace: &Namespace,
+    firstname: &ClassFirstname,
+    typarams: &[String],
+    defs: &[ast::Definition],
+) {
+    let fullname = namespace.class_fullname(firstname);
+    cindex.insert(fullname.clone(), ty::typarams(typarams));
+    let inner_namespace = namespace.add(firstname);
+    for def in defs {
+        match def {
+            ast::Definition::ClassDefinition {
+                name,
+                typarams,
+                defs,
+                ..
+            } => {
+                index_class(cindex, &inner_namespace, &name, &typarams, &defs);
+            }
+            ast::Definition::EnumDefinition {
+                name,
+                typarams,
+                cases,
+            } => {
+                index_enum(cindex, &inner_namespace, &name, &typarams, &cases);
+            }
+            _ => (),
+        }
+    }
+}
+
+fn index_enum(
+    cindex: &mut ClassIndex,
+    namespace: &Namespace,
+    firstname: &ClassFirstname,
+    typarams: &[String],
+    cases: &[ast::EnumCase],
+) {
+    let fullname = namespace.class_fullname(firstname);
+    cindex.insert(fullname.clone(), ty::typarams(typarams));
+
+    let inner_namespace = namespace.add(firstname);
+    for case in cases {
+        let case_fullname = inner_namespace.class_fullname(&case.name);
+        cindex.insert(case_fullname, ty::typarams(&typarams));
+    }
+}

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -384,7 +384,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         names: &[String],
     ) -> Result<Vec<String>, Error> {
         let n = namespace.len();
-        for k in 0..n {
+        for k in 0..=n {
             let mut resolved = namespace.head(n - k).to_vec();
             resolved.append(&mut names.to_vec());
             if self.class_exists(&resolved.join("::")) {

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -60,15 +60,19 @@ impl<'hir_maker> ClassDict<'hir_maker> {
     ) -> Result<(), Error> {
         let fullname = namespace.class_fullname(firstname);
         let metaclass_fullname = fullname.meta_name();
-        // TODO: check ast_superclass is valid
-        let superclass = if let Some(n) = ast_superclass {
-            Superclass::from_const_name(n, typarams)
+        let superclass = if let Some(name) = ast_superclass {
+            Superclass::from_ty(self._resolve_typename(
+                namespace,
+                typarams,
+                Default::default(),
+                name,
+            )?)
         } else {
             Superclass::default()
         };
         let new_sig = signature::signature_of_new(
             &metaclass_fullname,
-            self.initializer_params(namespace, typarams, &superclass, &defs)?,
+            self._initializer_params(namespace, typarams, &superclass, &defs)?,
             &ty::return_type_of_new(&fullname, typarams),
         );
 
@@ -110,7 +114,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
     /// Return parameters of `initialize` which is defined by
     /// - `#initialize` in `defs` (if any) or,
     /// - `#initialize` inherited from ancestors.
-    fn initializer_params(
+    fn _initializer_params(
         &self,
         namespace: &Namespace,
         typarams: &[String],

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -121,7 +121,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             defs.iter().find(|d| d.is_initializer())
         {
             // Has explicit initializer definition
-            self._convert_params(namespace, &sig.params, typarams, Default::default())
+            self.convert_params(namespace, &sig.params, typarams, Default::default())
         } else {
             // Inherit #initialize from superclass
             let (sig, _) = self
@@ -323,13 +323,13 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         Ok(MethodSignature {
             fullname,
             ret_ty,
-            params: self._convert_params(namespace, &sig.params, class_typarams, &sig.typarams)?,
+            params: self.convert_params(namespace, &sig.params, class_typarams, &sig.typarams)?,
             typarams: sig.typarams.clone(),
         })
     }
 
     /// Convert ast params to hir params
-    fn _convert_params(
+    pub fn convert_params(
         &self,
         namespace: &Namespace,
         ast_params: &[ast::Param],

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -277,13 +277,6 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             class_methods.insert(sig.fullname.first_name.clone(), sig);
         }
 
-        if !self.is_valid_superclass(superclass.ty(), typaram_names) {
-            return Err(error::name_error(&format!(
-                "superclass {:?} of {:?} does not exist",
-                superclass, fullname,
-            )));
-        }
-
         self.add_class(SkClass {
             fullname: fullname.clone(),
             typarams: typarams.clone(),

--- a/src/hir/class_dict/mod.rs
+++ b/src/hir/class_dict/mod.rs
@@ -2,7 +2,6 @@ mod indexing;
 mod query;
 use crate::ast;
 use crate::error::*;
-use crate::hir;
 use crate::hir::*;
 use crate::names::*;
 
@@ -39,29 +38,6 @@ pub fn create<'hir_maker>(
 }
 
 impl<'hir_maker> ClassDict<'hir_maker> {
-    /// Return parameters of `initialize` which is defined by
-    /// - `#initialize` in `defs` (if any) or,
-    /// - `#initialize` inherited from ancestors.
-    fn initializer_params(
-        &self,
-        typarams: &[String],
-        superclass: &Superclass,
-        defs: &[ast::Definition],
-    ) -> Vec<MethodParam> {
-        if let Some(ast::Definition::InstanceMethodDefinition { sig, .. }) =
-            defs.iter().find(|d| d.is_initializer())
-        {
-            // Has explicit initializer definition
-            hir::signature::convert_params(&sig.params, typarams, &[])
-        } else {
-            // Inherit #initialize from superclass
-            let (sig, _) = self
-                .lookup_method(&superclass.ty(), &method_firstname("initialize"), &[])
-                .expect("[BUG] initialize not found");
-            specialized_initialize(&sig, superclass).params
-        }
-    }
-
     /// Returns information for creating class constants
     pub fn constant_list(&self) -> Vec<(String, bool)> {
         self.sk_classes

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -93,39 +93,6 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         self.lookup_class(&class_fullname(fullname)).is_some()
     }
 
-    /// Check if given superclass can exist
-    /// (TODO: consider namespace)
-    pub fn is_valid_superclass(&self, ty: &TermTy, typaram_names: &[String]) -> bool {
-        match &ty.body {
-            TyBody::TyRaw => self.class_exists(&ty.fullname.0),
-            TyBody::TySpe {
-                base_name,
-                type_args,
-            } => {
-                if !self.class_exists(&base_name) {
-                    return false;
-                }
-                for t in type_args {
-                    if !self.is_valid_superclass(&t, typaram_names) {
-                        return false;
-                    }
-                }
-                true
-            }
-            TyBody::TyParamRef {
-                kind: TyParamKind::Class,
-                name,
-                idx,
-            } => {
-                let s = typaram_names.get(*idx);
-                debug_assert!(s.is_some());
-                debug_assert!(s.unwrap() == name);
-                true
-            }
-            _ => panic!("must not happen"),
-        }
-    }
-
     /// Returns supertype of `ty` (except it is `Object`)
     pub fn supertype(&self, ty: &TermTy) -> Option<TermTy> {
         self.get_class(&ty.erasure())

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -70,6 +70,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             .or_else(|| self.imported_classes.get(class_fullname))
     }
 
+    /// Returns if there is a class of the given name
     /// Find a class. Panic if not found
     pub fn get_class(&self, class_fullname: &ClassFullname) -> &SkClass {
         self.lookup_class(class_fullname)

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -492,11 +492,13 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         exprs: &[AstExpression],
         is_fn: &bool,
     ) -> Result<HirExpression, Error> {
-        let hir_params = signature::convert_params(
+        let namespace = self.ctx.const_scopes().next().unwrap();
+        let hir_params = self.class_dict.convert_params(
+            &namespace,
             params,
             &self.current_class_typarams(),
             &self.current_method_typarams(),
-        );
+        )?;
 
         // Convert lambda body
         self.ctx

--- a/src/hir/signature.rs
+++ b/src/hir/signature.rs
@@ -1,4 +1,3 @@
-use crate::ast;
 use crate::names::*;
 use crate::ty;
 use crate::ty::*;
@@ -53,42 +52,6 @@ pub fn find_param<'a>(params: &'a [MethodParam], name: &str) -> Option<(usize, &
         .iter()
         .enumerate()
         .find(|(_, param)| param.name == name)
-}
-
-pub fn convert_typ(
-    typ: &ConstName,
-    class_typarams: &[String],
-    method_typarams: &[String],
-) -> TermTy {
-    let name = typ.names.join("::");
-    let args = &typ.args;
-    if let Some(idx) = class_typarams.iter().position(|s| *s == name) {
-        ty::typaram(&name, ty::TyParamKind::Class, idx)
-    } else if let Some(idx) = method_typarams.iter().position(|s| *s == name) {
-        ty::typaram(&name, ty::TyParamKind::Method, idx)
-    } else if args.is_empty() {
-        ty::raw(&name)
-    } else {
-        let tyargs = args
-            .iter()
-            .map(|t| convert_typ(t, class_typarams, method_typarams))
-            .collect();
-        ty::spe(&name, tyargs)
-    }
-}
-
-pub fn convert_params(
-    params: &[ast::Param],
-    class_typarams: &[String],
-    method_typarams: &[String],
-) -> Vec<MethodParam> {
-    params
-        .iter()
-        .map(|param| MethodParam {
-            name: param.name.to_string(),
-            ty: convert_typ(&param.typ, class_typarams, method_typarams),
-        })
-        .collect()
 }
 
 /// Create a signature of a `new` method

--- a/src/hir/signature.rs
+++ b/src/hir/signature.rs
@@ -55,27 +55,6 @@ pub fn find_param<'a>(params: &'a [MethodParam], name: &str) -> Option<(usize, &
         .find(|(_, param)| param.name == name)
 }
 
-/// Create `hir::MethodSignature` from `ast::MethodSignature`
-pub fn create_signature(
-    class_fullname: &ClassFullname,
-    sig: &ast::AstMethodSignature,
-    class_typarams: &[String],
-) -> MethodSignature {
-    let fullname = method_fullname(class_fullname, &sig.name.0);
-    let ret_ty = if let Some(typ) = &sig.ret_typ {
-        convert_typ(&typ, class_typarams, &sig.typarams)
-    } else {
-        ty::raw("Void") // Default return type.
-    };
-    let params = convert_params(&sig.params, class_typarams, &sig.typarams);
-    MethodSignature {
-        fullname,
-        ret_ty,
-        params,
-        typarams: sig.typarams.clone(),
-    }
-}
-
 pub fn convert_typ(
     typ: &ConstName,
     class_typarams: &[String],

--- a/src/hir/superclass.rs
+++ b/src/hir/superclass.rs
@@ -10,7 +10,7 @@ pub struct Superclass(TermTy);
 
 impl Superclass {
     /// Create a `Superclass`
-    fn from_ty(t: TermTy) -> Superclass {
+    pub fn from_ty(t: TermTy) -> Superclass {
         debug_assert!(matches!(t.body, TyBody::TyRaw | TyBody::TySpe { .. }));
         Superclass(t)
     }
@@ -33,10 +33,6 @@ impl Superclass {
     /// Default superclass (= Object)
     pub fn default() -> Superclass {
         Superclass::simple("Object")
-    }
-
-    pub fn from_const_name(name: &ConstName, typarams: &[String]) -> Superclass {
-        Superclass::from_ty(name.to_ty(typarams))
     }
 
     pub fn ty(&self) -> &TermTy {

--- a/src/names.rs
+++ b/src/names.rs
@@ -171,7 +171,7 @@ impl std::fmt::Display for Namespace {
 impl Namespace {
     /// Create a namespace object
     pub fn new(names: Vec<String>) -> Namespace {
-        // TODO: should check each name does not contain `::`
+        debug_assert!(names.iter().all(|x| !x.contains("::")));
         Namespace(names)
     }
 
@@ -200,6 +200,15 @@ impl Namespace {
         } else {
             class_fullname(format!("{}::{}", n, &name.0))
         }
+    }
+
+    pub fn head(&self, n: usize) -> &[String] {
+        &self.0[0..n]
+    }
+
+    /// Number of names
+    pub fn len(&self) -> usize {
+        self.0.len()
     }
 
     /// Returns string representation of self
@@ -288,6 +297,10 @@ impl std::fmt::Display for ResolvedConstName {
 }
 
 impl ResolvedConstName {
+    pub fn new(names: Vec<String>, args: Vec<ResolvedConstName>) -> ResolvedConstName {
+        ResolvedConstName { names, args }
+    }
+
     pub fn unsafe_create(s: String) -> ResolvedConstName {
         ResolvedConstName {
             names: vec![s],

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -71,6 +71,7 @@ pub fn build_corelib() -> Result<(), Error> {
     Ok(())
 }
 
+/// Load ./builtin/*.sk into a String
 fn load_builtin() -> Result<String, Box<dyn std::error::Error>> {
     let mut s = String::new();
     let dir =

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -430,6 +430,15 @@ pub fn typaram(name: impl Into<String>, kind: TyParamKind, idx: usize) -> TermTy
     }
 }
 
+pub fn typarams(names: &[String]) -> Vec<TyParam> {
+    names
+        .iter()
+        .map(|s| TyParam {
+            name: s.to_string(),
+        })
+        .collect()
+}
+
 /// A type parameter
 /// In the future, may have something like +T/-T or in/out
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -329,6 +329,14 @@ impl TermTy {
     }
 }
 
+pub fn nonmeta(names: &[String], args: Vec<TermTy>) -> TermTy {
+    if args.is_empty() {
+        ty::raw(&names.join("::"))
+    } else {
+        ty::spe(&names.join("::"), args)
+    }
+}
+
 pub fn raw(fullname: &str) -> TermTy {
     debug_assert!(!fullname.contains('<'), "{}", fullname.to_string());
     TermTy {

--- a/tests/sk/nested_class.sk
+++ b/tests/sk/nested_class.sk
@@ -1,11 +1,14 @@
 class A
-  class B
-    def foo -> Int
+  class B; end
+  class C : B
+    def foo(b: B) -> Int
       1
     end
   end
+  # TODO: If B is here, indexing C fails as it finds B#initialize
+  #class B; end
 end
 b = A::B.new
-unless b.foo == 1 then puts "ng 1" end
+unless A::C.new.foo(b) == 1 then puts "ng 1" end
 
 puts "ok"


### PR DESCRIPTION
This program compiles with this PR.
```rb
class A
  class B; end
  class C : B  # Superclass is A::B
    def foo(b: B) # The type of B is A::B
    end
  end
end
```
Also, raise error for unknown typename instead of a compiler crash.

fix #221