### PR TITLE
Angle operator

### DIFF
--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -560,6 +560,7 @@ impl Hir {
         fullname: ClassFullname,
         str_literal_idx: usize,
     ) -> HirExpression {
+        debug_assert!(ty.is_metaclass());
         HirExpression {
             ty,
             node: HirExpressionBase::HirClassLiteral {

--- a/src/hir/sk_class.rs
+++ b/src/hir/sk_class.rs
@@ -41,12 +41,11 @@ impl SkClass {
     /// Create a specialized metaclass of a generic metaclass
     /// eg. create `Meta:Array<Int>` from `Meta:Array`
     pub fn specialized_meta(&self, tyargs: &[TermTy]) -> SkClass {
-        // `self` must be a generic metaclass.
-        debug_assert!(!self.typarams.is_empty());
+        debug_assert!(self.typarams.len() == tyargs.len());
         let base_name = if let TyBody::TyMeta { base_fullname } = &self.instance_ty.body {
             base_fullname
         } else {
-            panic!("SkClass::specialize: not TyMeta")
+            panic!("SkClass::specialize: not TyMeta: {:?}", &self.fullname)
         };
         let instance_ty = ty::spe_meta(base_name, tyargs.to_vec());
         let method_sigs = self
@@ -54,7 +53,6 @@ impl SkClass {
             .iter()
             .map(|(name, sig)| (name.clone(), sig.specialize(tyargs, Default::default())))
             .collect();
-
         SkClass {
             fullname: instance_ty.fullname.clone(),
             typarams: vec![],

--- a/tests/expression_parser_test.rs
+++ b/tests/expression_parser_test.rs
@@ -1,5 +1,4 @@
 use shiika::ast;
-use shiika::names;
 use shiika::parser::Parser;
 
 fn parse_expr(src: &str) -> Result<ast::AstExpression, shiika::error::Error> {
@@ -39,7 +38,7 @@ fn test_const_assign() {
     assert_eq!(
         result.unwrap(),
         ast::assignment(
-            ast::const_ref(names::const_name(vec!["X".to_string()])),
+            ast::const_ref(vec!["X".to_string()]),
             ast::decimal_literal(1)
         )
     )


### PR DESCRIPTION
This PR changes interpretation of `A<B>` from `ConstRef("A<B>")` to `SpecializeExpression(ConstRef("A"), [ConstRef("B")])`.

motivation: #292