### PR TITLE
Re-redesign ctx stack

### DIFF
--- a/src/hir/ctx_stack.rs
+++ b/src/hir/ctx_stack.rs
@@ -1,0 +1,371 @@
+use crate::hir::hir_maker_context::*;
+use crate::hir::MethodParam;
+use crate::names::Namespace;
+use crate::ty;
+use crate::ty::*;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct CtxStack(Vec<HirMakerContext>);
+
+impl CtxStack {
+    /// Create a CtxStack
+    pub fn new(v: Vec<HirMakerContext>) -> CtxStack {
+        CtxStack(v)
+    }
+
+    /// Returns length of stack
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns nth item
+    pub fn get(&self, idx: usize) -> &HirMakerContext {
+        &self.0[idx]
+    }
+
+    /// Push a ctx
+    pub fn push(&mut self, c: HirMakerContext) {
+        self.0.push(c);
+    }
+
+    /// Pop a ctx
+    pub fn pop(&mut self) -> HirMakerContext {
+        self.0.pop().expect("[BUG] no ctx to pop")
+    }
+
+    /// Pop the ToplevelCtx on the stack top
+    pub fn pop_toplevel_ctx(&mut self) -> ToplevelCtx {
+        if let HirMakerContext::Toplevel(toplevel_ctx) = self.pop() {
+            toplevel_ctx
+        } else {
+            panic!("[BUG] top is not ToplevelCtx");
+        }
+    }
+
+    /// Pop the MethodCtx on the stack top
+    pub fn pop_method_ctx(&mut self) -> MethodCtx {
+        if let HirMakerContext::Method(method_ctx) = self.pop() {
+            method_ctx
+        } else {
+            panic!("[BUG] top is not MethodCtx");
+        }
+    }
+
+    /// Pop the MethodCtx on the stack top
+    pub fn pop_lambda_ctx(&mut self) -> LambdaCtx {
+        if let HirMakerContext::Lambda(lambda_ctx) = self.pop() {
+            lambda_ctx
+        } else {
+            panic!("[BUG] top is not LambdaCtx");
+        }
+    }
+
+    /// Returns the ctx on the top of the stack
+    pub fn top(&self) -> &HirMakerContext {
+        // ctx_stack will not be empty because toplevel ctx is always there
+        self.0.last().expect("[BUG] ctx_stack is empty")
+    }
+
+    /// Returns the ctx on the top of the stack
+    pub fn top_mut(&mut self) -> &mut HirMakerContext {
+        // ctx_stack will not be empty because toplevel ctx is always there
+        self.0.last_mut().expect("[BUG] ctx_stack is empty")
+    }
+
+    /// Return nearest enclosing class ctx, if any
+    pub fn class_ctx(&self) -> Option<&ClassCtx> {
+        for x in self.0.iter().rev() {
+            if let HirMakerContext::Class(c) = x {
+                return Some(c);
+            }
+        }
+        None
+    }
+
+    /// Return enclosing method ctx, if any
+    pub fn method_ctx(&self) -> Option<&MethodCtx> {
+        for x in self.0.iter().rev() {
+            if let HirMakerContext::Method(c) = x {
+                return Some(c);
+            }
+        }
+        None
+    }
+
+    /// Return enclosing method ctx, if any
+    pub fn method_ctx_mut(&mut self) -> Option<&mut MethodCtx> {
+        for x in self.0.iter_mut().rev() {
+            if let HirMakerContext::Method(c) = x {
+                return Some(c);
+            }
+        }
+        None
+    }
+
+    /// Return ctx of nearest enclosing lambda, if any
+    pub fn lambda_ctx(&self) -> Option<&LambdaCtx> {
+        for x in self.0.iter().rev() {
+            if let HirMakerContext::Lambda(c) = x {
+                return Some(c);
+            }
+        }
+        None
+    }
+
+    /// Return ctx of nearest enclosing lambda, if any
+    pub fn lambda_ctx_mut(&mut self) -> Option<&mut LambdaCtx> {
+        for x in self.0.iter_mut().rev() {
+            if let HirMakerContext::Lambda(c) = x {
+                return Some(c);
+            }
+        }
+        None
+    }
+
+    /// Returns a debugging string like "toplevel", "Class1", "Class1#method1", etc.
+    pub fn describe_current_place(&self) -> String {
+        if let Some(method_ctx) = self.method_ctx() {
+            method_ctx.signature.fullname.to_string()
+        } else {
+            match self.top() {
+                HirMakerContext::Toplevel(_) => "toplevel".to_string(),
+                HirMakerContext::Class(class_ctx) => class_ctx.namespace.string(),
+                HirMakerContext::Method(method_ctx) => method_ctx.signature.fullname.to_string(),
+                HirMakerContext::Lambda(_) => "lambda".to_string(),
+                HirMakerContext::While(_) => "while".to_string(),
+            }
+        }
+    }
+
+    /// The type of `self` in the current scope
+    pub fn self_ty(&self) -> TermTy {
+        if let Some(class_ctx) = self.class_ctx() {
+            if let Some(_) = self.method_ctx() {
+                ty::raw(&class_ctx.namespace.string())
+            } else {
+                ty::meta(&class_ctx.namespace.string())
+            }
+        } else {
+            // This lambda is on the toplevel
+            ty::raw("Object")
+        }
+    }
+
+    /// Add a local variable to current context
+    pub fn declare_lvar(&mut self, name: &str, ty: TermTy, readonly: bool) {
+        let lvars = self.current_lvars_mut();
+        let k = name.to_string();
+        let v = CtxLVar {
+            name: name.to_string(),
+            ty,
+            readonly,
+        };
+        lvars.insert(k, v);
+    }
+
+    /// Returns if we're in an `#initialize`
+    pub fn in_initializer(&self) -> bool {
+        if let Some(method_ctx) = self.method_ctx() {
+            method_ctx.signature.fullname.first_name.0 == "initialize"
+        } else {
+            false
+        }
+    }
+
+    /// Push a LambdaCapture to captures
+    pub fn push_lambda_capture(&mut self, cap: LambdaCapture) -> usize {
+        let lambda_ctx = self.lambda_ctx_mut().expect("not in lambda");
+        lambda_ctx.captures.push(cap);
+        lambda_ctx.captures.len() - 1
+    }
+
+    /// Returns type parameter of the current class
+    pub fn current_class_typarams(&self) -> Vec<String> {
+        if let Some(class_ctx) = self.class_ctx() {
+            if let Some(method_ctx) = self.method_ctx() {
+                if !method_ctx.signature.fullname.is_class_method() {
+                    return class_ctx.typarams.clone();
+                }
+            }
+        }
+        vec![]
+    }
+
+    /// Returns type parameter of the current method
+    pub fn current_method_typarams(&self) -> Vec<String> {
+        if let Some(method_ctx) = self.method_ctx() {
+            method_ctx.signature.typarams.clone()
+        } else {
+            vec![]
+        }
+    }
+
+    /// If there is a method or class typaram named `name`, returns its type
+    pub fn lookup_typaram(&self, name: &str) -> Option<TermTy> {
+        if let Some(method_ctx) = self.method_ctx() {
+            let typarams = &method_ctx.signature.typarams;
+            if let Some(i) = typarams.iter().position(|s| *name == *s) {
+                return Some(ty::typaram(name, ty::TyParamKind::Method, i));
+            }
+            if let Some(class_ctx) = self.class_ctx() {
+                if method_ctx.signature.fullname.is_class_method() {
+                    return None;
+                }
+                let typarams = &class_ctx.typarams;
+                if let Some(i) = typarams.iter().position(|s| *name == *s) {
+                    return Some(ty::typaram(name, ty::TyParamKind::Class, i));
+                }
+            }
+        }
+        // No typarams are accessible outside methods
+        None
+    }
+
+    /// Iterates over lvar scopes starting from the current scope
+    pub fn lvar_scopes(&self) -> LVarIter {
+        LVarIter::new(self)
+    }
+
+    pub fn current_lvars_mut(&mut self) -> &mut CtxLVars {
+        for ctx in self.0.iter_mut().rev() {
+            if let Some(lvars) = ctx.opt_lvars() {
+                return lvars;
+            }
+        }
+        panic!("[BUG] current lvars not found")
+    }
+
+    /// Iterates over constant scopes starting from the current one
+    pub fn const_scopes(&self) -> NamespaceIter {
+        NamespaceIter::new(self)
+    }
+}
+
+/// Iterates over each lvar scope.
+pub struct LVarIter<'hir_maker> {
+    ctx_stack: &'hir_maker CtxStack,
+    cur: usize,
+    finished: bool,
+}
+
+impl<'hir_maker> LVarIter<'hir_maker> {
+    fn new(ctx_stack: &CtxStack) -> LVarIter {
+        let mut finished = false;
+        let mut cur = ctx_stack.len();
+        loop {
+            if cur == 0 {
+                finished = true;
+                break;
+            }
+            cur -= 1;
+            match ctx_stack.get(cur) {
+                HirMakerContext::Toplevel(_)
+                | HirMakerContext::Class(_)
+                | HirMakerContext::Method(_)
+                | HirMakerContext::Lambda(_) => break,
+                // Does not make lvar scope
+                HirMakerContext::While(_) => (),
+            }
+        }
+        LVarIter {
+            ctx_stack,
+            cur,
+            finished,
+        }
+    }
+}
+
+impl<'a> Iterator for LVarIter<'a> {
+    /// Yields `(lvars, params, depth)`
+    type Item = (&'a HashMap<String, CtxLVar>, &'a [MethodParam], isize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+        match self.ctx_stack.get(self.cur) {
+            // Toplevel -> end.
+            HirMakerContext::Toplevel(toplevel_ctx) => {
+                self.finished = true;
+                Some((&toplevel_ctx.lvars, &[], -1))
+            }
+            // Classes -> end.
+            HirMakerContext::Class(class_ctx) => {
+                self.finished = true;
+                Some((&class_ctx.lvars, &[], -1))
+            }
+            // Method -> end.
+            HirMakerContext::Method(method_ctx) => {
+                self.finished = true;
+                Some((&method_ctx.lvars, &method_ctx.signature.params, -1))
+            }
+            // Lambdas -> (Method or Class or Toplevel)
+            HirMakerContext::Lambda(lambda_ctx) => {
+                let orig_idx = self.cur;
+                self.cur -= 1;
+                Some((&lambda_ctx.lvars, &lambda_ctx.params, orig_idx as isize))
+            }
+            // ::new() never sets `While` to .cur
+            HirMakerContext::While(_) => panic!("must not happen"),
+        }
+    }
+}
+
+/// Iterates over each constant scope.
+pub struct NamespaceIter<'hir_maker> {
+    ctx_stack: &'hir_maker CtxStack,
+    cur: usize,
+    finished: bool,
+}
+
+impl<'hir_maker> NamespaceIter<'hir_maker> {
+    fn new(ctx_stack: &CtxStack) -> NamespaceIter {
+        let mut finished = false;
+        let mut cur = ctx_stack.len();
+        loop {
+            if cur == 0 {
+                finished = true;
+                break;
+            }
+            cur -= 1;
+            match ctx_stack.get(cur) {
+                HirMakerContext::Toplevel(_) | HirMakerContext::Class(_) => break,
+                // Does not make constant scope
+                HirMakerContext::Method(_)
+                | HirMakerContext::Lambda(_)
+                | HirMakerContext::While(_) => (),
+            }
+        }
+        NamespaceIter {
+            ctx_stack,
+            cur,
+            finished,
+        }
+    }
+}
+
+impl<'a> Iterator for NamespaceIter<'a> {
+    /// Yields namespace
+    type Item = Namespace;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+        for idx in (0..=self.cur).rev() {
+            match self.ctx_stack.get(idx) {
+                HirMakerContext::Toplevel(_) => {
+                    self.finished = true;
+                    return Some(Namespace::root());
+                }
+                HirMakerContext::Class(class_ctx) => {
+                    self.cur -= 1;
+                    return Some(class_ctx.namespace.clone());
+                }
+                _ => (), // Skip this ctx
+            }
+        }
+        panic!("[BUG] no more namespace");
+    }
+}

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -8,6 +8,7 @@ use crate::hir::*;
 use crate::library::LibraryExports;
 use crate::names;
 use crate::type_checking;
