### PR TITLE
Object#class

### DIFF
--- a/builtin/object.sk
+++ b/builtin/object.sk
@@ -1,9 +1,4 @@
 class Object
-  def ==(other: Object) -> Bool
-    panic "[`==` not yet implemented for this class]"
-    false
-  end
-
   def <(other: Object) -> Bool
     panic "[`< is not implemented for this class]"
     false

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -882,12 +882,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             self.gen_string_literal(str_literal_idx),
             "@name",
         );
-        self.build_ivar_store(
-            &cls_obj,
-            1,
-            self.box_i8ptr(self.vtable_ref(&meta_name).into_pointer_value()),
-            "@vtable",
-        );
 
         if fullname.0 == "Class" {
             // We need a trick here to achieve `Class.class == Class`.

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -418,8 +418,8 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         receiver_value: inkwell::values::BasicValueEnum<'run>,
         func_type: inkwell::types::FunctionType<'run>,
     ) -> inkwell::values::PointerValue<'run> {
-        let class = self.get_class_of_obj(receiver_value);
-        let vtable = self.get_vtable_of_class(class);
+        //let class = self.get_class_of_obj(receiver_value);
+        let vtable = self.get_vtable_of_obj(receiver_value).into_pointer_value();
         let (idx, size) = self.__lookup_vtable(&receiver_ty, &method_name);
         let func_raw = self.build_vtable_ref(vtable, *idx, size);
         self.builder

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -370,7 +370,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ret_ty: &TermTy,
     ) -> Result<Option<inkwell::values::BasicValueEnum<'run>>, Error> {
         // Prepare arguments
-        let method_name = &method_fullname.first_name;
         let receiver_value = self.gen_expr(ctx, receiver_expr)?.unwrap();
         let mut arg_values = vec![];
         for arg_expr in arg_exprs {
@@ -384,22 +383,19 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.build_unconditional_branch(start_block);
         self.builder.position_at_end(start_block);
 
-        // Get the llvm function from vtable
-        let (idx, size) = self.lookup_vtable(&receiver_expr.ty, method_name)?;
-        let func_raw = self.build_vtable_ref(receiver_value, *idx, size);
-        let func_type = self
-            .llvm_func_type(
-                Some(&receiver_expr.ty),
-                &arg_exprs.iter().map(|x| &x.ty).collect::<Vec<_>>(),
-                ret_ty,
-            )
-            .ptr_type(AddressSpace::Generic);
-        let func = self
-            .builder
-            .build_bitcast(func_raw, func_type, "func")
-            .into_pointer_value();
+        // Get the llvm function from vtable of the class of the object
+        let func_type = self.llvm_func_type(
+            Some(&receiver_expr.ty),
+            &arg_exprs.iter().map(|x| &x.ty).collect::<Vec<_>>(),
+            ret_ty,
+        );
+        let func = self._get_method_func(
+            &method_fullname.first_name,
+            &receiver_expr.ty,
+            receiver_value,
+            func_type,
+        );
 
-        // Invoke the llvm function
         let result = self.gen_llvm_function_call(func, receiver_value, arg_values);
         if ret_ty.is_never_type() {
             self.builder.build_unreachable();
@@ -414,21 +410,31 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         }
     }
 
-    /// Get the idx and size of vtable
-    fn lookup_vtable(
+    /// Retrieve the llvm func
+    fn _get_method_func(
         &self,
-        ty: &TermTy,
         method_name: &MethodFirstname,
-    ) -> Result<(&usize, usize), Error> {
+        receiver_ty: &TermTy,
+        receiver_value: inkwell::values::BasicValueEnum<'run>,
+        func_type: inkwell::types::FunctionType<'run>,
+    ) -> inkwell::values::PointerValue<'run> {
+        let class = self.get_class_of_obj(receiver_value);
+        let vtable = self.get_vtable_of_class(class);
+        let (idx, size) = self.__lookup_vtable(&receiver_ty, &method_name);
+        let func_raw = self.build_vtable_ref(vtable, *idx, size);
+        self.builder
+            .build_bitcast(func_raw, func_type.ptr_type(AddressSpace::Generic), "func")
+            .into_pointer_value()
+    }
+
+    /// Get the idx and size of vtable
+    fn __lookup_vtable(&self, ty: &TermTy, method_name: &MethodFirstname) -> (&usize, usize) {
         if let Some(found) = self.vtables.method_idx(ty, method_name) {
-            Ok(found)
+            found
         } else if let Some(found) = self.imported_vtables.method_idx(ty, method_name) {
-            Ok(found)
+            found
         } else {
-            Err(error::bug(format!(
-                "[BUG] method_idx: vtable of {} not found",
-                &ty.fullname
-            )))
+            panic!("[BUG] method_idx: vtable of {} not found", &ty.fullname);
         }
     }
 
