### PR TITLE
Use `Maybe` in builtin classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -74,12 +74,6 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -208,17 +202,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi",
-]
 
 [[package]]
 name = "gimli"
@@ -351,7 +334,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -418,7 +401,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi",
  "instant",
  "libc",
@@ -435,12 +418,6 @@ checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-error"
@@ -482,55 +459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -636,8 +564,6 @@ dependencies = [
  "inkwell",
  "log",
  "mac-sys-info",
- "rand",
- "rand_pcg",
  "serde",
  "serde_json",
 ]
@@ -751,12 +677,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,3 @@ log = "0.4.11"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0"
 mac-sys-info = "0.1.13"
-rand = "0.8.4"
-rand_pcg = "0.3.1"

--- a/builtin/_maybe.sk
+++ b/builtin/_maybe.sk
@@ -1,3 +1,5 @@
+# TODO: Rename to `maybe.sk` after `require` is implemented
+
 enum Maybe<V>
   case Some(value: V)
   case None

--- a/builtin/array.sk
+++ b/builtin/array.sk
@@ -131,9 +131,13 @@ class Array<T>
     end
   end
 
-  # Return the first element
-  def first -> T  # TODO: Return Option
-    self[0]
+  # Returns the first element, unless `self` is empty.
+  def first -> Maybe<T>
+    if self.is_empty
+      None
+    else
+      Some<T>.new(self[0])
+    end
   end
 
   # Like `map` but `f` should return an array and the result is flattened.
@@ -208,12 +212,13 @@ class Array<T>
     ret._unsafe_to_s
   end
 
-  # TODO: return Option
-  def last -> T
+  # Returns the last item, unless `self` is empty.
+  def last -> Maybe<T>
     if @n_items == 0
-      panic "[Array#last: array is empty]"
+      None
+    else
+      Some<T>.new(self[@n_items - 1])
     end
-    self[@n_items - 1]
   end
 
   # Return the number of items
@@ -311,16 +316,16 @@ class Array<T>
 
   # Removes the first element and returns it.
   # Panics if `self` is empty
-  # TODO: Return Option<T>
-  def shift -> T
+  def shift -> Maybe<T>
     if @n_items == 0
-      panic "[Array#shift: array is empty]"
+      None
+    else
+      ret = self[0]
+      @capa -= 1
+      @n_items -= 1
+      @items += BYTES_OF_PTR
+      Some<T>.new(ret)
     end
-    ret = self[0]
-    @capa -= 1
-    @n_items -= 1
-    @items += BYTES_OF_PTR
-    ret
   end
 
   # Create sorted version of `self`

--- a/builtin/hash.sk
+++ b/builtin/hash.sk
@@ -11,41 +11,40 @@ end
 class Hash<K, V>
   N_TABLES = 1000
 
-  class Table<K, V>
+  class Table<KK, VV>
     def initialize
-      @pairs = Array<Pair<K, V>>.new
+      @pairs = Array<Pair<KK, VV>>.new
     end
 
     # Set the value of specified key.
-    def []=(key: K, value: V)
+    def []=(key: KK, value: VV)
       var done = false
-      @pairs.each do |pair: Pair<K, V>|
+      @pairs.each do |pair: Pair<KK, VV>|
         if pair.fst == key
           pair.snd = value
           done = true
         end
       end
       unless done
-        @pairs.push(Pair<K, V>.new(key, value))
+        @pairs.push(Pair<KK, VV>.new(key, value))
       end
     end
 
     # Get the value of specified key.
-    # If that key does not exist, the behavior is undefined (TODO: Return Option<V>)
-    def [](key: K) -> V
-      var ret = @pairs.first.snd
-      @pairs.each do |pair: Pair<K, V>|
+    def [](key: KK) -> Maybe<VV>
+      var ret = None
+      @pairs.each do |pair: Pair<KK, VV>|
         if pair.fst == key
-          ret = pair.snd
+          ret = Some.new(pair.snd)
         end
       end
       ret
     end
 
     # Return true if `self` has `key` (compared with `==`)
-    def has_key(key: K) -> Bool
+    def has_key(key: KK) -> Bool
       var ret = false
-      @pairs.each do |pair: Pair<K, V>|
+      @pairs.each do |pair: Pair<KK, VV>|
         if pair.fst == key
           ret = true
         end
