### PR TITLE
Add Meta:Class

### DIFF
--- a/builtin/metaclass.sk
+++ b/builtin/metaclass.sk
@@ -1,6 +1,6 @@
 # Class of metaclasses
 # see also: src/corelib/
-class Metaclass
+class Metaclass : Class
   def name -> String
     if @base_name == "Metaclass"
       "Metaclass"

--- a/builtin/metaclass.sk
+++ b/builtin/metaclass.sk
@@ -10,6 +10,6 @@ class Metaclass
   end
 
   def inspect -> String
-    "#<class " + self.name + ">"
+    "#<metaclass " + self.name + ">"
   end
 end

--- a/doc/guide/src/classes.md
+++ b/doc/guide/src/classes.md
@@ -124,13 +124,30 @@ Last but not least, don't confuse this class-instance relationship with class in
 ~ ... class-instance relationship
 ^ ... superclass-subclass relationship
 
-                Object       Object       Object
-                  ^            ^            ^
-                Class     ~ MetaClass  ~ MetaClass
-                  ^
-     Object ~ Meta:Object ~ MetaClass
-        ^         ^ 
-        |         |       
-        |         |        
-123 ~  Int ~   Meta:Int   ~ MetaClass
+                    Object            Class        Class
+                      ^                 ^            ^
+                    Class          ~ Meta:Class  ~ Metaclass
+                      ^
+     Object     ~ Meta:Object      ~ Metaclass
+        ^             ^ 
+        |             |             
+123 ~  Int      ~   Meta:Int        ~ Metaclass
+```
+
+For each class, there is a class object
+
+```
+                      Object               Class                      Class
+                        ^                    ^                          ^
+                      Class             ~ Meta:Class              ~ Metaclass
+                   #<class Class>      #<metaclass Meta:Class>
+                        ^
+                        |
+     Object     ~   Meta:Object          ~ Metaclass
+  #<class Object> #<metaclass Meta:Object>
+        ^               ^ 
+        |               |             
+       Int      ~     Meta:Int           ~  Metaclass
+    #<class Int>  #<metaclass Meta:Int>    #<metaclass Metaclass>
+
 ```

--- a/lib/shiika_core/src/names.rs
+++ b/lib/shiika_core/src/names.rs
@@ -45,7 +45,7 @@ pub fn class_fullname(s: impl Into<String>) -> ClassFullname {
 pub fn metaclass_fullname(base_: impl Into<String>) -> ClassFullname {
     let base = base_.into();
     debug_assert!(!base.is_empty());
-    if base == "Class" || base == "Metaclass" || base.starts_with("Meta:") {
+    if base == "Metaclass" || base.starts_with("Meta:") {
         class_fullname("Metaclass")
     } else {
         class_fullname(&("Meta:".to_string() + &base))

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -284,6 +284,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
     }
 
     /// Register a class and its metaclass to self
+    // REFACTOR: fix too_many_arguments
     #[allow(clippy::too_many_arguments)]
     fn add_new_class(
         &mut self,
@@ -313,7 +314,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             foreign: false,
         });
 
-        // Crete metaclass (which is a subclass of `Class`)
+        // Create metaclass (which is a subclass of `Class`)
         let the_class = self.get_class(&class_fullname("Class"));
         let meta_ivars = the_class.ivars.clone();
         self.add_class(SkClass {

--- a/lib/skc_ast2hir/src/hir_maker.rs
+++ b/lib/skc_ast2hir/src/hir_maker.rs
@@ -74,10 +74,12 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         }
     }
 
-    /// Register constants which hold class object
+    /// Register constants which has the same as the class
     /// eg.
-    /// - ::Int
-    /// - ::Meta:Int
+    /// - ::Int (#<class Int>)
+    /// - ::Array (#<class Array>)
+    /// - ::Void (the only instance of the class Void)
+    /// - ::Maybe::None (the only instance of the class Maybe::None)
     pub fn define_class_constants(&mut self) {
         for (name, const_is_obj) in self.class_dict.constant_list() {
             let resolved = ResolvedConstName::unsafe_create(name);

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -264,7 +264,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         }
 
         // Initialize own constants
-        let basic_classes = vec!["::Class", "::Shiika::Internal::Ptr"];
+        let basic_classes = vec!["::Metaclass", "::Class", "::Shiika::Internal::Ptr"];
         if !is_main {
             // These builtin classes must be created first
             for name in &basic_classes {

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -159,7 +159,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         global.set_constant(true);
     }
 
-    /// Define llvm struct type for `Class`
+    /// Define llvm struct type for `Class` in advance
     fn define_class_class(&mut self) {
         self.llvm_struct_types.insert(
             class_fullname("Class"),

--- a/lib/skc_corelib/src/lib.rs
+++ b/lib/skc_corelib/src/lib.rs
@@ -45,7 +45,7 @@ fn rust_body_items() -> Vec<ClassItem> {
         ),
         (
             "Metaclass".to_string(),
-            Some(Superclass::simple("Object")),
+            Some(Superclass::simple("Class")),
             Default::default(),
             vec![],
             metaclass::ivars(),
@@ -168,10 +168,8 @@ fn make_classes(
 
         if name == "Metaclass" {
             // The class of `Metaclass` is `Metaclass` itself. So we don't need to create again
-        } else if name == "Class" {
-            // The class of `Class` is `Metaclass`. So we don't need to create again
         } else {
-            let meta_ivars = class::ivars(); // `Meta::XX` inherits `Class`
+            let meta_ivars = class::ivars();
             sk_classes.insert(
                 metaclass_fullname(&name),
                 SkClass {

--- a/tests/sk/class_hierarchy.sk
+++ b/tests/sk/class_hierarchy.sk
@@ -1,0 +1,14 @@
+unless Int.name == "Int"; puts "ng Int"; end
+unless Int.class.name == "Meta:Int"; puts "ng Meta:Int"; end
+unless Int.class.class.name == "Metaclass"; puts "ng Int Metaclass"; end
+
+unless Class.name == "Class"; puts "ng Class"; end
+unless Class.class.name == "Meta:Class"; puts "ng Meta:Class"; end
+unless Class.class.class.name == "Metaclass"; puts "ng Class Metaclass"; end
+
+metaclass = Int.class.class
+unless Metaclass == metaclass; puts "ng Metaclass"; end
+unless metaclass.name == "Metaclass"; puts "ng Metaclass"; end
+unless metaclass.class == Metaclass; puts "ng metaclass.class"; end
+
+puts "ok"


### PR DESCRIPTION
This PR adds `Meta:Class` for `Class.class`.

## Motivation

To provide APIs like `Class.foo`, there should be `Meta:Class`.