@@ -501,6 +507,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     }
 
     /// Generate llvm function call
+    // REFACTOR: make this public and make `receiver_value` optional
     fn gen_llvm_func_call(
         &self,
         func_name: &str,
@@ -511,7 +518,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.gen_llvm_function_call(function, receiver_value, arg_values)
     }
 
-    fn gen_llvm_function_call<F>(
+    pub(super) fn gen_llvm_function_call<F>(
         &self,
         function: F,
         receiver_value: inkwell::values::BasicValueEnum<'run>,
@@ -668,7 +675,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             let fn_x = ctx.function.get_first_param().unwrap();
             self.build_ivar_load(fn_x, FN_X_THE_SELF_IDX, "@obj")
         } else {
-            // The first arg of llvm function is `self`
             ctx.function.get_first_param().unwrap()
         };
         self.builder
@@ -706,23 +712,20 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Create a string object
     fn gen_string_literal(&self, idx: &usize) -> inkwell::values::BasicValueEnum<'run> {
-        let func = self.get_llvm_func("Meta:String#new");
-        let receiver_value = self.gen_const_ref(&toplevel_const("String"));
         let global = self
             .module
             .get_global(&format!("str_{}", idx))
             .unwrap_or_else(|| panic!("[BUG] global for str_{} not created", idx))
             .as_pointer_value();
-        let glob_i8 = self
-            .builder
-            .build_bitcast(global, self.i8ptr_type, "")
-            .into_pointer_value();
         let bytesize = self
             .i64_type
             .const_int(self.str_literals[*idx].len() as u64, false);
-        let arg_values = vec![self.box_i8ptr(glob_i8), self.box_int(&bytesize)];
-
-        self.gen_llvm_function_call(func, receiver_value, arg_values)
+        let func = self.get_llvm_func("gen_literal_string");
+        self.builder
+            .build_call(func, &[self.into_i8ptr(global), bytesize.into()], "sk_str")
+            .try_as_basic_value()
+            .left()
+            .unwrap()
     }
 
     fn gen_boolean_literal(&self, value: bool) -> inkwell::values::BasicValueEnum<'run> {
@@ -856,21 +859,42 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     }
 
     /// Create a class object
-    #[allow(clippy::let_and_return)]
+    /// ("class literal" is a special Hir that will not appear directly
+    /// on a source text.)
     fn gen_class_literal(
         &self,
         fullname: &ClassFullname,
         str_literal_idx: &usize,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        let cls_obj = self.allocate_sk_obj(fullname, &fullname.0.to_string());
+        debug_assert!(!fullname.is_meta());
+        let meta_name = fullname.meta_name();
+        let reg_name = format!("class_{}", fullname);
+        let cls_obj = if fullname.0 == "Class" {
+            // We need a trick here to achieve `Class.class == Class`.
+            let null = self.i8ptr_type.const_null();
+            self._allocate_sk_obj(&meta_name, &reg_name, null.into())
+        } else {
+            self.allocate_sk_obj(&meta_name, &reg_name)
+        };
         self.build_ivar_store(
             &cls_obj,
             0,
             self.gen_string_literal(str_literal_idx),
             "@name",
         );
-        // We assume class objects never have custom `initialize` method
+        self.build_ivar_store(
+            &cls_obj,
+            1,
+            self.box_i8ptr(self.vtable_ref(&meta_name).into_pointer_value()),
+            "@vtable",
+        );
 
+        if fullname.0 == "Class" {
+            // We need a trick here to achieve `Class.class == Class`.
+            self.set_class_of_obj(&cls_obj, cls_obj);
+        }
+
+        // We assume class objects never have custom `initialize` method
         cls_obj
     }
 }

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -104,6 +104,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
     pub fn gen_program(&mut self, hir: &'hir Hir, imports: &LibraryExports) -> Result<(), Error> {
         self.gen_declares();
+        self.define_class_class();
         self.gen_imports(imports);
         self.gen_class_structs(&hir.sk_classes);
         self.gen_string_literals(&hir.str_literals);
@@ -186,6 +187,14 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             self.i8_type.const_int(0, false),
         ]));
         global.set_constant(true);
