### PR TITLE
Disallow inheriting from enum.

### DIFF
--- a/src/corelib/mod.rs
+++ b/src/corelib/mod.rs
@@ -168,6 +168,7 @@ fn make_classes(
                     .iter()
                     .map(|x| (x.signature.first_name().clone(), x.signature.clone()))
                     .collect(),
+                is_final: Some(false),
                 const_is_obj: (name == "Void"),
                 foreign: false,
             },
@@ -193,6 +194,7 @@ fn make_classes(
                         .iter()
                         .map(|x| (x.signature.first_name().clone(), x.signature.clone()))
                         .collect(),
+                    is_final: None,
                     const_is_obj: false,
                     foreign: false,
                 },

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -176,9 +176,14 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         let mut instance_methods = enum_case_getters(&fullname, &ivar_list);
         instance_methods.insert(method_firstname("initialize"), initialize_sig);
 
+        let case_typarams = if case.params.is_empty() {
+            Default::default()
+        } else {
+            typarams
+        };
         self.add_new_class(
             &fullname,
-            typarams,
+            case_typarams,
             superclass,
             Some(new_sig),
             instance_methods,

--- a/src/hir/sk_class.rs
+++ b/src/hir/sk_class.rs
@@ -15,6 +15,10 @@ pub struct SkClass {
     pub instance_ty: TermTy,
     pub ivars: HashMap<String, super::SkIVar>,
     pub method_sigs: HashMap<MethodFirstname, MethodSignature>,
+    /// true if this class cannot be a explicit superclass.
+    /// None if not applicable (eg. metaclasses cannot be a explicit superclass because there is no
+    /// such syntax)
+    pub is_final: Option<bool>,
     /// eg. `Void` is an instance, not the class
     pub const_is_obj: bool,
     /// true if this class is an imported one
@@ -60,6 +64,7 @@ impl SkClass {
             instance_ty,
             ivars: self.ivars.clone(),
             method_sigs,
+            is_final: None,
             const_is_obj: self.const_is_obj,
             foreign: false,
         }


### PR DESCRIPTION
This PR denies inheriting from enum classes and enum case classes.

Also fixed cases with no params (eg. `Maybe::None`) had typarams (should have no typarams).