### PR TITLE
Fix error `Undefined symbols _init_::None`

### DIFF
--- a/builtin/_lambda.sk
+++ b/builtin/_lambda.sk
@@ -40,6 +40,3 @@ end
 
 class Fn9<S1, S2, S3, S4, S5, S6, S7, S8, S9, T> : Fn
 end
-
-# Create `::FnX` by these ConstRef's for lambda exprs (#178)
-Fn0; Fn1; Fn2; Fn3; Fn4; Fn5; Fn6; Fn7; Fn8; Fn9

--- a/builtin/array.sk
+++ b/builtin/array.sk
@@ -385,6 +385,3 @@ class Array<T>
     l
   end
 end
-
-# Create `Meta:Array` by this ConstRef for array literals (#178)
-Array

--- a/builtin/maybe.sk
+++ b/builtin/maybe.sk
@@ -2,5 +2,5 @@ enum Maybe<V>
   case Some(value: V)
   case None
 end
-#Some = Maybe::Some
-#None = Maybe::None
+Some = Maybe::Some
+None = Maybe::None

--- a/builtin/result.sk
+++ b/builtin/result.sk
@@ -1,4 +1,6 @@
 enum Result<V, E>
   case Ok(value: V)
-  case Err(err: E)
+  case Fail(err: E)
 end
+Ok = Result::Ok
+Fail = Result::Fail

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -175,6 +175,18 @@ impl AstExpression {
             _ => false,
         }
     }
+
+    /// If `self` is ConstAssign, convert it to a ConstDefinition
+    pub fn as_const_def(&self) -> Option<Definition> {
+        if let AstExpressionBody::ConstAssign { names, rhs } = &self.body {
+            Some(Definition::ConstDefinition {
+                name: names.join("::"),
+                expr: *rhs.clone(),
+            })
+        } else {
+            None
+        }
+    }
 }
 
 pub fn logical_not(expr: AstExpression) -> AstExpression {

--- a/src/parser/definition_parser.rs
+++ b/src/parser/definition_parser.rs
@@ -539,7 +539,7 @@ impl<'a> Parser<'a> {
         Ok(ConstName { names, args })
     }
 
-    fn parse_const_definition(&mut self) -> Result<ast::Definition, Error> {
+    pub fn parse_const_definition(&mut self) -> Result<ast::Definition, Error> {
         self.debug_log("parse_const_definition");
         self.lv += 1;
         let name;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -77,12 +77,19 @@ impl<'a> Parser<'a> {
                     items.push(ast::TopLevelItem::Def(self.parse_enum_definition()?));
                 }
                 Token::KwDef => {
-                    // REFACTOR: Raise error here (rather than on ClassDict::index_program)
-                    items.push(ast::TopLevelItem::Def(self.parse_method_definition()?));
+                    return Err(parse_error!(
+                        self,
+                        "you cannot define toplevel method in Shiika"
+                    ));
                 }
                 Token::Eof | Token::KwEnd => break,
                 _ => {
-                    items.push(ast::TopLevelItem::Expr(self.parse_expr()?));
+                    let expr = self.parse_expr()?;
+                    if let Some(constdef) = expr.as_const_def() {
+                        items.push(ast::TopLevelItem::Def(constdef));
+                    } else {
+                        items.push(ast::TopLevelItem::Expr(expr));
+                    }
                 }
             }
             self.skip_wsn();

--- a/tests/expression_parser_test.rs
+++ b/tests/expression_parser_test.rs
@@ -33,18 +33,6 @@ fn test_if_expr_with_sep() {
 }
 
 #[test]
-fn test_const_assign() {
-    let result = parse_expr("X = 1");
-    assert_eq!(
-        result.unwrap(),
-        ast::assignment(
-            ast::const_ref(vec!["X".to_string()]),
-            ast::decimal_literal(1)
-        )
-    )
-}
-
-#[test]
 fn test_equality_expr() {
     let result = parse_expr("1 != 2");
     assert_eq!(

--- a/tests/sk/enum.sk
+++ b/tests/sk/enum.sk
@@ -1,11 +1,11 @@
-a = Maybe::Some<Int>.new(1)
-b = Maybe::None
+a = Some<Int>.new(1)
+b = None
 f = fn(x: Maybe<Int>) { x }
 f(a)
 f(b)
 unless a.value == 1; puts "ng Some#value"; end
 
-o = Result::Ok<Int, Error>.new(0)
-e = Result::Err<Int, Error>.new(Error.new("fail"))
+o = Ok<Int, Error>.new(0)
+e = Fail<Int, Error>.new(Error.new("fail"))
 
 puts "ok"


### PR DESCRIPTION
fix #296 

Rather than exporting all the `init_::XX` functions, only the new function `(package name)_init_constants` is exported. 