+    }
+
+    /// Define llvm struct type for `Class`
+    fn define_class_class(&mut self) {
+        self.llvm_struct_types.insert(
+            class_fullname("Class"),
+            self.context.opaque_struct_type("Class"),
+        );
     }
 
     /// Generate information to use imported items

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -168,13 +168,22 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         class_fullname: &ClassFullname,
         reg_name: &str,
     ) -> inkwell::values::BasicValueEnum<'ictx> {
+        let class_obj = self.load_class_object(class_fullname);
+        self._allocate_sk_obj(class_fullname, reg_name, class_obj)
+    }
+
+    /// Load a class object
+    fn load_class_object(
+        &self,
+        class_fullname: &ClassFullname,
+    ) -> inkwell::values::BasicValueEnum<'ictx> {
         let class_const_name = llvm_class_const_name(class_fullname);
-        let class_obj = self
+        let class_obj_addr = self
             .module
             .get_global(&class_const_name)
             .unwrap_or_else(|| panic!("global `{}' not found", class_const_name))
-            .as_basic_value_enum();
-        self._allocate_sk_obj(class_fullname, reg_name, class_obj)
+            .as_pointer_value();
+        self.builder.build_load(class_obj_addr, "class_obj")
     }
 
     pub fn _allocate_sk_obj(

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -11,9 +11,6 @@ const OBJ_VTABLE_IDX: usize = 0;
 /// 1st: reference to the class object
 const OBJ_CLASS_IDX: usize = 1;
 
-/// @vtable of class
-const CLASS_VTABLE_IDX: usize = 1;
-
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Build IR to return ::Void
     pub fn build_return_void(&self) {
@@ -70,7 +67,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         object: &inkwell::values::BasicValueEnum<'run>,
         class_obj: inkwell::values::BasicValueEnum<'run>,
     ) {
-        self.build_llvm_struct_set(object, OBJ_CLASS_IDX, self.into_i8ptr(class_obj), "class");
+        let cast =
+            self.builder
+                .build_bitcast(class_obj, self.llvm_type(&ty::raw("Class")), "class");
+        self.build_llvm_struct_set(object, OBJ_CLASS_IDX, cast, "my_class");
     }
 
     /// Set `vtable` to `object`

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -52,13 +52,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         object: inkwell::values::BasicValueEnum<'run>,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        let i8ptr = self.build_llvm_struct_ref(object, OBJ_CLASS_IDX, "class");
-        let class_type = self.llvm_struct_type(&class_fullname("Class"));
-        self.builder.build_bitcast(
-            i8ptr,
-            class_type.ptr_type(AddressSpace::Generic),
-            "sk_class",
-        )
+        self.build_llvm_struct_ref(object, OBJ_CLASS_IDX, "class")
     }
 
     /// Set `class_obj` to the class object field of `object`

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -82,14 +82,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.build_llvm_struct_set(object, OBJ_VTABLE_IDX, vtable, "vtable");
     }
 
-    //    /// Get vtable of a class object as *i8
-    //    pub fn get_vtable_of_class(
-    //        &self,
-    //        class: inkwell::values::BasicValueEnum<'run>,
-    //    ) -> inkwell::values::PointerValue<'run> {
-    //        self.unbox_i8ptr(self.build_ivar_load(class, CLASS_VTABLE_IDX, "@vtable"))
-    //    }
-
     /// Get vtable of the class of the given name as *i8
     pub fn vtable_ref(&self, classname: &ClassFullname) -> inkwell::values::BasicValueEnum<'run> {
         let vtable_const_name = llvm_vtable_const_name(classname);

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -1,13 +1,15 @@
+use crate::code_gen::*;
 /// Provides utility functions used by code_gen/*.rs
 /// (some are also used by corelib/*.rs)