+use ctx_stack::CtxStack;
 
 #[derive(Debug)]
 pub struct HirMaker<'hir_maker> {
@@ -24,7 +25,7 @@ pub struct HirMaker<'hir_maker> {
     /// List of string literals found so far
     pub(super) str_literals: Vec<String>,
     /// Contextual information
-    pub(super) ctx: HirMakerContext,
+    pub(super) ctx_stack: CtxStack,
     /// Counter to give unique name for lambdas
     pub(super) lambda_ct: usize,
 }
@@ -64,7 +65,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             imported_constants,
             const_inits: vec![],
             str_literals: vec![],
-            ctx: HirMakerContext::new(),
+            ctx_stack: CtxStack::new(vec![HirMakerContext::toplevel()]),
             lambda_ct: 0,
         }
     }
@@ -479,4 +480,12 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         );
         Ok(())
     }
+}
+
+/// Destructively extract list of local variables
+pub fn extract_lvars(lvars: &mut HashMap<String, CtxLVar>) -> HirLVars {
+    std::mem::take(lvars)
+        .into_iter()
+        .map(|(name, ctx_lvar)| (name, ctx_lvar.ty))
+        .collect::<Vec<_>>()
 }

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -1,33 +1,72 @@
-use crate::hir::hir_maker::HirMaker;
 use crate::hir::*;
 use crate::names::*;