@@ -54,18 +53,18 @@ class Hash<K, V>
     end
 
     # Return list of the keys
-    def keys -> Array<K>
-      ret = Array<K>.new
-      @pairs.each do |pair: Pair<K, V>|
+    def keys -> Array<KK>
+      ret = Array<KK>.new
+      @pairs.each do |pair: Pair<KK, VV>|
         ret.push(pair.fst)
       end
       ret
     end
 
     # Return list of the values
-    def values -> Array<V>
-      ret = Array<V>.new
-      @pairs.each do |pair: Pair<K, V>|
+    def values -> Array<VV>
+      ret = Array<VV>.new
+      @pairs.each do |pair: Pair<KK, VV>|
         ret.push(pair.snd)
       end
       ret
@@ -87,9 +86,8 @@ class Hash<K, V>
     _table(key)[key] = value
   end
 
-  # Get the value of specified key.
-  # If that key does not exist, the behavior is undefined (TODO: Return Option<V>)
-  def [](key: K) -> V
+  # Get the value of specified key, if any.
+  def [](key: K) -> Maybe<V>
     _table(key)[key]
   end
 

--- a/builtin/maybe.sk
+++ b/builtin/maybe.sk
@@ -21,6 +21,15 @@ enum Maybe<V>
       panic msg
     end
   end
+
+  def inspect -> String
+    match self
+    when Some(v)
+      "#<Some \{v}>"
+    else
+      "#<None>"
+    end
+  end
 end
 Some = Maybe::Some
 None = Maybe::None

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -118,8 +118,27 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         v
     }
 
-    /// Return the nearest common ancestor of the classes
-    pub fn nearest_common_ancestor(&self, ty1: &TermTy, ty2: &TermTy) -> TermTy {
+    /// Returns the nearest common ancestor of the classes
+    /// Returns `None` if there is no common ancestor except `Object`, the
+    /// top type. However, returns `Some(Object)` when either of the arguments
+    /// is `Object`.
+    pub fn nearest_common_ancestor(&self, ty1: &TermTy, ty2: &TermTy) -> Option<TermTy> {
+        let t = self._nearest_common_ancestor(ty1, ty2);
+        let obj = ty::raw("Object");
+        if t == obj {
+            if *ty1 == obj || *ty2 == obj {
+                Some(obj)
+            } else {
+                // No common ancestor found (except `Object`)
+                None
+            }
+        } else {
+            Some(t)
+        }
+    }
+
+    /// Find common ancestor of two types
+    fn _nearest_common_ancestor(&self, ty1: &TermTy, ty2: &TermTy) -> TermTy {
         let ancestors1 = self.ancestor_types(ty1);
         let ancestors2 = self.ancestor_types(ty2);
         for t2 in &ancestors2 {
@@ -142,7 +161,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
                 return t3.clone();
             }
         }
-        panic!("[BUG] nearest common ancestor type not found");
+        panic!("[BUG] _nearest_common_ancestor not found");
     }
 
     /// Return true if `ty1` conforms to `ty2` i.e.
@@ -343,15 +362,37 @@ mod tests {
     }
 
     #[test]