-use crate::code_gen::*;
 use inkwell::types::*;
 use inkwell::AddressSpace;
 
 /// Number of elements before ivars
 const OBJ_HEADER_SIZE: usize = 1;
-/// 0th: reference to vtable
-const OBJ_VTABLE_IDX: usize = 0;
+/// 0th: reference to the class object
+const OBJ_CLASS_IDX: usize = 0;
+/// @vtable of class
+const CLASS_VTABLE_IDX: usize = 1;
 
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Build IR to return ::Void
@@ -37,19 +39,60 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.build_llvm_struct_set(object, OBJ_HEADER_SIZE + idx, value, name)
     }
 
+    /// Get the class object of an object as `*Class`
+    pub fn get_class_of_obj(
+        &self,
+        object: inkwell::values::BasicValueEnum<'run>,
+    ) -> inkwell::values::BasicValueEnum<'run> {
+        let i8ptr = self.build_llvm_struct_ref(object, OBJ_CLASS_IDX, "class");
+        let class_type = self.llvm_struct_type(&class_fullname("Class"));
+        self.builder.build_bitcast(
+            i8ptr,
+            class_type.ptr_type(AddressSpace::Generic),
+            "sk_class",
+        )
+    }
+
+    /// Set `class_obj` to the class object field of `object`
+    pub fn set_class_of_obj(
+        &self,
+        object: &inkwell::values::BasicValueEnum<'run>,
+        class_obj: inkwell::values::BasicValueEnum<'run>,
+    ) {
+        self.build_llvm_struct_set(object, OBJ_CLASS_IDX, self.into_i8ptr(class_obj), "class");
+    }
+
+    /// Get vtable of a class object as *i8
+    pub fn get_vtable_of_class(
+        &self,
+        class: inkwell::values::BasicValueEnum<'run>,
+    ) -> inkwell::values::PointerValue<'run> {
+        self.unbox_i8ptr(self.build_ivar_load(class, CLASS_VTABLE_IDX, "@vtable"))
+    }
+
+    /// Get vtable of the class of the given name as *i8
+    pub fn vtable_ref(&self, classname: &ClassFullname) -> inkwell::values::BasicValueEnum<'run> {
+        let vtable_const_name = llvm_vtable_const_name(classname);
+        let llvm_ary_ptr = self
+            .module
+            .get_global(&vtable_const_name)
+            .unwrap_or_else(|| panic!("[BUG] global `{}' not found", &vtable_const_name))
+            .as_pointer_value();
+        self.into_i8ptr(llvm_ary_ptr)
+    }
+
     /// Lookup llvm func from vtable of an object
     pub fn build_vtable_ref(
         &self,
-        object: inkwell::values::BasicValueEnum<'run>,
+        vtable_i8ptr: inkwell::values::PointerValue<'run>,
         idx: usize,
         size: usize,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        let vtable_ref = self.build_llvm_struct_ref(object, OBJ_VTABLE_IDX, "vtable_ref");
         let ary_type = self.i8ptr_type.array_type(size as u32);
         let vtable_ptr = self
             .builder
             .build_bitcast(
-                vtable_ref,
+                vtable_i8ptr,
                 ary_type.ptr_type(AddressSpace::Generic),
                 "vtable_ptr",
             )
@@ -63,23 +106,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .unwrap()
     }
 
-    /// Store reference to vtable into an object
-    pub fn build_store_vtable<'a>(
-        &'a self,
-        object: inkwell::values::BasicValueEnum<'a>,
-        class_fullname: &ClassFullname,
-    ) {
-        let vtable_ref = self
-            .module
-            .get_global(&llvm_vtable_name(class_fullname))
-            .unwrap()
-            .as_pointer_value();
-        let vtable = self
-            .builder
-            .build_bitcast(vtable_ref, self.i8ptr_type, "vtable");
-        self.build_llvm_struct_set(&object, OBJ_VTABLE_IDX, vtable, "vtable")
-    }
-
     /// Load value of nth element of llvm struct
     fn build_llvm_struct_ref(
         &self,
@@ -87,17 +113,20 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         idx: usize,
         name: &str,
     ) -> inkwell::values::BasicValueEnum<'run> {
