### PR TITLE
Add crate for mangling Shiika methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
@@ -748,6 +748,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shiika_ffi"
+version = "0.1.0"
+
+[[package]]
+name = "shiika_ffi_macro"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "shiika_ffi",
+ "syn",
+]
+
+[[package]]
 name = "shiika_parser"
 version = "0.1.0"
 dependencies = [
@@ -782,6 +795,7 @@ dependencies = [
  "serde_json",
  "shiika_ast",
  "shiika_core",
+ "shiika_ffi",
  "skc_hir",
  "skc_mir",
 ]
@@ -827,6 +841,7 @@ version = "0.1.0"
 dependencies = [
  "bdwgc-alloc",
  "plain",
+ "shiika_ffi_macro",
 ]
 
 [[package]]
@@ -843,9 +858,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/shiika_ffi/Cargo.toml
+++ b/lib/shiika_ffi/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "shiika_ffi"
+version = "0.1.0"
+edition = "2018"

--- a/lib/shiika_ffi/README.md
+++ b/lib/shiika_ffi/README.md
@@ -1,0 +1,3 @@
+# shiika_ffi
+
+Currently this crate just provides `mangle_method` function which returns the llvm function name of a Shiika method.

--- a/lib/shiika_ffi/src/lib.rs
+++ b/lib/shiika_ffi/src/lib.rs
@@ -1,0 +1,23 @@
+pub fn mangle_method(method_name: &str) -> String {
+    method_name
+        // Replace '_' to use '_' as delimiter
+        .replace("_", "__")
+        // Replace symbols to make the function callable from Rust(skc_rustlib)
+        .replace("::", "_")
+        .replace("Meta:", "Meta_")
+        .replace("#", "_")
+        .replace("+@", "uplus_")
+        .replace("-@", "uminus_")
+        .replace("+", "add_")
+        .replace("-", "sub_")
+        .replace("*", "mul_")
+        .replace("/", "div_")
+        .replace("%", "mod_")
+        .replace("==", "eq_")
+        .replace("<", "lt_")
+        .replace(">", "gt_")
+        .replace("<=", "le_")
+        .replace(">=", "ge_")
+        .replace("[]", "aref_")
+        .replace("[]=", "aset_")
+}

--- a/lib/shiika_ffi_macro/Cargo.toml
+++ b/lib/shiika_ffi_macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "shiika_ffi_macro"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+shiika_ffi = { path = "../shiika_ffi" }
+syn = { version = "1.0.82", features = ["full"] }
+quote = "1.0"

--- a/lib/shiika_ffi_macro/README.md
+++ b/lib/shiika_ffi_macro/README.md
@@ -1,0 +1,3 @@
+# shiika_ffi_macro
+
+This crate provides `#[shiika_method(...)]` attribute which expands into `#[export_name = "..."]`.

--- a/lib/shiika_ffi_macro/src/lib.rs
+++ b/lib/shiika_ffi_macro/src/lib.rs
@@ -1,0 +1,17 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use shiika_ffi::mangle_method;
+use syn::parse_macro_input;
+
+#[proc_macro_attribute]
+pub fn shiika_method(args: TokenStream, input: TokenStream) -> TokenStream {
+    let method_name = parse_macro_input!(args as syn::LitStr);
+    let function_definition = parse_macro_input!(input as syn::ItemFn);
+
+    let mangled_name = mangle_method(&method_name.value());
+    let gen = quote! {
+        #[export_name = #mangled_name]
+        #function_definition
+    };
+    gen.into()
+}

--- a/lib/skc_codegen/Cargo.toml
+++ b/lib/skc_codegen/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 shiika_core = { path = "../shiika_core" }
 shiika_ast = { path = "../shiika_ast" }
+shiika_ffi = { path = "../shiika_ffi" }
 skc_hir = { path = "../skc_hir" }
 skc_mir = { path = "../skc_mir" }
 anyhow = "1.0"

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -1,3 +1,4 @@
+use crate::utils::llvm_func_name;
 use crate::values::*;
 use crate::CodeGen;
 use inkwell::types::*;
@@ -137,52 +138,65 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let str_i8ptr = function.get_nth_param(0).unwrap();
         let bytesize = function.get_nth_param(1).unwrap().into_int_value();
         let args = vec![self.box_i8ptr(str_i8ptr), self.box_int(&bytesize)];
-        let sk_str = self.call_method_func("Meta:String#new", receiver, &args, "sk_str");
+        let sk_str = self.call_method_func(
+            &method_fullname(&metaclass_fullname("String"), "new"),
+            receiver,
+            &args,
+            "sk_str",
+        );
         self.build_return(&sk_str);
     }
 
     /// Convert LLVM bool(i1) into Shiika Bool
     pub fn box_bool(&self, b: inkwell::values::IntValue<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func("box_bool", &[b.into()], "sk_bool"))
