### PR TITLE
refactor: Wrap inkwell values 

### DIFF
--- a/src/code_gen/boxing.rs
+++ b/src/code_gen/boxing.rs
@@ -1,7 +1,6 @@
 use crate::code_gen::*;
 use crate::names::*;
 use crate::ty;
-use inkwell::values::*;
 
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Generate llvm funcs about boxing
@@ -52,57 +51,57 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let i1_val = function.get_params()[0];
+        let i1_val = SkObj(function.get_params()[0]);
         let sk_bool = self.allocate_sk_obj(&class_fullname("Bool"), "sk_bool");
-        self.build_ivar_store(&sk_bool, 0, i1_val.as_basic_value_enum(), "@llvm_bool");
-        self.builder.build_return(Some(&sk_bool));
+        self.build_ivar_store(&sk_bool, 0, i1_val, "@llvm_bool");
+        self.build_return(&sk_bool);
 
         // unbox_bool
         let function = self.module.get_function("unbox_bool").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_bool = function.get_params()[0];
+        let sk_bool = SkObj(function.get_params()[0]);
         let i1_val = self.build_ivar_load(sk_bool, 0, "@llvm_bool");
-        self.builder.build_return(Some(&i1_val));
+        self.build_return(&i1_val);
 
         // box_int
         let function = self.module.get_function("box_int").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let i64_val = function.get_params()[0];
+        let i64_val = SkObj(function.get_params()[0]);
         let sk_int = self.allocate_sk_obj(&class_fullname("Int"), "sk_int");
-        self.build_ivar_store(&sk_int, 0, i64_val.as_basic_value_enum(), "@llvm_int");
-        self.builder.build_return(Some(&sk_int));
+        self.build_ivar_store(&sk_int, 0, i64_val, "@llvm_int");
+        self.build_return(&sk_int);
 
         // unbox_int
         let function = self.module.get_function("unbox_int").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_int = function.get_params()[0];
+        let sk_int = SkObj(function.get_params()[0]);
         let i64_val = self.build_ivar_load(sk_int, 0, "@llvm_int");
-        self.builder.build_return(Some(&i64_val));
+        self.build_return(&i64_val);
 
         // box_float
         let function = self.module.get_function("box_float").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let f64_val = function.get_params()[0];
+        let f64_val = SkObj(function.get_params()[0]);
         let sk_float = self.allocate_sk_obj(&class_fullname("Float"), "sk_float");
-        self.build_ivar_store(&sk_float, 0, f64_val.as_basic_value_enum(), "@llvm_float");
-        self.builder.build_return(Some(&sk_float));
+        self.build_ivar_store(&sk_float, 0, f64_val, "@llvm_float");
+        self.build_return(&sk_float);
 
         // unbox_float
         let function = self.module.get_function("unbox_float").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_float = function.get_params()[0];
+        let sk_float = SkObj(function.get_params()[0]);
         let f64_val = self.build_ivar_load(sk_float, 0, "@llvm_float");
-        self.builder.build_return(Some(&f64_val));
+        self.build_return(&f64_val);
 
         // box_i8ptr
         let function = self.module.get_function("box_i8ptr").unwrap();
@@ -111,17 +110,17 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i8ptr = function.get_params()[0];
         let sk_ptr = self.allocate_sk_obj(&class_fullname("Shiika::Internal::Ptr"), "sk_ptr");
-        self.build_ivar_store(&sk_ptr, 0, i8ptr.as_basic_value_enum(), "@llvm_i8ptr");
-        self.builder.build_return(Some(&sk_ptr));
+        self.build_ivar_store_raw(&sk_ptr, 0, i8ptr, "@llvm_i8ptr");
+        self.build_return(&sk_ptr);
 
         // unbox_i8ptr
         let function = self.module.get_function("unbox_i8ptr").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_ptr = function.get_params()[0];
+        let sk_ptr = SkObj(function.get_params()[0]);
         let i8ptr = self.build_ivar_load(sk_ptr, 0, "@llvm_i8ptr");
-        self.builder.build_return(Some(&i8ptr));
+        self.build_return(&i8ptr);
 
         // gen_literal_string
         self.impl_gen_literal_string();
@@ -132,120 +131,57 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let func = self.get_llvm_func("Meta:String#new");
-        let receiver_value = self.gen_const_ref(&toplevel_const("String"));
-        let str_i8ptr = function.get_nth_param(0).unwrap().into_pointer_value();
+        let receiver = self.gen_const_ref(&toplevel_const("String"));
+        let str_i8ptr = I8Ptr(function.get_nth_param(0).unwrap().into_pointer_value());
         let bytesize = function.get_nth_param(1).unwrap().into_int_value();
-        let arg_values = vec![self.box_i8ptr(str_i8ptr), self.box_int(&bytesize)];
-        let sk_str = self.gen_llvm_function_call(func, receiver_value, arg_values);
-        self.builder.build_return(Some(&sk_str));
+        let args = vec![self.box_i8ptr(str_i8ptr), self.box_int(&bytesize)];
+        let sk_str = self.call_method_func("Meta:String#new", receiver, &args, "sk_str");
+        self.build_return(&sk_str);
     }
 
     /// Convert LLVM bool(i1) into Shiika Bool