+        let obj_ptr = object.into_pointer_value();
+        let obj_ptr_ty = obj_ptr.get_type();
         let ptr = self
             .builder
             .build_struct_gep(
-                object.into_pointer_value(),
+                obj_ptr,
                 idx as u32,
                 &format!("addr_{}", name),
             )
             .unwrap_or_else(|_| {
+                let pointee_ty = obj_ptr_ty.get_element_type();
                 panic!(
-                    "build_llvm_struct_ref: elem not found (idx: {}, name: {}, object: {:?})",
-                    &idx, &name, &object
+                    "build_llvm_struct_ref: elem not found (idx: {}, name: {}, pointee_ty: {:?}, object: {:?})",
+                    &idx, &name, &pointee_ty, &object
                 )
             });
         self.builder.build_load(ptr, name)
@@ -133,6 +162,21 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         class_fullname: &ClassFullname,
         reg_name: &str,
     ) -> inkwell::values::BasicValueEnum<'ictx> {
+        let class_const_name = llvm_class_const_name(class_fullname);
+        let class_obj = self
+            .module
+            .get_global(&class_const_name)
+            .unwrap_or_else(|| panic!("global `{}' not found", class_const_name))
+            .as_basic_value_enum();
+        self._allocate_sk_obj(class_fullname, reg_name, class_obj)
+    }
+
+    pub fn _allocate_sk_obj(
+        &self,
+        class_fullname: &ClassFullname,
+        reg_name: &str,
+        class_obj: inkwell::values::BasicValueEnum,
+    ) -> inkwell::values::BasicValueEnum<'ictx> {
         let object_type = self.llvm_struct_type(class_fullname);
         let obj_ptr_type = object_type.ptr_type(AddressSpace::Generic);
         let size = object_type
@@ -151,8 +195,8 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         // %foo = bitcast i8* %mem to %#{t}*",
         let obj = self.builder.build_bitcast(raw_addr, obj_ptr_type, reg_name);
 
-        // Store reference to vtable
-        self.build_store_vtable(obj, class_fullname);
+        // Store reference to class obj
+        self.set_class_of_obj(&obj, class_obj);
 
         obj
     }
@@ -189,9 +233,26 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .get_function(name)
             .unwrap_or_else(|| panic!("[BUG] get_llvm_func: `{:?}' not found", name))
     }
+
+    /// Cast `sk_obj` to `i8*`
+    pub(super) fn into_i8ptr<V>(&self, sk_obj: V) -> inkwell::values::BasicValueEnum<'run>
+    where
+        V: inkwell::values::BasicValue<'run>,
+    {
+        self.builder.build_bitcast(sk_obj, self.i8ptr_type, "i8ptr")
+    }
 }
 
 /// Name of llvm constant of a vtable
-pub(super) fn llvm_vtable_name(classname: &ClassFullname) -> String {
-    format!("vtable_{}", classname)
+pub(super) fn llvm_vtable_const_name(classname: &ClassFullname) -> String {
+    format!("shiika_vtable_{}", classname.0)
+}
+
+/// Name of llvm constant of a class object
+fn llvm_class_const_name(classname: &ClassFullname) -> String {
+    if classname.is_meta() {
+        "::Class".to_string()
+    } else {
+        format!("::{}", classname.0)
+    }
 }

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -207,10 +207,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         // %foo = bitcast i8* %mem to %#{t}*",
         let obj = self.builder.build_bitcast(raw_addr, obj_ptr_type, reg_name);
 
-        // Store reference to class obj
-        self.set_class_of_obj(&obj, class_obj);
         // Store reference to vtable
         self.set_vtable_of_obj(&obj, self.vtable_ref(class_fullname));
+        // Store reference to class obj
+        self.set_class_of_obj(&obj, class_obj);
 
         obj
     }