+        SkObj(self.call_llvm_func(&llvm_func_name("box_bool"), &[b.into()], "sk_bool"))
     }
 
     /// Convert Shiika Bool into LLVM bool(i1)
     pub fn unbox_bool(&self, sk_bool: SkObj<'run>) -> inkwell::values::IntValue<'run> {
-        self.call_llvm_func("unbox_bool", &[sk_bool.0], "llvm_bool")
+        self.call_llvm_func(&llvm_func_name("unbox_bool"), &[sk_bool.0], "llvm_bool")
             .into_int_value()
     }
 
     /// Convert LLVM int into Shiika Int
     pub fn box_int(&self, i: &inkwell::values::IntValue<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func("box_int", &[i.as_basic_value_enum()], "sk_int"))
+        SkObj(self.call_llvm_func(
+            &llvm_func_name("box_int"),
+            &[i.as_basic_value_enum()],
+            "sk_int",
+        ))
     }
 
     /// Convert Shiika Int into LLVM int
     pub fn unbox_int(&self, sk_int: SkObj<'run>) -> inkwell::values::IntValue<'run> {
-        self.call_llvm_func("unbox_int", &[sk_int.0], "llvm_int")
+        self.call_llvm_func(&llvm_func_name("unbox_int"), &[sk_int.0], "llvm_int")
             .into_int_value()
     }
 
     /// Convert LLVM float into Shiika Float
     pub fn box_float(&self, fl: &inkwell::values::FloatValue<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func("box_float", &[fl.as_basic_value_enum()], "sk_float"))
+        SkObj(self.call_llvm_func(
+            &llvm_func_name("box_float"),
+            &[fl.as_basic_value_enum()],
+            "sk_float",
+        ))
     }
 
     /// Convert Shiika Float into LLVM float
     pub fn unbox_float(&self, sk_float: SkObj<'run>) -> inkwell::values::FloatValue<'run> {
-        self.call_llvm_func("unbox_float", &[sk_float.0], "llvm_float")
+        self.call_llvm_func(&llvm_func_name("unbox_float"), &[sk_float.0], "llvm_float")
             .into_float_value()
     }
 
     /// Convert LLVM i8* into Shiika::Internal::Ptr
     pub fn box_i8ptr(&self, p: inkwell::values::BasicValueEnum<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func("box_i8ptr", &[p], "sk_ptr"))
+        SkObj(self.call_llvm_func(&llvm_func_name("box_i8ptr"), &[p], "sk_ptr"))
     }
 
     /// Convert Shiika::Internal::Ptr into LLVM i8*
     pub fn unbox_i8ptr(&self, sk_obj: SkObj<'run>) -> I8Ptr<'run> {
         I8Ptr(
-            self.call_llvm_func("unbox_i8ptr", &[sk_obj.0], "llvm_ptr")
+            self.call_llvm_func(&llvm_func_name("unbox_i8ptr"), &[sk_obj.0], "llvm_ptr")
                 .into_pointer_value(),
         )
     }

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -1,3 +1,4 @@
+use crate::utils::{llvm_func_name, LlvmFuncName};
 use crate::CodeGen;
 use anyhow::Result;
 use either::Either::*;
@@ -105,7 +106,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 lvars,
                 ..
             } => {
-                self.gen_lambda_func(name, params, exprs, ret_ty, lvars)?;
+                self.gen_lambda_func(&llvm_func_name(name), params, exprs, ret_ty, lvars)?;
                 self.gen_lambda_funcs_in_exprs(&exprs.exprs)?;
             }
             HirSelfExpression => (),