-use crate::ty;
 use crate::ty::*;
 use std::collections::HashMap;
 
 #[derive(Debug)]
-pub struct HirMakerContext {
-    /// Which kind of scope we're in
-    pub current: CtxKind,
-    // Context of each scope
-    pub toplevel: ToplevelCtx,
-    pub classes: Vec<ClassCtx>,
-    pub method: Option<MethodCtx>,
-    pub lambdas: Vec<LambdaCtx>,
+pub enum HirMakerContext {
+    Toplevel(ToplevelCtx),
+    Class(ClassCtx),
+    Method(MethodCtx),
+    Lambda(LambdaCtx),
+    While(WhileCtx),
+}
+
+impl HirMakerContext {
+    /// Get the hashmap of local variables
+    pub fn opt_lvars(&mut self) -> Option<&mut CtxLVars> {
+        match self {
+            HirMakerContext::Toplevel(c) => Some(&mut c.lvars),
+            HirMakerContext::Class(c) => Some(&mut c.lvars),
+            HirMakerContext::Method(c) => Some(&mut c.lvars),
+            HirMakerContext::Lambda(c) => Some(&mut c.lvars),
+            HirMakerContext::While(_) => None,
+        }
+    }
+
+    pub fn toplevel() -> HirMakerContext {
+        HirMakerContext::Toplevel(ToplevelCtx {
+            lvars: Default::default(),
+        })
+    }
+
+    pub fn class(namespace: Namespace, typarams: Vec<String>) -> HirMakerContext {
+        HirMakerContext::Class(ClassCtx {
+            namespace,
+            typarams,
+            lvars: Default::default(),
+        })
+    }
+
+    pub fn method(signature: MethodSignature, super_ivars: Option<SkIVars>) -> HirMakerContext {
+        HirMakerContext::Method(MethodCtx {
+            signature,
+            lvars: Default::default(),
+            iivars: Default::default(),
+            super_ivars: super_ivars.unwrap_or_default(),
+        })
+    }
+
+    pub fn lambda(is_fn: bool, params: Vec<MethodParam>) -> HirMakerContext {
+        HirMakerContext::Lambda(LambdaCtx {
+            is_fn,
+            params,
+            lvars: Default::default(),
+            captures: Default::default(),
+            has_break: false,
+        })
+    }
+
+    // `while' is Rust's keyword
+    pub fn while_ctx() -> HirMakerContext {
+        HirMakerContext::While(WhileCtx {})
+    }
 }
 
 #[derive(Debug)]
 pub struct ToplevelCtx {
     /// Current local variables
     pub lvars: HashMap<String, CtxLVar>,
-}
-
-impl ToplevelCtx {
-    pub fn new() -> ToplevelCtx {
-        ToplevelCtx {
-            lvars: Default::default(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -38,16 +77,6 @@ pub struct ClassCtx {
     pub typarams: Vec<String>,
     /// Current local variables
     pub lvars: HashMap<String, CtxLVar>,
-}
-
-impl ClassCtx {
-    pub fn new(namespace: Namespace, typarams: Vec<String>) -> ClassCtx {
-        ClassCtx {
-            namespace,
-            typarams,
-            lvars: Default::default(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -64,17 +93,6 @@ pub struct MethodCtx {
     pub super_ivars: SkIVars, // TODO: this can be just &'a SkIVars
 }
 
-impl MethodCtx {
-    pub fn new(signature: MethodSignature, super_ivars: Option<SkIVars>) -> MethodCtx {
-        MethodCtx {
-            signature,
-            lvars: Default::default(),
-            iivars: Default::default(),
-            super_ivars: super_ivars.unwrap_or_default(),
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct LambdaCtx {
     /// true if this lambda is `fn(){}`. false if it is a block (`do..end`,`{...}`)
@@ -89,26 +107,9 @@ pub struct LambdaCtx {
     pub has_break: bool,
 }
 
-impl LambdaCtx {
-    pub fn new(is_fn: bool, params: Vec<MethodParam>) -> LambdaCtx {
-        LambdaCtx {
-            is_fn,
-            params,
-            lvars: Default::default(),
-            captures: Default::default(),
-            has_break: false,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub enum CtxKind {
-    Toplevel,
-    Class,
-    Method,
-    Lambda,
-    While,
-}
+/// Indicates we're in a while expr
+#[derive(Debug)]
+pub struct WhileCtx;
 
 /// A local variable
 #[derive(Debug)]
@@ -117,6 +118,8 @@ pub struct CtxLVar {
     pub ty: TermTy,
     pub readonly: bool,
 }
+
+pub type CtxLVars = HashMap<String, CtxLVar>;
 
 #[derive(Debug)]
 pub struct LambdaCapture {
@@ -131,317 +134,4 @@ pub struct LambdaCapture {
 pub enum LambdaCaptureDetail {
     CapLVar { name: String },
     CapFnArg { idx: usize },
-}
-
-impl HirMakerContext {
-    /// Create initial ctx
-    pub fn new() -> HirMakerContext {
-        HirMakerContext {
-            current: CtxKind::Toplevel,
-            toplevel: ToplevelCtx::new(),
-            classes: vec![],
-            method: None,
-            lambdas: vec![],
-        }
-    }
-
-    /// Returns true if current context is a fn
-    pub fn current_is_fn(&self) -> bool {
-        self.current == CtxKind::Lambda && self.lambdas.last().unwrap().is_fn
-    }
-
-    /// Returns a debugging string like "toplevel", "Class1", "Class1#method1", etc.
-    pub fn describe_current_place(&self) -> String {
-        if let Some(method_ctx) = &self.method {
-            method_ctx.signature.fullname.to_string()
-        } else {
-            match self.current {
-                CtxKind::Toplevel => "toplevel".to_string(),
-                CtxKind::Class => self.classes.last().unwrap().namespace.string(),
-                CtxKind::Lambda => "lambda".to_string(),
-                _ => panic!("must not happen"),
-            }
-        }
-    }
-
-    /// Set `c` to `self.current` and the original value to `c`
-    pub fn swap_current(&mut self, c: &mut CtxKind) {
-        std::mem::swap(c, &mut self.current);
-    }
-
-    /// Returns the nearest lambda ctx
-    pub fn lambda_mut(&mut self) -> &mut LambdaCtx {
-        self.lambdas.last_mut().unwrap()
-    }
-
-    /// The type of `self` in the current scope
-    pub fn self_ty(&self) -> TermTy {
-        match self.current {
-            CtxKind::Toplevel => ty::raw("Object"),
-            CtxKind::Class => {
-                let class_ctx = self.classes.last().unwrap();
-                ty::meta(&class_ctx.namespace.string())
-            }
-            _ => {
-                if let Some(class_ctx) = self.classes.last() {
-                    ty::raw(&class_ctx.namespace.string())
-                } else {
-                    // This lambda is on the toplevel
-                    ty::raw("Object")
-                }
-            }
-        }
-    }
-
-    /// Iterates over constant scopes starting from the current one
-    pub fn const_scopes(&self) -> NamespaceIter {
-        NamespaceIter::new(self)
-    }
-
-    /// Iterates over lvar scopes starting from the current scope
-    pub fn lvar_scopes(&self) -> LVarIter {
-        LVarIter::new(self)
-    }
-
-    /// Add a local variable to current context
-    pub fn declare_lvar(&mut self, name: &str, ty: TermTy, readonly: bool) {
-        let lvars = match self.current {
-            CtxKind::Toplevel => &mut self.toplevel.lvars,
-            CtxKind::Class => &mut self.classes.last_mut().unwrap().lvars,
-            CtxKind::Method => &mut self.method.as_mut().unwrap().lvars,
-            CtxKind::Lambda => &mut self.lambdas.last_mut().unwrap().lvars,
-            CtxKind::While => {
-                if !self.lambdas.is_empty() {
-                    &mut self.lambdas.last_mut().unwrap().lvars
-                } else if self.method.is_some() {
-                    &mut self.method.as_mut().unwrap().lvars
-                } else if !self.classes.is_empty() {
-                    &mut self.classes.last_mut().unwrap().lvars
-                } else {
-                    &mut self.toplevel.lvars
-                }
-            }
-        };
-        let k = name.to_string();
-        let v = CtxLVar {
-            name: name.to_string(),
-            ty,
-            readonly,
-        };
-        lvars.insert(k, v);
-    }
-
-    /// Returns if we're in an `#initialize`
-    pub fn in_initializer(&self) -> bool {
-        if let Some(method_ctx) = &self.method {
-            method_ctx.signature.fullname.first_name.0 == "initialize"
-        } else {
-            false
-        }
-    }
-
-    /// Push a LambdaCapture to captures
-    pub fn push_lambda_capture(&mut self, cap: LambdaCapture) -> usize {
-        let lambda_ctx = self.lambdas.last_mut().expect("not in lambda");
-        lambda_ctx.captures.push(cap);
-        lambda_ctx.captures.len() - 1
-    }
-
-    /// If there is a method or class typaram named `name`, returns its type
-    pub fn lookup_typaram(&self, name: &str) -> Option<TermTy> {
-        if let Some(method_ctx) = &self.method {
-            let typarams = &method_ctx.signature.typarams;
-            if let Some(i) = typarams.iter().position(|s| *name == *s) {
-                return Some(ty::typaram(name, ty::TyParamKind::Method, i));
-            }
-            if let Some(class_ctx) = self.classes.last() {
-                if method_ctx.signature.fullname.is_class_method() {
-                    return None;
-                }
-                let typarams = &class_ctx.typarams;
-                if let Some(i) = typarams.iter().position(|s| *name == *s) {
-                    return Some(ty::typaram(name, ty::TyParamKind::Class, i));
-                }
-            }
-        }
-        None
-    }
-}
-
-/// Iterates over each lvar scope.
-pub struct LVarIter<'a> {
-    ctx: &'a HirMakerContext,
-    cur: Option<CtxKind>,
-    idx: usize,
-}
-
-impl<'a> LVarIter<'a> {
-    fn new(ctx: &HirMakerContext) -> LVarIter {
-        let c = ctx.current.clone();
-        let (cur, idx) = match &c {
-            CtxKind::Toplevel => (c, 0),
-            CtxKind::Class => (c, ctx.classes.len() - 1),
-            CtxKind::Method => (c, 0),
-            CtxKind::Lambda => (c, ctx.lambdas.len() - 1),
-            // `while` does not make a lvar scope, so find the nearest one
-            CtxKind::While => {
-                if !ctx.lambdas.is_empty() {
-                    (CtxKind::Lambda, ctx.lambdas.len() - 1)
-                } else if ctx.method.is_some() {
-                    (CtxKind::Method, 0)
-                } else if !ctx.classes.is_empty() {
-                    (CtxKind::Class, ctx.classes.len() - 1)
-                } else {
-                    (CtxKind::Toplevel, 0)
-                }
-            }
-        };
-        LVarIter {
-            ctx,
-            cur: Some(cur),
-            idx,
-        }
-    }
-}
-
-impl<'a> Iterator for LVarIter<'a> {
-    /// Yields `(lvars, params, depth)`
-    type Item = (&'a HashMap<String, CtxLVar>, &'a [MethodParam], isize);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.cur {
-            // Toplevel -> end.
-            Some(CtxKind::Toplevel) => {
-                self.cur = None;
-                Some((&self.ctx.toplevel.lvars, &[], -1))
-            }
-            // Classes -> end.
-            Some(CtxKind::Class) => {
-                let class_ctx = self.ctx.classes.get(self.idx).unwrap();
-                if self.idx == 0 {
-                    self.cur = None;
-                } else {
-                    self.idx -= 1;
-                }
-                Some((&class_ctx.lvars, &[], -1))
-            }
-            // Method -> end.
-            Some(CtxKind::Method) => {
-                self.cur = None;
-                let method_ctx = self.ctx.method.as_ref().unwrap();
-                Some((&method_ctx.lvars, &method_ctx.signature.params, -1))
-            }
-            // Lambdas -> (Method or Class or Toplevel)
-            Some(CtxKind::Lambda) => {
-                let orig_idx = self.idx as isize;
-                let lambda_ctx = self.ctx.lambdas.get(self.idx).unwrap();
-                if self.idx == 0 {
-                    self.cur = if self.ctx.method.is_some() {
-                        Some(CtxKind::Method)
-                    } else if !self.ctx.classes.is_empty() {
-                        self.idx = self.ctx.classes.len() - 1;
-                        Some(CtxKind::Class)
-                    } else {
-                        Some(CtxKind::Toplevel)
-                    }
-                } else {
-                    self.idx -= 1;
-                }
-                Some((&lambda_ctx.lvars, &lambda_ctx.params, orig_idx))
-            }
-            // ::new() never sets `While` to .cur
-            Some(CtxKind::While) => panic!("must not happen"),
-            None => None,
-        }
-    }
-}
-
-/// Destructively extract list of local variables
-pub fn extract_lvars(lvars: &mut HashMap<String, CtxLVar>) -> HirLVars {
-    std::mem::take(lvars)
-        .into_iter()
-        .map(|(name, ctx_lvar)| (name, ctx_lvar.ty))
-        .collect::<Vec<_>>()
-}
-
-/// Iterates over each constant scope.
-pub struct NamespaceIter<'a> {
-    ctx: &'a HirMakerContext,
-    cur: Option<CtxKind>,
-    idx: usize,
-}
-
-impl<'a> NamespaceIter<'a> {
-    fn new(ctx: &HirMakerContext) -> NamespaceIter {
-        let c = ctx.current.clone();
-        let (cur, idx) = match &c {
-            CtxKind::Toplevel => (c, 0),
-            CtxKind::Class => (c, ctx.classes.len() - 1),
-            CtxKind::Method => (CtxKind::Class, ctx.classes.len() - 1),
-            // These does not make a constant scope, so find the nearest one
-            CtxKind::Lambda | CtxKind::While => {
-                if !ctx.classes.is_empty() {
-                    (CtxKind::Class, ctx.classes.len() - 1)
-                } else {
-                    (CtxKind::Toplevel, 0)
-                }
-            }
-        };
-        NamespaceIter {
-            ctx,
-            cur: Some(cur),
-            idx,
-        }
-    }
-}
-
-impl<'a> Iterator for NamespaceIter<'a> {
-    /// Yields namespace
-    type Item = Namespace;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.cur {
-            // Toplevel -> end.
-            Some(CtxKind::Toplevel) => {
-                self.cur = None;
-                Some(Namespace::root())
-            }
-            // Classes -> Toplevel
-            Some(CtxKind::Class) => {
-                let class_ctx = self.ctx.classes.get(self.idx).unwrap();
-                if self.idx == 0 {
-                    self.cur = Some(CtxKind::Toplevel);
-                } else {
-                    self.idx -= 1;
-                }
-                Some(class_ctx.namespace.clone())
-            }
-            Some(_) => panic!("must not happen"),
-            None => None,
-        }
-    }
-}
-
-// REFACTOR: Move to HirMakerContext
-impl<'hir_maker> HirMaker<'hir_maker> {
-    /// Returns type parameter of the current class
-    pub(super) fn current_class_typarams(&self) -> Vec<String> {
-        if let Some(class_ctx) = self.ctx.classes.last() {
-            if let Some(method_ctx) = &self.ctx.method {
-                if !method_ctx.signature.fullname.is_class_method() {
-                    return class_ctx.typarams.clone();
-                }
-            }
-        }
-        vec![]
-    }
-
-    /// Returns type parameter of the current method
-    pub(super) fn current_method_typarams(&self) -> Vec<String> {
-        if let Some(method_ctx) = &self.ctx.method {
-            method_ctx.signature.typarams.clone()
-        } else {
-            vec![]
-        }
-    }
 }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -1,6 +1,7 @@
 mod accessors;
 pub mod class_dict;
 mod convert_exprs;
+mod ctx_stack;
 mod hir_maker;
 mod hir_maker_context;
 mod method_dict;


### PR DESCRIPTION
To implement pattern matching (#306), refactored `HirMaker` to have single stack of ctx (`CtxStack`) which contains all kinds of ctx (`enum HirMakerContext`).