--- a/src/corelib/class.rs
+++ b/src/corelib/class.rs
@@ -13,5 +13,14 @@ pub fn ivars() -> HashMap<String, SkIVar> {
             readonly: true,
         },
     );
+    ivars.insert(
+        "@vtable".to_string(),
+        SkIVar {
+            name: "@vtable".to_string(),
+            idx: 1,
+            ty: ty::raw("Shiika::Internal::Ptr"),
+            readonly: true,
+        },
+    );
     ivars
 }

--- a/src/corelib/class.rs
+++ b/src/corelib/class.rs
@@ -13,14 +13,5 @@ pub fn ivars() -> HashMap<String, SkIVar> {
             readonly: true,
         },
     );
-    ivars.insert(
-        "@vtable".to_string(),
-        SkIVar {
-            name: "@vtable".to_string(),
-            idx: 1,
-            ty: ty::raw("Shiika::Internal::Ptr"),
-            readonly: true,
-        },
-    );
     ivars
 }

--- a/src/corelib/object.rs
+++ b/src/corelib/object.rs
@@ -4,8 +4,40 @@ use inkwell::values::*;
 
 pub fn create_methods() -> Vec<SkMethod> {
     vec![
+        create_method(
+            "Object",
+            "==(other: Object) -> Bool",
+            |code_gen, function| {
+                let receiver = function
+                    .get_nth_param(0)
+                    .unwrap()
+                    .into_pointer_value()
+                    .const_to_int(code_gen.i64_type);
+                let other = function
+                    .get_nth_param(1)
+                    .unwrap()
+                    .into_pointer_value()
+                    .const_to_int(code_gen.i64_type);
+                let result = code_gen.builder.build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    receiver,
+                    other,
+                    "eq",
+                );
+                code_gen
+                    .builder
+                    .build_return(Some(&code_gen.box_bool(result)));
+                Ok(())
+            },
+        ),
         create_method("Object", "initialize() -> Void", |code_gen, _function| {
             code_gen.build_return_void();
+            Ok(())
+        }),
+        create_method("Object", "class() -> Class", |code_gen, function| {
+            let receiver = function.get_nth_param(0).unwrap();
+            let cls_obj = code_gen.get_class_of_obj(receiver);
+            code_gen.builder.build_return(Some(&cls_obj));
             Ok(())
         }),
         create_method("Object", "putd(n: Int) -> Void", |code_gen, function| {

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -827,7 +827,11 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         self._create_specialized_meta_class(&meta_ty);
         // Register const `A<B>`
         let str_idx = self.register_string_literal(&full.0);
-        let expr = Hir::class_literal(meta_ty.clone(), meta_ty.fullname.clone(), str_idx);
+        let expr = Hir::class_literal(
+            meta_ty.clone(),
+            meta_ty.instance_ty().fullname.clone(),
+            str_idx,
+        );
         self.register_const_full(full.clone(), expr);
     }
 

--- a/src/names.rs
+++ b/src/names.rs
@@ -2,8 +2,6 @@ use crate::ty;
 use crate::ty::*;
 use serde::{Deserialize, Serialize};
 
-pub const INTERNAL_CONST_NAMESPACE: &str = "<internal>";
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct ClassFirstname(pub String);
 
@@ -169,13 +167,6 @@ pub fn toplevel_const(first_name: &str) -> ConstFullname {
     ConstFullname(format!("::{}", first_name))
 }
 
-impl ConstFullname {
-    /// Returns true if this const is not visible in Shiika level
-    pub fn is_internal(&self) -> bool {
-        self.0.contains(INTERNAL_CONST_NAMESPACE)
-    }
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct Namespace(pub Vec<String>);
 
@@ -195,11 +186,6 @@ impl Namespace {
     /// Returns a toplevel namespace
     pub fn root() -> Namespace {
         Namespace::new(vec![])
-    }
-
-    /// Returns the hidden namespace
-    pub fn internal() -> Namespace {
-        Namespace::new(vec![INTERNAL_CONST_NAMESPACE.to_string()])
     }
 
     /// Add `name` to the end of `self`
@@ -424,11 +410,4 @@ pub fn resolved_const_name(namespace: Namespace, names: Vec<String>) -> Resolved
 // ad hoc. Not sure I'm doing right
 pub fn typaram_as_resolved_const_name(name: impl Into<String>) -> ResolvedConstName {
     resolved_const_name(Namespace::root(), vec![name.into()])
-}
-
-// The constant `::Void` is an *instance* of the class `Void`. However we need
-// the class object for `::Void.class`; Returns name for this internal constant
-fn const_is_obj_class_internal_const_name(name: &ResolvedConstName) -> ResolvedConstName {
-    debug_assert!(!name.has_type_args());
-    resolved_const_name(Namespace::internal(), name.names.clone())
 }

--- a/src/parser/definition_parser.rs
+++ b/src/parser/definition_parser.rs
@@ -307,6 +307,7 @@ impl<'a> Parser<'a> {
     fn get_method_name(&mut self) -> Result<&str, Error> {
         let name = match self.current_token() {
             Token::LowerWord(s) => s,
+            Token::KwClass => "class",
             Token::UPlusMethod => "+@",
             Token::UMinusMethod => "-@",
             Token::GetMethod => "[]",

--- a/src/parser/expression_parser.rs
+++ b/src/parser/expression_parser.rs
@@ -624,6 +624,7 @@ impl<'a> Parser<'a> {
         // Method name
         let method_name = match self.current_token() {
             Token::LowerWord(s) => s.clone(),
+            Token::KwClass => "class".to_string(),
             token => return Err(parse_error!(self, "invalid method name: {:?}", token)),
         };
         self.consume_token();

--- a/src/rustlib/src/sk_obj.rs
+++ b/src/rustlib/src/sk_obj.rs
@@ -2,6 +2,7 @@
 #[derive(Debug)]
 pub struct SkInt {
     vtable: *const u8,
+    class_obj: *const u8,
     value: i64,
 }
 
@@ -9,6 +10,7 @@ pub struct SkInt {
 #[derive(Debug)]
 pub struct SkPtr {
     vtable: *const u8,
+    class_obj: *const u8,
     value: *const u8,
 }
 
@@ -16,6 +18,7 @@ pub struct SkPtr {
 #[derive(Debug)]
 pub struct SkString {
     vtable: *const u8,
+    class_obj: *const u8,
     ptr: *const SkPtr,
     bytesize: *const SkInt,
 }

--- a/src/rustlib/src/sk_obj.rs
+++ b/src/rustlib/src/sk_obj.rs
@@ -1,8 +1,3 @@
-//extern "C" {
-//    fn box_int(int: i64) -> *const SkInt;
-//    fn unbox_int(sk_int: *const SkInt) -> i64;
-//}
-
 #[repr(C)]
 #[derive(Debug)]
 pub struct SkInt {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -245,7 +245,7 @@ impl TermTy {
     pub fn erasure(&self) -> ClassFullname {
         match &self.body {
             TyRaw => self.fullname.clone(),
-            TyMeta { base_fullname } => class_fullname(base_fullname),
+            TyMeta { base_fullname } => metaclass_fullname(base_fullname),
             TyClass => class_fullname("Class"),
             TySpe { base_name, .. } => class_fullname(base_name),
             TySpeMeta { base_name, .. } => metaclass_fullname(base_name),

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -365,6 +365,7 @@ pub fn raw(fullname_: impl Into<String>) -> TermTy {
 
 pub fn meta(base_fullname_: impl Into<String>) -> TermTy {
     let base_fullname = base_fullname_.into();
+    debug_assert!(!base_fullname.is_empty());
     debug_assert!(!base_fullname.contains('<'));
     TermTy {
         fullname: metaclass_fullname(&base_fullname),


### PR DESCRIPTION
This PR implements `Object#class` method. 

- To achieve this, objects now have reference to its class object next to the vtable.
- Removed "internal constants"
  - `#<class Void>` is stored in `::Void` and accessible by `Void.class` 
- `Object#==` now provides basic equality check (compare by pointer address)

fix #299 