-    fn test_nearest_common_ancestor() -> Result<(), Error> {
+    fn test_nearest_common_ancestor_Some() -> Result<(), Error> {
         let src = "";
         test_class_dict(src, |class_dict| {
             let a = ty::raw("Maybe::None");
             let b = ty::spe("Maybe::Some", vec![ty::raw("Int")]);
             let c = class_dict.nearest_common_ancestor(&a, &b);
-            assert_eq!(c, ty::spe("Maybe", vec![ty::raw("Int")]));
+            assert_eq!(c, Some(ty::spe("Maybe", vec![ty::raw("Int")])));
             let d = class_dict.nearest_common_ancestor(&b, &a);
-            assert_eq!(d, ty::spe("Maybe", vec![ty::raw("Int")]));
+            assert_eq!(d, Some(ty::spe("Maybe", vec![ty::raw("Int")])));
+        })
+    }
+
+    #[test]
+    fn test_nearest_common_ancestor_Some_Object() -> Result<(), Error> {
+        let src = "";
+        test_class_dict(src, |class_dict| {
+            let a = ty::raw("Int");
+            let b = ty::raw("Object");
+            let c = class_dict.nearest_common_ancestor(&a, &b);
+            assert_eq!(c, Some(ty::raw("Object")));
+        })
+    }
+
+    #[test]
+    fn test_nearest_common_ancestor_None() -> Result<(), Error> {
+        let src = "";
+        test_class_dict(src, |class_dict| {
+            let a = ty::raw("Int");
+            let b = ty::spe("Array", vec![ty::raw("Int")]);
+            let c = class_dict.nearest_common_ancestor(&a, &b);
+            assert_eq!(c, None);
         })
     }
 }

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nearest_common_ancestor_Some() -> Result<(), Error> {
+    fn test_nearest_common_ancestor__some() -> Result<(), Error> {
         let src = "";
         test_class_dict(src, |class_dict| {
             let a = ty::raw("Maybe::None");
@@ -375,7 +375,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nearest_common_ancestor_Some_Object() -> Result<(), Error> {
+    fn test_nearest_common_ancestor__some_object() -> Result<(), Error> {
         let src = "";
         test_class_dict(src, |class_dict| {
             let a = ty::raw("Int");
@@ -386,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nearest_common_ancestor_None() -> Result<(), Error> {
+    fn test_nearest_common_ancestor__none() -> Result<(), Error> {
         let src = "";
         test_class_dict(src, |class_dict| {
             let a = ty::raw("Int");

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -10,14 +10,18 @@ use crate::type_checking;
 
 /// Result of looking up a lvar
 #[derive(Debug)]
-enum LVarInfo {
+struct LVarInfo {
+    ty: TermTy,
+    detail: LVarDetail,
+}
+#[derive(Debug)]
+enum LVarDetail {
     /// Found in the current scope
-    CurrentScope { ty: TermTy, name: String },
+    CurrentScope { name: String },
     /// Found in the current method/lambda argument
-    Argument { ty: TermTy, idx: usize },
+    Argument { idx: usize },
     /// Found in outer scope
     OuterScope {
-        ty: TermTy,
         /// Index of the lvar in `captures`
         cidx: usize,
         readonly: bool,
@@ -25,32 +29,23 @@ enum LVarInfo {
 }
 
 impl LVarInfo {
-    /// The type of the lvar
-    fn ty(&self) -> &TermTy {
-        match self {
-            LVarInfo::CurrentScope { ty, .. } => ty,
-            LVarInfo::Argument { ty, .. } => ty,
-            LVarInfo::OuterScope { ty, .. } => ty,
-        }
-    }
-
     /// Returns HirExpression to refer this lvar
     fn ref_expr(&self) -> HirExpression {
-        match self {
-            LVarInfo::CurrentScope { ty, name } => Hir::lvar_ref(ty.clone(), name.clone()),
-            LVarInfo::Argument { ty, idx } => Hir::arg_ref(ty.clone(), *idx),
-            LVarInfo::OuterScope {
-                ty, cidx, readonly, ..
-            } => Hir::lambda_capture_ref(ty.clone(), *cidx, *readonly),
+        match &self.detail {
+            LVarDetail::CurrentScope { name } => Hir::lvar_ref(self.ty.clone(), name.clone()),
+            LVarDetail::Argument { idx } => Hir::arg_ref(self.ty.clone(), *idx),
+            LVarDetail::OuterScope { cidx, readonly } => {
+                Hir::lambda_capture_ref(self.ty.clone(), *cidx, *readonly)
+            }
         }
     }
 
     /// Returns HirExpression to update this lvar
     fn assign_expr(&self, expr: HirExpression) -> HirExpression {
-        match self {
-            LVarInfo::CurrentScope { name, .. } => Hir::lvar_assign(name, expr),
-            LVarInfo::Argument { .. } => panic!("[BUG] Cannot reassign argument"),
-            LVarInfo::OuterScope { cidx, .. } => Hir::lambda_capture_write(*cidx, expr),
+        match &self.detail {
+            LVarDetail::CurrentScope { name, .. } => Hir::lvar_assign(name, expr),
+            LVarDetail::Argument { .. } => panic!("[BUG] Cannot reassign argument"),
+            LVarDetail::OuterScope { cidx, .. } => Hir::lambda_capture_write(*cidx, expr),
         }
     }
 }
@@ -323,9 +318,23 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 name
             )));
         }
-        if let Some(lvar_info) = self._find_var(name, true)? {
+        if let Some(mut lvar_info) = self._find_var(name, true)? {
             // Reassigning
-            type_checking::check_reassign_var(lvar_info.ty(), &expr.ty, name)?;
+            if lvar_info.ty != expr.ty {
+                if let Some(t) = self
+                    .class_dict
+                    .nearest_common_ancestor(&lvar_info.ty, &expr.ty)
+                {
+                    // Upgrade lvar type (eg. from `None` to `Maybe<Int>`)
+                    lvar_info.ty = t;
+                } else {
+                    return Err(type_checking::invalid_reassign_error(
+                        &lvar_info.ty,
+                        &expr.ty,
+                        name,
+                    ));
+                }
+            }
             Ok(lvar_info.assign_expr(expr))
         } else {
             // Create new lvar
@@ -434,7 +443,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         // Check if this is a lambda invocation
         if receiver_expr.is_none() {
             if let Some(lvar) = self._lookup_var(&method_name.0) {
-                if let Some(ret_ty) = lvar.ty().fn_x_info() {
+                if let Some(ret_ty) = lvar.ty.fn_x_info() {
                     return Ok(Hir::lambda_invocation(ret_ty, lvar.ref_expr(), arg_hirs));
                 }
             }
@@ -658,16 +667,20 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                             name: name.to_string(),
                         },
                     };
-                    let lvar_info = LVarInfo::OuterScope {
+                    let lvar_info = LVarInfo {
                         ty: lvar.ty.clone(),
-                        cidx,
-                        readonly: false,
+                        detail: LVarDetail::OuterScope {
+                            cidx,
+                            readonly: false,
+                        },
                     };
                     return Ok((Some(lvar_info), Some(cap)));
                 } else {
-                    let lvar_info = LVarInfo::CurrentScope {
+                    let lvar_info = LVarInfo {
                         ty: lvar.ty.clone(),
-                        name: name.to_string(),
+                        detail: LVarDetail::CurrentScope {
+                            name: name.to_string(),
+                        },
                     };
                     return Ok((Some(lvar_info), None));
                 }
@@ -685,16 +698,18 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                         ty: param.ty.clone(),
                         detail: LambdaCaptureDetail::CapFnArg { idx },
                     };
-                    let lvar_info = LVarInfo::OuterScope {
+                    let lvar_info = LVarInfo {
                         ty: param.ty.clone(),
-                        cidx,
-                        readonly: true,
+                        detail: LVarDetail::OuterScope {
+                            cidx,
+                            readonly: true,
+                        },
                     };
                     return Ok((Some(lvar_info), Some(cap)));
                 } else {
-                    let lvar_info = LVarInfo::Argument {
+                    let lvar_info = LVarInfo {
                         ty: param.ty.clone(),
-                        idx,
+                        detail: LVarDetail::Argument { idx },
                     };
                     return Ok((Some(lvar_info), None));
                 }

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -198,9 +198,10 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             then_hirs.voidify();
             ty::raw("Void")
         } else {
-            let ty = self
+            let opt_ty = self
                 .class_dict
                 .nearest_common_ancestor(&then_hirs.ty, &else_hirs.ty);
+            let ty = type_checking::check_if_body_ty(opt_ty)?;
             if !then_hirs.ty.equals_to(&ty) {
                 then_hirs = then_hirs.bitcast_to(ty.clone());
             }
@@ -895,7 +896,10 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         };
 
         for expr in &item_exprs {
-            item_ty = self.class_dict.nearest_common_ancestor(&item_ty, &expr.ty);
+            item_ty = self
+                .class_dict
+                .nearest_common_ancestor(&item_ty, &expr.ty)
+                .expect("array literal elements type mismatch");
         }
         let ary_ty = ty::spe("Array", vec![item_ty]);
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,8 +1,6 @@
 use crate::error::*;
 use crate::library;
 use crate::targets;
-use rand::prelude::SliceRandom;
-use rand::SeedableRng;
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
@@ -78,21 +76,20 @@ fn load_builtin() -> Result<String, Box<dyn std::error::Error>> {
     let mut s = String::new();
     let dir =
         fs::read_dir("builtin").map_err(|e| runner_error("./builtin not found", Box::new(e)))?;
-    let mut files = dir.collect::<Vec<_>>();
-    if false {
-        // Randomize loading order (for debugging purpose)
-        let mut rng = rand_pcg::Pcg64::seed_from_u64(123);
-        files.shuffle(&mut rng);
+    let mut files = vec![];
+    for entry in dir {
+        let pathbuf = entry?.path();
+        let path = pathbuf.to_str().ok_or_else(|| plain_runner_error("Filename not utf8"))?;
+        files.push(path.to_string());
     }
-    for item in files {
-        let pathbuf = item?.path();
-        let path = pathbuf
-            .to_str()
-            .ok_or_else(|| plain_runner_error("Filename not utf8"))?;
+    files.sort();
+    for path in files {
         if path.ends_with(".sk") {
             //dbg!(&path);
-            s += &fs::read_to_string(path)
-                .map_err(|e| runner_error(format!("failed to load {}", path), Box::new(e)))?;
+            match fs::read_to_string(&path) {
+                Ok(src) => s += &src,
+                Err(e) => return Err(Box::new(runner_error(format!("failed to load {}", path), Box::new(e)))),
+            }
         }
     }
     Ok(s)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -79,7 +79,9 @@ fn load_builtin() -> Result<String, Box<dyn std::error::Error>> {
     let mut files = vec![];
     for entry in dir {
         let pathbuf = entry?.path();
-        let path = pathbuf.to_str().ok_or_else(|| plain_runner_error("Filename not utf8"))?;
+        let path = pathbuf
+            .to_str()
+            .ok_or_else(|| plain_runner_error("Filename not utf8"))?;
         files.push(path.to_string());
     }
     files.sort();
@@ -88,7 +90,12 @@ fn load_builtin() -> Result<String, Box<dyn std::error::Error>> {
             //dbg!(&path);
             match fs::read_to_string(&path) {
                 Ok(src) => s += &src,
-                Err(e) => return Err(Box::new(runner_error(format!("failed to load {}", path), Box::new(e)))),
+                Err(e) => {
+                    return Err(Box::new(runner_error(
+                        format!("failed to load {}", path),
+                        Box::new(e),
+                    )))
+                }
             }
         }
     }

--- a/src/type_checking/mod.rs
+++ b/src/type_checking/mod.rs
@@ -47,6 +47,13 @@ pub fn check_condition_ty(ty: &TermTy, on: &str) -> Result<(), Error> {
     }
 }
 
+pub fn check_if_body_ty(opt_ty: Option<TermTy>) -> Result<TermTy, Error> {
+    match opt_ty {
+        Some(ty) => Ok(ty),
+        None => Err(type_error!("if clauses type mismatch")),
+    }
+}
+
 /// Check the type of the argument of `return`
 pub fn check_return_arg_type(
     class_dict: &ClassDict,
@@ -65,17 +72,13 @@ pub fn check_return_arg_type(
     }
 }
 
-pub fn check_reassign_var(orig_ty: &TermTy, new_ty: &TermTy, name: &str) -> Result<(), Error> {
-    if orig_ty.equals_to(new_ty) {
-        Ok(())
-    } else {
-        Err(type_error!(
-            "variable {} is {:?} but tried to assign a {:?}",
-            name,
-            orig_ty,
-            new_ty
-        ))
-    }
+pub fn invalid_reassign_error(orig_ty: &TermTy, new_ty: &TermTy, name: &str) -> Error {
+    type_error!(
+        "variable {} is {:?} but tried to assign a {:?}",
+        name,
+        orig_ty,
+        new_ty
+    )
 }
 
 /// Check argument types of a method call

--- a/tests/sk/array.sk
+++ b/tests/sk/array.sk
@@ -1,5 +1,11 @@
 a = [123]
-unless a.first == 123; puts "ng #first"; end
+fst = a.first
+match a.first
+when Some(v)
+  puts "ng #first" unless v == 123
+else
+  puts "ng #first"
+end
 
 b = Array<Int>.new
 b.push(123)

--- a/tests/sk/generics.sk
+++ b/tests/sk/generics.sk
@@ -1,6 +1,6 @@
 class A
   def self.foo(a: Array<Int>) -> Int
-    a.first
+    a[0]
   end
 end
 if A.foo([99]) != 99; puts "ng 1"; end


### PR DESCRIPTION
This PR changes core class methods to return `Maybe` where they should.

Also includes these changes:

- Raise error when common ancestor falls back to `Object` (7764364) 
- Allow reassign `Some` to a variable contains `None` (3189cf8)
- Fix loading order of builtin/*.sk (5a9bafe)