@@ -126,7 +127,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
     fn gen_lambda_func(
         &self,
-        func_name: &str,
+        func_name: &LlvmFuncName,
         params: &'hir [MethodParam],
         exprs: &'hir HirExpressions,
         ret_ty: &TermTy,

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -12,6 +12,13 @@ const OBJ_VTABLE_IDX: usize = 0;
 /// 1st: reference to the class object
 const OBJ_CLASS_IDX: usize = 1;
 
+#[derive(Debug)]
+pub struct LlvmFuncName(pub String);
+
+pub fn llvm_func_name(name: impl Into<String>) -> LlvmFuncName {
+    LlvmFuncName(name.into())
+}
+
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Build IR to return Shiika object
     pub fn build_return(&self, obj: &SkObj<'run>) {
@@ -306,4 +313,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 /// Name of llvm constant of a vtable
 pub(super) fn llvm_vtable_const_name(classname: &ClassFullname) -> String {
     format!("shiika_vtable_{}", classname.0)
+}
+
+/// Returns llvm function name of the given method
+pub fn method_func_name(method_name: &MethodFullname) -> LlvmFuncName {
+    LlvmFuncName(mangle_method(&method_name.full_name))
 }

--- a/lib/skc_rustlib/Cargo.toml
+++ b/lib/skc_rustlib/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2018"
 crate-type = ["staticlib"]
 
 [dependencies]
+shiika_ffi_macro = { path = "../shiika_ffi_macro" }
 bdwgc-alloc = "0.6.0"
 plain = "0.2.3"

--- a/lib/skc_rustlib/src/builtin/array.rs
+++ b/lib/skc_rustlib/src/builtin/array.rs
@@ -1,5 +1,6 @@
 use crate::builtin::object::ShiikaObject;
 use crate::builtin::{SkInt, SkPtr};
+use shiika_ffi_macro::shiika_method;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -15,7 +16,7 @@ struct ShiikaArray {
     items: SkPtr,
 }
 
-#[export_name = "Array#[]"]
+#[shiika_method("Array#[]")]
 pub extern "C" fn array_get(receiver: SkAry, idx: SkInt) -> *const ShiikaObject {
     unsafe {
         let items_ptr = (*receiver.0).items.unbox() as *const *const ShiikaObject;

--- a/lib/skc_rustlib/src/builtin/float.rs
+++ b/lib/skc_rustlib/src/builtin/float.rs
@@ -1,5 +1,6 @@
 //! Instance of `::Float`
 use crate::builtin::{SkBool, SkInt, SkStr};
+use shiika_ffi_macro::shiika_method;
 
 extern "C" {
     fn box_float(f: f64) -> SkFloat;
@@ -36,72 +37,72 @@ impl SkFloat {
     }
 }
 
-#[export_name = "Float#-@"]
+#[shiika_method("Float#-@")]
 pub extern "C" fn float_inv(receiver: SkFloat) -> SkFloat {
     (-receiver.val()).into()
 }
 
-#[export_name = "Float#+"]
+#[shiika_method("Float#+")]
 pub extern "C" fn float_add(receiver: SkFloat, other: SkFloat) -> SkFloat {
     (receiver.val() + other.val()).into()
 }
 
-#[export_name = "Float#-"]
+#[shiika_method("Float#-")]
 pub extern "C" fn float_sub(receiver: SkFloat, other: SkFloat) -> SkFloat {
     (receiver.val() - other.val()).into()
 }
 
-#[export_name = "Float#*"]
+#[shiika_method("Float#*")]
 pub extern "C" fn float_mul(receiver: SkFloat, other: SkFloat) -> SkFloat {
     (receiver.val() * other.val()).into()
 }
 
-#[export_name = "Float#/"]
+#[shiika_method("Float#/")]
 pub extern "C" fn float_div(receiver: SkFloat, other: SkFloat) -> SkFloat {
     (receiver.val() / other.val()).into()
 }
 
-#[export_name = "Float#<"]
+#[shiika_method("Float#<")]
 pub extern "C" fn float_lt(receiver: SkFloat, other: SkFloat) -> SkBool {
     (receiver.val() < other.val()).into()
 }
 
-#[export_name = "Float#<="]
+#[shiika_method("Float#<=")]
 pub extern "C" fn float_le(receiver: SkFloat, other: SkFloat) -> SkBool {
     (receiver.val() <= other.val()).into()
 }
 
-#[export_name = "Float#>"]
+#[shiika_method("Float#>")]
 pub extern "C" fn float_gt(receiver: SkFloat, other: SkFloat) -> SkBool {
     (receiver.val() > other.val()).into()
 }
 
-#[export_name = "Float#>="]
+#[shiika_method("Float#>=")]
 pub extern "C" fn float_ge(receiver: SkFloat, other: SkFloat) -> SkBool {
     (receiver.val() >= other.val()).into()
 }
 
-#[export_name = "Float#=="]
+#[shiika_method("Float#==")]
 pub extern "C" fn float_eq(receiver: SkFloat, other: SkFloat) -> SkBool {
     (receiver.val() == other.val()).into()
 }
 
-#[export_name = "Float#abs"]
+#[shiika_method("Float#abs")]
 pub extern "C" fn float_abs(receiver: SkFloat) -> SkFloat {
     receiver.val().abs().into()
 }
 
-#[export_name = "Float#floor"]
+#[shiika_method("Float#floor")]
 pub extern "C" fn float_floor(receiver: SkFloat) -> SkFloat {
     receiver.val().floor().into()
 }
 
-#[export_name = "Float#to_i"]
+#[shiika_method("Float#to_i")]
 pub extern "C" fn float_to_i(receiver: SkFloat) -> SkInt {
     (receiver.val().trunc() as i64).into()
 }
 
-#[export_name = "Float#to_s"]
+#[shiika_method("Float#to_s")]
 pub extern "C" fn float_to_s(receiver: SkFloat) -> SkStr {
     format!("{}", receiver.val()).into()
 }

--- a/lib/skc_rustlib/src/builtin/int.rs
+++ b/lib/skc_rustlib/src/builtin/int.rs
@@ -1,6 +1,7 @@
 //! Instance of `::Int`
 //! May represent big number in the future
 use crate::builtin::{SkBool, SkFloat};
+use shiika_ffi_macro::shiika_method;
 
 extern "C" {
     fn box_int(i: i64) -> SkInt;
@@ -37,73 +38,73 @@ impl SkInt {
     }
 }
 
-#[export_name = "Int#-@"]
+#[shiika_method("Int#-@")]
 pub extern "C" fn int_inv(receiver: SkInt) -> SkInt {
     (-receiver.val()).into()
 }
 
-#[export_name = "Int#+"]
+#[shiika_method("Int#+")]
 pub extern "C" fn int_add(receiver: SkInt, other: SkInt) -> SkInt {
     (receiver.val() + other.val()).into()
 }
 
-#[export_name = "Int#-"]
+#[shiika_method("Int#-")]
 pub extern "C" fn int_sub(receiver: SkInt, other: SkInt) -> SkInt {
     (receiver.val() - other.val()).into()
 }
 
-#[export_name = "Int#*"]
+#[shiika_method("Int#*")]
 pub extern "C" fn int_mul(receiver: SkInt, other: SkInt) -> SkInt {
     (receiver.val() * other.val()).into()
 }
 
 // TODO: Return Float?
-#[export_name = "Int#/"]
+#[shiika_method("Int#/")]
 pub extern "C" fn int_div(receiver: SkInt, other: SkInt) -> SkInt {
     (receiver.val() / other.val()).into()
 }
 
-#[export_name = "Int#%"]
+#[shiika_method("Int#%")]
 pub extern "C" fn int_mod(receiver: SkInt, other: SkInt) -> SkInt {
     (receiver.val() % other.val()).into()
 }
 
-#[export_name = "Int#<<"]
+#[shiika_method("Int#<<")]
 pub extern "C" fn int_lshift(receiver: SkInt, other: SkInt) -> SkInt {
     (receiver.val() << other.val()).into()
 }
 
-#[export_name = "Int#>>"]
+#[shiika_method("Int#>>")]
 pub extern "C" fn int_rshift(receiver: SkInt, other: SkInt) -> SkInt {
     (receiver.val() >> other.val()).into()
 }
 
-#[export_name = "Int#<"]
+#[shiika_method("Int#<")]
 pub extern "C" fn int_lt(receiver: SkInt, other: SkInt) -> SkBool {
     (receiver.val() < other.val()).into()
 }
 
-#[export_name = "Int#<="]
+#[shiika_method("Int#<=")]
 pub extern "C" fn int_le(receiver: SkInt, other: SkInt) -> SkBool {
     (receiver.val() <= other.val()).into()
 }
 
-#[export_name = "Int#>"]
+#[shiika_method("Int#>")]
 pub extern "C" fn int_gt(receiver: SkInt, other: SkInt) -> SkBool {
     (receiver.val() > other.val()).into()
 }
 
-#[export_name = "Int#>="]
+#[shiika_method("Int#>=")]
 pub extern "C" fn int_ge(receiver: SkInt, other: SkInt) -> SkBool {
     (receiver.val() >= other.val()).into()
 }
 
-#[export_name = "Int#=="]
+#[shiika_method("Int#==")]
 pub extern "C" fn int_eq(receiver: SkInt, other: SkInt) -> SkBool {
     (receiver.val() == other.val()).into()
 }
 
-#[export_name = "Int#to_f"]
+#[shiika_method("Int#to_f")]
 pub extern "C" fn int_to_f(receiver: SkInt) -> SkFloat {
     (receiver.val() as f64).into()
 }

--- a/lib/skc_rustlib/src/builtin/math.rs
+++ b/lib/skc_rustlib/src/builtin/math.rs
@@ -1,16 +1,17 @@
 use crate::builtin::SkFloat;
+use shiika_ffi_macro::shiika_method;
 
-#[export_name = "Meta:Math#sin"]
+#[shiika_method("Meta:Math#sin")]
 pub extern "C" fn math_sin(_receiver: *const u8, x: SkFloat) -> SkFloat {
     x.val().sin().into()
 }
 
-#[export_name = "Meta:Math#cos"]
+#[shiika_method("Meta:Math#cos")]
 pub extern "C" fn math_cos(_receiver: *const u8, x: SkFloat) -> SkFloat {
     x.val().cos().into()
 }
 
-#[export_name = "Meta:Math#sqrt"]
+#[shiika_method("Meta:Math#sqrt")]
 pub extern "C" fn math_sqrt(_receiver: *const u8, x: SkFloat) -> SkFloat {
     x.val().sqrt().into()
 }

--- a/lib/skc_rustlib/src/builtin/object.rs
+++ b/lib/skc_rustlib/src/builtin/object.rs
@@ -1,6 +1,7 @@
 use crate::builtin::class::{ShiikaClass, SkClass};
 use crate::builtin::{SkBool, SkInt, SkStr};
 use plain::Plain;
+use shiika_ffi_macro::shiika_method;
 use std::io::{self, Write};
 use std::mem;
 #[repr(C)]
@@ -27,23 +28,23 @@ impl SkObj {
     }
 }
 
-#[export_name = "Object#=="]
+#[shiika_method("Object#==")]
 pub extern "C" fn object_eq(receiver: *const u8, other: *const u8) -> SkBool {
     (receiver == other).into()
 }
 
-#[export_name = "Object#class"]
+#[shiika_method("Object#class")]
 pub extern "C" fn object_class(receiver: SkObj) -> SkClass {
     receiver.class()
 }
 
 // TODO: Move to `Process.exit` or something
-#[export_name = "Object#exit"]
+#[shiika_method("Object#exit")]
 pub extern "C" fn object_exit(_receiver: SkObj, code: SkInt) {
     std::process::exit(code.val() as i32);
 }
 
-#[export_name = "Object#object_id"]
+#[shiika_method("Object#object_id")]
 pub extern "C" fn object_object_id(receiver: SkObj) -> SkInt {
     unsafe {
         let i = mem::transmute::<*const ShiikaObject, i64>(receiver.0);
@@ -51,7 +52,7 @@ pub extern "C" fn object_object_id(receiver: SkObj) -> SkInt {
     }
 }
 
-#[export_name = "Object#puts"]
+#[shiika_method("Object#puts")]
 pub extern "C" fn object_puts(_receiver: *const u8, s: SkStr) {
     //TODO: Return SkVoid
     let _result = io::stdout().write_all(s.byteslice());

--- a/lib/skc_rustlib/src/builtin/shiika_internal_memory.rs
+++ b/lib/skc_rustlib/src/builtin/shiika_internal_memory.rs
@@ -5,11 +5,12 @@ use crate::allocator;
 use crate::builtin::int::SkInt;
 use crate::builtin::object::SkObj;
 use crate::builtin::shiika_internal_ptr::SkPtr;
+use shiika_ffi_macro::shiika_method;
 use std::convert::TryInto;
 use std::os::raw::c_void;
 use std::ptr;
 
-#[export_name = "Meta:Shiika::Internal::Memory#memcpy"]
+#[shiika_method("Meta:Shiika::Internal::Memory#memcpy")]
 pub extern "C" fn memory_memcpy(_receiver: SkObj, dst: SkPtr, src: SkPtr, n_bytes: SkInt) {
     let n: usize = n_bytes.val().try_into().unwrap();
     unsafe {
@@ -17,13 +18,13 @@ pub extern "C" fn memory_memcpy(_receiver: SkObj, dst: SkPtr, src: SkPtr, n_byte
     }
 }
 
-#[export_name = "Meta:Shiika::Internal::Memory#gc_malloc"]
+#[shiika_method("Meta:Shiika::Internal::Memory#gc_malloc")]
 pub extern "C" fn memory_gc_malloc(_receiver: SkObj, n_bytes: SkInt) -> SkPtr {
     let size = n_bytes.val() as usize;
     allocator::shiika_malloc(size).into()
 }
 
-#[export_name = "Meta:Shiika::Internal::Memory#gc_realloc"]
+#[shiika_method("Meta:Shiika::Internal::Memory#gc_realloc")]
 pub extern "C" fn memory_gc_realloc(_receiver: SkObj, ptr: SkPtr, n_bytes: SkInt) -> SkPtr {
     let p = ptr.unbox_mut() as *mut c_void;
     let size = n_bytes.val() as usize;

--- a/lib/skc_rustlib/src/builtin/shiika_internal_ptr.rs
+++ b/lib/skc_rustlib/src/builtin/shiika_internal_ptr.rs
@@ -3,6 +3,7 @@
 //! Should be removed once `Array`, etc. is re-implemented in skc_rustlib.
 use crate::builtin::object::ShiikaObject;
 use crate::builtin::SkInt;
+use shiika_ffi_macro::shiika_method;
 use std::convert::TryInto;
 use std::os::raw::c_void;
 extern "C" {
@@ -45,14 +46,14 @@ impl SkPtr {
     }
 }
 
-#[export_name = "Shiika::Internal::Ptr#+"]
+#[shiika_method("Shiika::Internal::Ptr#+")]
 pub extern "C" fn shiika_internal_ptr_add(receiver: SkPtr, n_bytes: SkInt) -> SkPtr {
     let p = receiver.unbox() as *const u8;
     let n = n_bytes.val().try_into().unwrap();
     unsafe { SkPtr::new(p.offset(n)) }
 }
 
-#[export_name = "Shiika::Internal::Ptr#load"]
+#[shiika_method("Shiika::Internal::Ptr#load")]
 pub extern "C" fn shiika_internal_ptr_load(receiver: SkPtr) -> *const ShiikaObject {
     unsafe {
         let p = receiver.unbox() as *const *const ShiikaObject;
@@ -60,7 +61,7 @@ pub extern "C" fn shiika_internal_ptr_load(receiver: SkPtr) -> *const ShiikaObje
     }
 }
 
-#[export_name = "Shiika::Internal::Ptr#store"]
+#[shiika_method("Shiika::Internal::Ptr#store")]
 pub extern "C" fn shiika_internal_ptr_store(receiver: SkPtr, object: *const ShiikaObject) {
     unsafe {
         let p = receiver.unbox_mut() as *mut *const ShiikaObject;
@@ -68,7 +69,7 @@ pub extern "C" fn shiika_internal_ptr_store(receiver: SkPtr, object: *const Shii
     }
 }
 
-#[export_name = "Shiika::Internal::Ptr#read"]
+#[shiika_method("Shiika::Internal::Ptr#read")]
 pub extern "C" fn shiika_internal_ptr_read(receiver: SkPtr) -> SkInt {
     unsafe {
         let b = std::ptr::read(receiver.unbox());
@@ -76,7 +77,7 @@ pub extern "C" fn shiika_internal_ptr_read(receiver: SkPtr) -> SkInt {
     }
 }
 
-#[export_name = "Shiika::Internal::Ptr#write"]
+#[shiika_method("Shiika::Internal::Ptr#write")]
 pub extern "C" fn shiika_internal_ptr_write(receiver: SkPtr, byte: SkInt) {
     unsafe {
         let p = receiver.unbox_mut();


### PR DESCRIPTION
This PR changes llvm function name for Shiika methods from `@"Array#push"` to `@Array_push`, for example.

## Motivation

I want to call Shiika methods from Rust (`skc_rustlib`) but Rust's `extern` does not allow us to use symbols other than `_` for function name.