-    pub fn box_bool(
-        &self,
-        b: inkwell::values::IntValue<'run>,
-    ) -> inkwell::values::BasicValueEnum<'run> {
-        let f = self.module.get_function("box_bool").unwrap();
-        self.builder
-            .build_call(f, &[b.into()], "bool")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
+    pub fn box_bool(&self, b: inkwell::values::IntValue<'ictx>) -> SkObj<'ictx> {
+        SkObj(self.call_llvm_func("box_bool", &[b.into()], "sk_bool"))
     }
 
     /// Convert Shiika Bool into LLVM bool(i1)
-    pub fn unbox_bool(
-        &self,
-        sk_bool: inkwell::values::BasicValueEnum<'run>,
-    ) -> inkwell::values::IntValue<'run> {
-        let f = self.module.get_function("unbox_bool").unwrap();
-        self.builder
-            .build_call(f, &[sk_bool], "b")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
+    pub fn unbox_bool(&self, sk_bool: SkObj<'ictx>) -> inkwell::values::IntValue<'ictx> {
+        self.call_llvm_func("unbox_bool", &[sk_bool.0], "llvm_bool")
             .into_int_value()
     }
 
     /// Convert LLVM int into Shiika Int
-    pub fn box_int(
-        &self,
-        i: &inkwell::values::IntValue<'run>,
-    ) -> inkwell::values::BasicValueEnum<'run> {
-        let f = self.module.get_function("box_int").unwrap();
-        self.builder
-            .build_call(f, &[i.as_basic_value_enum()], "int")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
+    pub fn box_int(&self, i: &inkwell::values::IntValue<'ictx>) -> SkObj<'ictx> {
+        SkObj(self.call_llvm_func("box_int", &[i.as_basic_value_enum()], "sk_int"))
     }
 
     /// Convert Shiika Int into LLVM int
-    pub fn unbox_int(
-        &self,
-        sk_int: inkwell::values::BasicValueEnum<'run>,
-    ) -> inkwell::values::IntValue<'run> {
-        let f = self.module.get_function("unbox_int").unwrap();
-        self.builder
-            .build_call(f, &[sk_int], "i")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
+    pub fn unbox_int(&self, sk_int: SkObj<'ictx>) -> inkwell::values::IntValue<'ictx> {
+        self.call_llvm_func("unbox_int", &[sk_int.0], "llvm_int")
             .into_int_value()
     }
 
     /// Convert LLVM float into Shiika Float
-    pub fn box_float(
-        &self,
-        fl: &inkwell::values::FloatValue<'run>,
-    ) -> inkwell::values::BasicValueEnum<'run> {
-        let f = self.module.get_function("box_float").unwrap();
-        self.builder
-            .build_call(f, &[fl.as_basic_value_enum()], "float")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
+    pub fn box_float(&self, fl: &inkwell::values::FloatValue<'ictx>) -> SkObj<'ictx> {
+        SkObj(self.call_llvm_func("box_float", &[fl.as_basic_value_enum()], "sk_float"))
     }
 
     /// Convert Shiika Float into LLVM float
-    pub fn unbox_float(
-        &self,
-        sk_float: inkwell::values::BasicValueEnum<'run>,
-    ) -> inkwell::values::FloatValue<'run> {
-        let f = self.module.get_function("unbox_float").unwrap();
-        self.builder
-            .build_call(f, &[sk_float], "f")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
+    pub fn unbox_float(&self, sk_float: SkObj<'ictx>) -> inkwell::values::FloatValue<'ictx> {
+        self.call_llvm_func("unbox_float", &[sk_float.0], "llvm_float")
             .into_float_value()
     }
 
     /// Convert LLVM i8* into Shiika::Internal::Ptr
-    pub fn box_i8ptr(
-        &self,
-        p: inkwell::values::PointerValue<'run>,
-    ) -> inkwell::values::BasicValueEnum<'run> {
-        let f = self.module.get_function("box_i8ptr").unwrap();
-        self.builder
-            .build_call(f, &[p.as_basic_value_enum()], "sk_ptr")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
+    pub fn box_i8ptr(&self, p: I8Ptr<'ictx>) -> SkObj<'ictx> {
+        SkObj(self.call_llvm_func("box_i8ptr", &[p.0.into()], "sk_ptr"))
     }
 
     /// Convert Shiika::Internal::Ptr into LLVM i8*
-    pub fn unbox_i8ptr(
-        &self,
-        sk_obj: inkwell::values::BasicValueEnum<'run>,
-    ) -> inkwell::values::PointerValue<'run> {
-        let f = self.module.get_function("unbox_i8ptr").unwrap();
-        self.builder
-            .build_call(f, &[sk_obj], "p")
-            .try_as_basic_value()
-            .left()
-            .unwrap()
-            .into_pointer_value()
+    pub fn unbox_i8ptr(&self, sk_obj: SkObj<'ictx>) -> I8Ptr<'ictx> {
+        I8Ptr(
+            self.call_llvm_func("unbox_i8ptr", &[sk_obj.0], "llvm_ptr")
+                .into_pointer_value(),
+        )
     }
 }

--- a/src/code_gen/boxing.rs
+++ b/src/code_gen/boxing.rs
@@ -140,45 +140,45 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     }
 
     /// Convert LLVM bool(i1) into Shiika Bool
-    pub fn box_bool(&self, b: inkwell::values::IntValue<'ictx>) -> SkObj<'ictx> {
+    pub fn box_bool(&self, b: inkwell::values::IntValue<'run>) -> SkObj<'run> {
         SkObj(self.call_llvm_func("box_bool", &[b.into()], "sk_bool"))
     }
 
     /// Convert Shiika Bool into LLVM bool(i1)
-    pub fn unbox_bool(&self, sk_bool: SkObj<'ictx>) -> inkwell::values::IntValue<'ictx> {
+    pub fn unbox_bool(&self, sk_bool: SkObj<'run>) -> inkwell::values::IntValue<'run> {
         self.call_llvm_func("unbox_bool", &[sk_bool.0], "llvm_bool")
             .into_int_value()
     }
 
     /// Convert LLVM int into Shiika Int
-    pub fn box_int(&self, i: &inkwell::values::IntValue<'ictx>) -> SkObj<'ictx> {
+    pub fn box_int(&self, i: &inkwell::values::IntValue<'run>) -> SkObj<'run> {
         SkObj(self.call_llvm_func("box_int", &[i.as_basic_value_enum()], "sk_int"))
     }
 
     /// Convert Shiika Int into LLVM int
-    pub fn unbox_int(&self, sk_int: SkObj<'ictx>) -> inkwell::values::IntValue<'ictx> {
+    pub fn unbox_int(&self, sk_int: SkObj<'run>) -> inkwell::values::IntValue<'run> {
         self.call_llvm_func("unbox_int", &[sk_int.0], "llvm_int")
             .into_int_value()
     }
 
     /// Convert LLVM float into Shiika Float
-    pub fn box_float(&self, fl: &inkwell::values::FloatValue<'ictx>) -> SkObj<'ictx> {
+    pub fn box_float(&self, fl: &inkwell::values::FloatValue<'run>) -> SkObj<'run> {
         SkObj(self.call_llvm_func("box_float", &[fl.as_basic_value_enum()], "sk_float"))
     }
 
     /// Convert Shiika Float into LLVM float
-    pub fn unbox_float(&self, sk_float: SkObj<'ictx>) -> inkwell::values::FloatValue<'ictx> {
+    pub fn unbox_float(&self, sk_float: SkObj<'run>) -> inkwell::values::FloatValue<'run> {
         self.call_llvm_func("unbox_float", &[sk_float.0], "llvm_float")
             .into_float_value()
     }
 
     /// Convert LLVM i8* into Shiika::Internal::Ptr
-    pub fn box_i8ptr(&self, p: I8Ptr<'ictx>) -> SkObj<'ictx> {
+    pub fn box_i8ptr(&self, p: I8Ptr<'run>) -> SkObj<'run> {
         SkObj(self.call_llvm_func("box_i8ptr", &[p.0.into()], "sk_ptr"))
     }
 
     /// Convert Shiika::Internal::Ptr into LLVM i8*
-    pub fn unbox_i8ptr(&self, sk_obj: SkObj<'ictx>) -> I8Ptr<'ictx> {
+    pub fn unbox_i8ptr(&self, sk_obj: SkObj<'run>) -> I8Ptr<'run> {
         I8Ptr(
             self.call_llvm_func("unbox_i8ptr", &[sk_obj.0], "llvm_ptr")
                 .into_pointer_value(),

--- a/src/code_gen/boxing.rs
+++ b/src/code_gen/boxing.rs
@@ -132,7 +132,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let receiver = self.gen_const_ref(&toplevel_const("String"));
-        let str_i8ptr = I8Ptr(function.get_nth_param(0).unwrap().into_pointer_value());
+        let str_i8ptr = function.get_nth_param(0).unwrap();
         let bytesize = function.get_nth_param(1).unwrap().into_int_value();
         let args = vec![self.box_i8ptr(str_i8ptr), self.box_int(&bytesize)];
         let sk_str = self.call_method_func("Meta:String#new", receiver, &args, "sk_str");
@@ -173,8 +173,8 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     }
 
     /// Convert LLVM i8* into Shiika::Internal::Ptr
-    pub fn box_i8ptr(&self, p: I8Ptr<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func("box_i8ptr", &[p.0.into()], "sk_ptr"))
+    pub fn box_i8ptr(&self, p: inkwell::values::BasicValueEnum<'run>) -> SkObj<'run> {
+        SkObj(self.call_llvm_func("box_i8ptr", &[p], "sk_ptr"))
     }
 
     /// Convert Shiika::Internal::Ptr into LLVM i8*

--- a/src/code_gen/code_gen_context.rs
+++ b/src/code_gen/code_gen_context.rs
@@ -1,3 +1,4 @@
+use crate::code_gen::values::SkObj;
 use crate::hir::*;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -18,10 +19,7 @@ pub struct CodeGenContext<'hir: 'run, 'run> {
     /// End of the current llvm function. Only used for lambdas
     pub current_func_end: Rc<inkwell::basic_block::BasicBlock<'run>>,
     /// Arguments of `return` found in this context
-    pub returns: Vec<(
-        inkwell::values::BasicValueEnum<'run>,
-        inkwell::basic_block::BasicBlock<'run>,
-    )>,
+    pub returns: Vec<(SkObj<'run>, inkwell::basic_block::BasicBlock<'run>)>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -611,7 +611,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .as_global_value()
             .as_basic_value_enum();
         let fnptr_i8 = self.builder.build_bitcast(fnptr, self.i8ptr_type, "");
-        let sk_ptr = self.box_i8ptr(I8Ptr(fnptr_i8.into_pointer_value()));
+        let sk_ptr = self.box_i8ptr(fnptr_i8);
         let the_self = self.gen_self_expression(ctx, &ty::raw("Object"));
         let arg_values = vec![sk_ptr, the_self, self._gen_lambda_captures(ctx, captures)];
         self.gen_llvm_func_call(&format!("Meta:{}#new", cls_name), meta, arg_values)

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -3,8 +3,10 @@ mod code_gen_context;
 mod gen_exprs;
 mod lambda;
 mod utils;
+pub mod values;
 use crate::code_gen::code_gen_context::*;
 use crate::code_gen::utils::llvm_vtable_const_name;
+use crate::code_gen::values::*;
 use crate::error::Error;
 use crate::hir::*;
 use crate::library::LibraryExports;
@@ -45,7 +47,7 @@ pub struct CodeGen<'hir: 'ictx, 'run, 'ictx: 'run> {
     vtables: &'hir mir::VTables,
     imported_vtables: &'hir mir::VTables,
     /// Toplevel `self`
-    the_main: Option<inkwell::values::BasicValueEnum<'ictx>>,
+    the_main: Option<SkObj<'ictx>>,
 }
 
 /// Compile hir and dump it to `outpath`
@@ -450,10 +452,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             let name = &fullname.0;
             let global = self.module.add_global(self.llvm_type(ty), None, name);
             let null = self.i32_type.ptr_type(AddressSpace::Generic).const_null();
-            match self.llvm_zero_value(ty) {
-                Some(zero) => global.set_initializer(&zero),
-                None => global.set_initializer(&null),
-            }
+            global.set_initializer(&null);
         }
     }
 
@@ -673,12 +672,12 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             let mut incomings = ctx
                 .returns
                 .iter()
-                .map(|(v, b)| (v as &dyn inkwell::values::BasicValue, *b))
+                .map(|(v, b)| (&v.0 as &dyn inkwell::values::BasicValue, *b))
                 .collect::<Vec<_>>();
             let v;
             if let Some(b) = last_value_block {
                 v = last_value.unwrap();
-                incomings.push((&v, b));
+                incomings.push((&v.0, b));
             }
             let phi_node = self
                 .builder
@@ -702,7 +701,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
     /// Generate body of `.new`
     pub fn gen_body_of_new(
         &self,
-        params: Vec<inkwell::values::BasicValueEnum>,
+        llvm_func_args: Vec<inkwell::values::BasicValueEnum>,
         class_fullname: &ClassFullname,
         initialize_name: &MethodFullname,
         init_cls_name: &ClassFullname,
@@ -715,7 +714,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         let obj = if const_is_obj {
             // Normally class object can be retrieved via constants,
             // but there is no such constant if `const_is_obj` is true.
-            let class_obj = params[0];
+            let class_obj = SkClassObj(llvm_func_args[0]);
             self._allocate_sk_obj(class_fullname, "addr", class_obj)
         } else {
             self.allocate_sk_obj(class_fullname, "addr")
@@ -733,14 +732,17 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 .get(init_cls_name)
                 .expect("ances_type not found")
                 .ptr_type(inkwell::AddressSpace::Generic);
-            addr = self.builder.build_bitcast(addr, ances_type, "obj_as_super");
+            addr = SkObj(
+                self.builder
+                    .build_bitcast(addr.0, ances_type, "obj_as_super"),
+            );
         }
         let args = (0..=arity)
-            .map(|i| if i == 0 { addr } else { params[i] })
+            .map(|i| if i == 0 { addr.0 } else { llvm_func_args[i] })
             .collect::<Vec<_>>();
         self.builder.build_call(initialize, &args, "");
 
-        self.builder.build_return(Some(&obj));
+        self.build_return(&obj);
     }
 
     /// Create a CodeGenContext

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -25,11 +25,13 @@ use std::rc::Rc;
 
 /// CodeGen
 ///
-/// 'hir > 'ictx >= 'run
+/// 'hir > 'ictx > 'run
 ///
 /// 'hir: the Hir
 /// 'ictx: inkwell context
-/// 'run: code_gen::run()
+/// 'run: code_gen::run() after 'ictx is created
+///
+/// Basically inkwell types has 'ictx and inkwell values has 'run.
 pub struct CodeGen<'hir: 'ictx, 'run, 'ictx: 'run> {
     pub generate_main: bool,
     pub context: &'ictx inkwell::context::Context,
@@ -47,7 +49,7 @@ pub struct CodeGen<'hir: 'ictx, 'run, 'ictx: 'run> {
     vtables: &'hir mir::VTables,
     imported_vtables: &'hir mir::VTables,
     /// Toplevel `self`
-    the_main: Option<SkObj<'ictx>>,
+    the_main: Option<SkObj<'run>>,
 }
 
 /// Compile hir and dump it to `outpath`
@@ -725,7 +727,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             .module
             .get_function(&initialize_name.full_name)
             .unwrap_or_else(|| panic!("[BUG] function `{}' not found", &initialize_name));
-        let mut addr = obj;
+        let mut addr = obj.clone();
         if need_bitcast {
             let ances_type = self
                 .llvm_struct_types

--- a/src/code_gen/utils.rs
+++ b/src/code_gen/utils.rs
@@ -223,7 +223,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         SkObj(self.call_llvm_func(func_name, &llvm_args, reg_name))
     }
 
-    /// Call llvm function
+    /// Call llvm function (whose return type is not `void`)
     pub fn call_llvm_func(
         &self,
         func_name: &str,
@@ -236,6 +236,16 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .try_as_basic_value()
             .left()
             .unwrap()
+    }
+
+    /// Call llvm function whose return type is `void`
+    pub fn call_llvm_void_func(
+        &self,
+        func_name: &str,
+        args: &[inkwell::values::BasicValueEnum<'run>],
+    ) {
+        let f = self.module.get_function(func_name).unwrap();
+        self.builder.build_call(f, args, "");
     }
 
     /// Get nth parameter of llvm func as SkObj

--- a/src/code_gen/values.rs
+++ b/src/code_gen/values.rs
@@ -1,0 +1,22 @@
+/// Shiika object (eg. `Int*`, `String*`)
+#[derive(Debug)]
+pub struct SkObj<'ictx>(pub inkwell::values::BasicValueEnum<'ictx>);
+
+/// Shiika class object (eg. `Meta:Int*`, `Meta:String*`)
+#[derive(Debug)]
+pub struct SkClassObj<'ictx>(pub inkwell::values::BasicValueEnum<'ictx>);
+
+impl<'ictx> SkClassObj<'ictx> {
+    /// A class object is a Shiika object.
+    pub fn as_sk_obj(self) -> SkObj<'ictx> {
+        SkObj(self.0)
+    }
+}
+
+/// Reference to vtable (eg. `shiika_vtable_Int`)
+#[derive(Debug)]
+pub struct VTableRef<'ictx>(pub inkwell::values::BasicValueEnum<'ictx>);
+
+/// i8*
+#[derive(Debug)]
+pub struct I8Ptr<'ictx>(pub inkwell::values::PointerValue<'ictx>);

--- a/src/code_gen/values.rs
+++ b/src/code_gen/values.rs
@@ -1,22 +1,22 @@
 /// Shiika object (eg. `Int*`, `String*`)
-#[derive(Debug)]
-pub struct SkObj<'ictx>(pub inkwell::values::BasicValueEnum<'ictx>);
+#[derive(Clone, Debug)]
+pub struct SkObj<'run>(pub inkwell::values::BasicValueEnum<'run>);
 
 /// Shiika class object (eg. `Meta:Int*`, `Meta:String*`)
 #[derive(Debug)]
-pub struct SkClassObj<'ictx>(pub inkwell::values::BasicValueEnum<'ictx>);
+pub struct SkClassObj<'run>(pub inkwell::values::BasicValueEnum<'run>);
 
-impl<'ictx> SkClassObj<'ictx> {
+impl<'run> SkClassObj<'run> {
     /// A class object is a Shiika object.
-    pub fn as_sk_obj(self) -> SkObj<'ictx> {
+    pub fn as_sk_obj(self) -> SkObj<'run> {
         SkObj(self.0)
     }
 }
 
 /// Reference to vtable (eg. `shiika_vtable_Int`)
 #[derive(Debug)]
-pub struct VTableRef<'ictx>(pub inkwell::values::BasicValueEnum<'ictx>);
+pub struct VTableRef<'run>(pub inkwell::values::BasicValueEnum<'run>);
 
 /// i8*
 #[derive(Debug)]
-pub struct I8Ptr<'ictx>(pub inkwell::values::PointerValue<'ictx>);
+pub struct I8Ptr<'run>(pub inkwell::values::PointerValue<'run>);

--- a/src/corelib/array.rs
+++ b/src/corelib/array.rs
@@ -10,14 +10,14 @@ pub fn create_methods() -> Vec<SkMethod> {
         "Array",
         "_corelib_array_get(ptr: Shiika::Internal::Ptr) -> T",
         |code_gen, function| {
-            let sk_ptr = function.get_params()[1];
+            let sk_ptr = code_gen.get_nth_param(function, 1);
             let i8ptr = code_gen.unbox_i8ptr(sk_ptr);
             // Object = T's upper bound
             let obj_ptr_type = code_gen.llvm_type(&ty::raw("Object")).into_pointer_type();
             let obj_ptrptr_type = obj_ptr_type.ptr_type(inkwell::AddressSpace::Generic);
             let obj_ptr = code_gen
                 .builder
-                .build_bitcast(i8ptr, obj_ptrptr_type, "")
+                .build_bitcast(i8ptr.0, obj_ptrptr_type, "")
                 .into_pointer_value();
             let loaded = code_gen.builder.build_load(obj_ptr, "element");
             code_gen.builder.build_return(Some(&loaded));

--- a/src/corelib/float.rs
+++ b/src/corelib/float.rs
@@ -9,14 +9,14 @@ macro_rules! create_comparison_method {
             "Float",
             format!("{}(other: Float) -> Bool", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
+                let this = code_gen.get_nth_param(function, 0);
                 let val1 = code_gen.unbox_float(this);
-                let that = function.get_params()[1];
+                let that = code_gen.get_nth_param(function, 1);
                 let val2 = code_gen.unbox_float(that);
                 $body
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_bool(result);
-                code_gen.builder.build_return(Some(&sk_result));
+                code_gen.build_return(&sk_result);
                 Ok(())
             },
         )
@@ -29,14 +29,14 @@ macro_rules! create_arithmetic_method {
             "Float",
             format!("{}(other: Float) -> Float", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
+                let this = code_gen.get_nth_param(function, 0);
                 let val1 = code_gen.unbox_float(this);
-                let that = function.get_params()[1];
+                let that = code_gen.get_nth_param(function, 1);
                 let val2 = code_gen.unbox_float(that);
                 $body
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_float(&result);
-                code_gen.builder.build_return(Some(&sk_result));
+                code_gen.build_return(&sk_result);
                 Ok(())
             },
         )
@@ -167,7 +167,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             }
         ),
         create_method("Float", "abs -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
+            let this = code_gen.get_nth_param(function, 0);
             let x = code_gen.unbox_float(this);
             let func = code_gen.module.get_function("fabs").unwrap();
             let result = code_gen
@@ -177,11 +177,11 @@ pub fn create_methods() -> Vec<SkMethod> {
                 .left()
                 .unwrap();
             let sk_result = code_gen.box_float(&result.into_float_value());
-            code_gen.builder.build_return(Some(&sk_result));
+            code_gen.build_return(&sk_result);
             Ok(())
         }),
         create_method("Float", "floor -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
+            let this = code_gen.get_nth_param(function, 0);
             let x = code_gen.unbox_float(this);
             let func = code_gen.module.get_function("floor").unwrap();
             let result = code_gen
@@ -191,26 +191,26 @@ pub fn create_methods() -> Vec<SkMethod> {
                 .left()
                 .unwrap();
             let sk_result = code_gen.box_float(&result.into_float_value());
-            code_gen.builder.build_return(Some(&sk_result));
+            code_gen.build_return(&sk_result);
             Ok(())
         }),
         create_method("Float", "to_i() -> Int", |code_gen, function| {
-            let this = function.get_params()[0];
+            let this = code_gen.get_nth_param(function, 0);
             let float = code_gen.unbox_float(this);
             let int = code_gen
                 .builder
                 .build_float_to_signed_int(float, code_gen.i64_type, "int");
-            let sk_int = code_gen.box_int(&int);
-            code_gen.builder.build_return(Some(&sk_int));
+            let sk_result = code_gen.box_int(&int);
+            code_gen.build_return(&sk_result);
             Ok(())
         }),
         create_method("Float", "-@ -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
+            let this = code_gen.get_nth_param(function, 0);
             let float = code_gen.unbox_float(this);
             let zero = code_gen.f64_type.const_float(0.0);
             let result = code_gen.builder.build_float_sub(zero, float, "result");
             let sk_result = code_gen.box_float(&result);
-            code_gen.builder.build_return(Some(&sk_result));
+            code_gen.build_return(&sk_result);
             Ok(())
         }),
     ]

--- a/src/corelib/int.rs
+++ b/src/corelib/int.rs
@@ -9,14 +9,14 @@ macro_rules! create_comparison_method {
             "Int",
             format!("{}(other: Int) -> Bool", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
+                let this = code_gen.get_nth_param(function, 0);
                 let val1 = code_gen.unbox_int(this);
-                let that = function.get_params()[1];
+                let that = code_gen.get_nth_param(function, 1);
                 let val2 = code_gen.unbox_int(that);
                 $body
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_bool(result);
-                code_gen.builder.build_return(Some(&sk_result));
+                code_gen.build_return(&sk_result);
                 Ok(())
             },
         )
@@ -29,14 +29,14 @@ macro_rules! create_arithmetic_method {
             "Int",
             format!("{}(other: Int) -> Int", $operator).as_str(),
             |code_gen, function| {
-                let this = function.get_params()[0];
+                let this = code_gen.get_nth_param(function, 0);
                 let val1 = code_gen.unbox_int(this);
-                let that = function.get_params()[1];
+                let that = code_gen.get_nth_param(function, 1);
                 let val2 = code_gen.unbox_int(that);
                 $body
                 let result = f(code_gen, val1, val2);
                 let sk_result = code_gen.box_int(&result);
-                code_gen.builder.build_return(Some(&sk_result));
+                code_gen.build_return(&sk_result);
                 Ok(())
             },
         )
@@ -220,7 +220,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             }
         ),
         create_method("Int", "to_f() -> Float", |code_gen, function| {
-            let this = function.get_params()[0];
+            let this = code_gen.get_nth_param(function, 0);
             let int = code_gen.unbox_int(this);
             let float = code_gen
                 .builder
@@ -230,10 +230,10 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Int", "-@ -> Int", |code_gen, function| {
-            let sk_int = function.get_params()[0];
-            let this = code_gen.unbox_int(sk_int);
+            let this = code_gen.get_nth_param(function, 0);
+            let i = code_gen.unbox_int(this);
             let zero = code_gen.i64_type.const_int(0, false);
-            let result = code_gen.builder.build_int_sub(zero, this, "result");
+            let result = code_gen.builder.build_int_sub(zero, i, "result");
             let sk_result = code_gen.box_int(&result);
             code_gen.builder.build_return(Some(&sk_result));
             Ok(())

--- a/src/corelib/int.rs
+++ b/src/corelib/int.rs
@@ -226,7 +226,7 @@ pub fn create_methods() -> Vec<SkMethod> {
                 .builder
                 .build_signed_int_to_float(int, code_gen.f64_type, "float");
             let sk_result = code_gen.box_float(&float);
-            code_gen.builder.build_return(Some(&sk_result));
+            code_gen.build_return(&sk_result);
             Ok(())
         }),
         create_method("Int", "-@ -> Int", |code_gen, function| {
@@ -235,7 +235,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             let zero = code_gen.i64_type.const_int(0, false);
             let result = code_gen.builder.build_int_sub(zero, i, "result");
             let sk_result = code_gen.box_int(&result);
-            code_gen.builder.build_return(Some(&sk_result));
+            code_gen.build_return(&sk_result);
             Ok(())
         }),
     ]

--- a/src/corelib/math.rs
+++ b/src/corelib/math.rs
@@ -7,8 +7,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Math",
             "sin(x: Float) -> Float",
             |code_gen, function| {
-                let arg = function.get_params()[1];
-                let x = code_gen.unbox_float(arg);
+                let x = code_gen.unbox_float(code_gen.get_nth_param(function, 1));
                 let func = code_gen.module.get_function("sin").unwrap();
                 let result = code_gen
                     .builder
@@ -17,7 +16,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                     .left()
                     .unwrap();
                 let sk_result = code_gen.box_float(&result.into_float_value());
-                code_gen.builder.build_return(Some(&sk_result));
+                code_gen.build_return(&sk_result);
                 Ok(())
             },
         ),
@@ -25,8 +24,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Math",
             "cos(x: Float) -> Float",
             |code_gen, function| {
-                let arg = function.get_params()[1];
-                let x = code_gen.unbox_float(arg);
+                let x = code_gen.unbox_float(code_gen.get_nth_param(function, 1));
                 let func = code_gen.module.get_function("cos").unwrap();
                 let result = code_gen
                     .builder
@@ -35,7 +33,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                     .left()
                     .unwrap();
                 let sk_result = code_gen.box_float(&result.into_float_value());
-                code_gen.builder.build_return(Some(&sk_result));
+                code_gen.build_return(&sk_result);
                 Ok(())
             },
         ),
@@ -43,8 +41,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
             "Meta:Math",
             "sqrt(x: Float) -> Float",
             |code_gen, function| {
-                let arg = function.get_params()[1];
-                let x = code_gen.unbox_float(arg);
+                let x = code_gen.unbox_float(code_gen.get_nth_param(function, 1));
                 let func = code_gen.module.get_function("sqrt").unwrap();
                 let result = code_gen
                     .builder
@@ -53,7 +50,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                     .left()
                     .unwrap();
                 let sk_result = code_gen.box_float(&result.into_float_value());
-                code_gen.builder.build_return(Some(&sk_result));
+                code_gen.build_return(&sk_result);
                 Ok(())
             },
         ),

--- a/src/corelib/object.rs
+++ b/src/corelib/object.rs
@@ -24,9 +24,7 @@ pub fn create_methods() -> Vec<SkMethod> {
                     other,
                     "eq",
                 );
-                code_gen
-                    .builder
-                    .build_return(Some(&code_gen.box_bool(result)));
+                code_gen.build_return(&code_gen.box_bool(result));
                 Ok(())
             },
         ),
@@ -35,14 +33,13 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Object", "class() -> Class", |code_gen, function| {
-            let receiver = function.get_nth_param(0).unwrap();
+            let receiver = code_gen.get_nth_param(function, 0);
             let cls_obj = code_gen.get_class_of_obj(receiver);
-            code_gen.builder.build_return(Some(&cls_obj));
+            code_gen.build_return(&cls_obj.as_sk_obj());
             Ok(())
         }),
         create_method("Object", "putd(n: Int) -> Void", |code_gen, function| {
-            let sk_int = function.get_params()[1];
-            let n = code_gen.unbox_int(sk_int);
+            let n = code_gen.unbox_int(code_gen.get_nth_param(function, 1));
             let printf = code_gen.module.get_function("printf").unwrap();
             let tmpl = code_gen
                 .module
@@ -62,8 +59,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             Ok(())
         }),
         create_method("Object", "putf(n: Float) -> Void", |code_gen, function| {
-            let arg = function.get_params()[1];
-            let n = code_gen.unbox_float(arg);
+            let n = code_gen.unbox_float(code_gen.get_nth_param(function, 1));
             let printf = code_gen.module.get_function("printf").unwrap();
             let tmpl = code_gen
                 .module
@@ -96,8 +92,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             "Object",
             "exit(status: Int) -> Never",
             |code_gen, function| {
-                let sk_int = function.get_params()[1];
-                let int64 = code_gen.unbox_int(sk_int);
+                let int64 = code_gen.unbox_int(code_gen.get_nth_param(function, 1));
                 let int32 = code_gen
                     .builder
                     .build_int_truncate(int64, code_gen.i32_type, "int32");

--- a/src/corelib/shiika_internal_memory.rs
+++ b/src/corelib/shiika_internal_memory.rs
@@ -30,7 +30,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                         .builder
                         .build_int_z_extend(n_bytes, code_gen.i64_type, "n_bytes_64");
                 let mem = code_gen.call_llvm_func(
-                    "shiika_malloc",
+                    "shiika_realloc",
                     &[ptr.0.into(), n_bytes_64.into()],
                     "mem",
                 );

--- a/src/corelib/shiika_internal_memory.rs
+++ b/src/corelib/shiika_internal_memory.rs
@@ -13,7 +13,6 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                     code_gen
                         .builder
                         .build_int_z_extend(n_bytes, code_gen.i64_type, "n_bytes_64");
-                let func = code_gen.module.get_function("shiika_malloc").unwrap();
                 let mem = code_gen.call_llvm_func("shiika_malloc", &[n_bytes_64.into()], "mem");
                 let skptr = code_gen.box_i8ptr(I8Ptr(mem.into_pointer_value()));
                 code_gen.build_return(&skptr);

--- a/src/corelib/shiika_internal_memory.rs
+++ b/src/corelib/shiika_internal_memory.rs
@@ -1,4 +1,3 @@
-use crate::code_gen::values::I8Ptr;
 use crate::corelib::create_method;
 use crate::hir::*;
 
@@ -14,7 +13,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                         .builder
                         .build_int_z_extend(n_bytes, code_gen.i64_type, "n_bytes_64");
                 let mem = code_gen.call_llvm_func("shiika_malloc", &[n_bytes_64.into()], "mem");
-                let skptr = code_gen.box_i8ptr(I8Ptr(mem.into_pointer_value()));
+                let skptr = code_gen.box_i8ptr(mem);
                 code_gen.build_return(&skptr);
                 Ok(())
             },
@@ -34,7 +33,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                     &[ptr.0.into(), n_bytes_64.into()],
                     "mem",
                 );
-                let skptr = code_gen.box_i8ptr(I8Ptr(mem.into_pointer_value()));
+                let skptr = code_gen.box_i8ptr(mem);
                 code_gen.build_return(&skptr);
                 Ok(())
             },

--- a/src/corelib/shiika_internal_memory.rs
+++ b/src/corelib/shiika_internal_memory.rs
@@ -50,7 +50,7 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                     code_gen
                         .builder
                         .build_int_z_extend(n_bytes, code_gen.i64_type, "n_bytes_64");
-                code_gen.call_llvm_func(
+                code_gen.call_llvm_void_func(
                     "llvm.memcpy.p0i8.p0i8.i64",
                     &[
                         dst.0.into(),
@@ -59,7 +59,6 @@ pub fn create_class_methods() -> Vec<SkMethod> {
                         code_gen.i32_type.const_int(0, false).into(),
                         code_gen.i1_type.const_int(0, false).into(),
                     ],
-                    "mem",
                 );
                 code_gen.build_return_void();
                 Ok(())

--- a/src/corelib/shiika_internal_ptr.rs
+++ b/src/corelib/shiika_internal_ptr.rs
@@ -1,3 +1,4 @@
+use crate::code_gen::values::I8Ptr;
 use crate::corelib::create_method;
 use crate::hir::*;
 use crate::ty;
@@ -8,12 +9,11 @@ pub fn create_methods() -> Vec<SkMethod> {
             "Shiika::Internal::Ptr",
             "+(n_bytes: Int) -> Shiika::Internal::Ptr",
             |code_gen, function| {
-                let ptr = code_gen.unbox_i8ptr(function.get_params()[0]);
-                let sk_int = function.get_params()[1];
-                let n_bytes = code_gen.unbox_int(sk_int);
-                let newptr = unsafe { code_gen.builder.build_gep(ptr, &[n_bytes], "newptr") };
-                let skptr = code_gen.box_i8ptr(newptr);
-                code_gen.builder.build_return(Some(&skptr));
+                let ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
+                let n_bytes = code_gen.unbox_int(code_gen.get_nth_param(function, 1));
+                let newptr = unsafe { code_gen.builder.build_gep(ptr.0, &[n_bytes], "newptr") };
+                let skptr = code_gen.box_i8ptr(I8Ptr(newptr));
+                code_gen.build_return(&skptr);
                 Ok(())
             },
         ),
@@ -21,12 +21,12 @@ pub fn create_methods() -> Vec<SkMethod> {
             "Shiika::Internal::Ptr",
             "store(value: Object)",
             |code_gen, function| {
-                let i8ptr = code_gen.unbox_i8ptr(function.get_params()[0]);
+                let i8ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
                 let obj_ptr_type = code_gen.llvm_type(&ty::raw("Object")).into_pointer_type();
                 let obj_ptrptr_type = obj_ptr_type.ptr_type(inkwell::AddressSpace::Generic);
                 let obj_ptr = code_gen
                     .builder
-                    .build_bitcast(i8ptr, obj_ptrptr_type, "")
+                    .build_bitcast(i8ptr.0, obj_ptrptr_type, "")
                     .into_pointer_value();
                 let sk_obj = function.get_params()[1];
                 code_gen.builder.build_store(obj_ptr, sk_obj);
@@ -38,12 +38,12 @@ pub fn create_methods() -> Vec<SkMethod> {
             "Shiika::Internal::Ptr",
             "load -> Object",
             |code_gen, function| {
-                let i8ptr = code_gen.unbox_i8ptr(function.get_params()[0]);
+                let i8ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
                 let obj_ptr_type = code_gen.llvm_type(&ty::raw("Object")).into_pointer_type();
                 let obj_ptrptr_type = obj_ptr_type.ptr_type(inkwell::AddressSpace::Generic);
                 let obj_ptr = code_gen
                     .builder
-                    .build_bitcast(i8ptr, obj_ptrptr_type, "")
+                    .build_bitcast(i8ptr.0, obj_ptrptr_type, "")
                     .into_pointer_value();
                 let loaded = code_gen.builder.build_load(obj_ptr, "object");
                 code_gen.builder.build_return(Some(&loaded));
@@ -54,14 +54,17 @@ pub fn create_methods() -> Vec<SkMethod> {
             "Shiika::Internal::Ptr",
             "read -> Int",
             |code_gen, function| {
-                let i8ptr = code_gen.unbox_i8ptr(function.get_params()[0]);
-                let i8val = code_gen.builder.build_load(i8ptr, "i8val").into_int_value();
+                let i8ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
+                let i8val = code_gen
+                    .builder
+                    .build_load(i8ptr.0, "i8val")
+                    .into_int_value();
                 let i64val =
                     code_gen
                         .builder
                         .build_int_z_extend(i8val, code_gen.i64_type, "i64val");
                 let sk_int = code_gen.box_int(&i64val);
-                code_gen.builder.build_return(Some(&sk_int));
+                code_gen.build_return(&sk_int);
                 Ok(())
             },
         ),
@@ -69,13 +72,13 @@ pub fn create_methods() -> Vec<SkMethod> {
             "Shiika::Internal::Ptr",
             "write(byte: Int)",
             |code_gen, function| {
-                let i8ptr = code_gen.unbox_i8ptr(function.get_params()[0]);
-                let i64val = code_gen.unbox_int(function.get_params()[1]);
+                let i8ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
+                let i64val = code_gen.unbox_int(code_gen.get_nth_param(function, 1));
                 let i8val = code_gen
                     .builder
                     .build_int_truncate(i64val, code_gen.i8_type, "i8val");
 
-                code_gen.builder.build_store(i8ptr, i8val);
+                code_gen.builder.build_store(i8ptr.0, i8val);
                 code_gen.build_return_void();
                 Ok(())
             },

--- a/src/corelib/shiika_internal_ptr.rs
+++ b/src/corelib/shiika_internal_ptr.rs
@@ -1,4 +1,3 @@
-use crate::code_gen::values::I8Ptr;
 use crate::corelib::create_method;
 use crate::hir::*;
 use crate::ty;
@@ -12,7 +11,7 @@ pub fn create_methods() -> Vec<SkMethod> {
                 let ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
                 let n_bytes = code_gen.unbox_int(code_gen.get_nth_param(function, 1));
                 let newptr = unsafe { code_gen.builder.build_gep(ptr.0, &[n_bytes], "newptr") };
-                let skptr = code_gen.box_i8ptr(I8Ptr(newptr));
+                let skptr = code_gen.box_i8ptr(newptr.into());
                 code_gen.build_return(&skptr);
                 Ok(())
             },

--- a/src/hir/accessors.rs
+++ b/src/hir/accessors.rs
@@ -83,6 +83,7 @@ fn create_setter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
         let this = code_gen.get_nth_param(function, 0);
         let val = code_gen.get_nth_param(function, 1);
         code_gen.build_ivar_store(&this, idx, val, &ivar_name);
+        let val = code_gen.get_nth_param(function, 1);
         code_gen.build_return(&val);
         Ok(())
     };

--- a/src/hir/accessors.rs
+++ b/src/hir/accessors.rs
@@ -50,9 +50,9 @@ fn create_getter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
     let name = ivar.name.clone(); // Clone to embed into the closure
     let idx = ivar.idx;
     let getter_body = move |code_gen: &CodeGen, function: &inkwell::values::FunctionValue| {
-        let this = function.get_params()[0];
+        let this = code_gen.get_nth_param(function, 0);
         let val = code_gen.build_ivar_load(this, idx, &name);
-        code_gen.builder.build_return(Some(&val));
+        code_gen.build_return(&val);
         Ok(())
     };
 
@@ -80,10 +80,10 @@ fn create_setter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
     let ivar_name = ivar.name.clone(); // Clone to embed into the closure
     let idx = ivar.idx;
     let setter_body = move |code_gen: &CodeGen, function: &inkwell::values::FunctionValue| {
-        let this = function.get_params()[0];
-        let val = function.get_params()[1];
+        let this = code_gen.get_nth_param(function, 0);
+        let val = code_gen.get_nth_param(function, 1);
         code_gen.build_ivar_store(&this, idx, val, &ivar_name);
-        code_gen.builder.build_return(Some(&val));
+        code_gen.build_return(&val);
         Ok(())
     };
 


### PR DESCRIPTION
This PR introduces some wrappers (`SkObj`, `I8Ptr`, etc) that wraps inkwell values to avoid simple mistakes.