### PR TITLE
Fix class of generic objects

### DIFF
--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -862,8 +862,9 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         // For `A<B>`, create its type `Meta:A<B>`
         self.create_specialized_meta_class(meta_ty);
         // Register const `A<B>`
-        let str_idx = self.register_string_literal(&full.0);
-        let expr = Hir::class_literal(meta_ty.clone(), meta_ty.instance_ty().fullname, str_idx);
+        let name = meta_ty.instance_ty().fullname;
+        let str_idx = self.register_string_literal(&name.0);
+        let expr = Hir::class_literal(meta_ty.clone(), name, str_idx);
         self.register_const_full(full.clone(), expr);
     }
 

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -849,10 +849,16 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         let ty = ty::spe(base_ty.fullname.0, type_args);
         let full = const_fullname(&ty.fullname.0);
         let meta_ty = ty.meta_ty();
+        self.register_specialized_const(&meta_ty);
+        Ok(Hir::const_ref(meta_ty, full))
+    }
+
+    /// Register specialized class constant (eg. `::Maybe<Int>`) if not found.
+    pub fn register_specialized_const(&mut self, meta_ty: &TermTy) {
+        let full = meta_ty.to_const_fullname();
         if self._lookup_const(&full).is_none() {
             self._register_specialized_const(&meta_ty, &full);
         }
-        Ok(Hir::const_ref(meta_ty, full))
     }
 
     /// Register specialized class constant and its type.
@@ -862,9 +868,8 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         // For `A<B>`, create its type `Meta:A<B>`
         self.create_specialized_meta_class(meta_ty);
         // Register const `A<B>`
-        let name = meta_ty.instance_ty().fullname;
-        let str_idx = self.register_string_literal(&name.0);
-        let expr = Hir::class_literal(meta_ty.clone(), name, str_idx);
+        let str_idx = self.register_string_literal(&meta_ty.instance_ty().fullname.0);
+        let expr = Hir::class_literal(meta_ty.clone(), meta_ty.instance_ty().fullname, str_idx);
         self.register_const_full(full.clone(), expr);
     }
 
@@ -878,7 +883,6 @@ impl<'hir_maker> HirMaker<'hir_maker> {
     }
 
     /// Generate HIR for an array literal
-    /// `[x,y]` is expanded into `tmp = Array<Object>.new; tmp.push(x); tmp.push(y)`
     fn convert_array_literal(&mut self, item_exprs: &[AstExpression]) -> Result<HirExpression> {
         let item_exprs = item_exprs
             .iter()
@@ -902,6 +906,8 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 .expect("array literal elements type mismatch");
         }
         let ary_ty = ty::spe("Array", vec![item_ty]);
+
+        self.register_specialized_const(&ary_ty.meta_ty());
 
         Hir::array_literal(item_exprs, ary_ty)
     }

--- a/lib/skc_ast2hir/src/pattern_match.rs
+++ b/lib/skc_ast2hir/src/pattern_match.rs
@@ -193,8 +193,11 @@ fn convert_extractor(
     }
     let cast_value = Hir::bit_cast(pat_ty.clone(), value.clone());
     let mut components = extract_props(mk, &cast_value, &pat_ty, param_patterns)?;
-    mk.create_specialized_meta_class(&pat_ty.meta_ty());
-    let test = Component::Test(test_class(value, &base_ty));
+
+    // eg. In case of `Maybe::Some<Int>` first appears in the program
+    mk.register_specialized_const(&pat_ty.meta_ty());
+
+    let test = Component::Test(test_class(value, &pat_ty));
     components.insert(0, test);
     Ok(components)
 }
@@ -241,8 +244,8 @@ fn extract_props(
 }
 
 /// Create `expr.class == cls`
-fn test_class(value: &HirExpression, base_ty: &TermTy) -> HirExpression {
-    let cls_ref = Hir::const_ref(base_ty.meta_ty(), base_ty.fullname.to_const_fullname());
+fn test_class(value: &HirExpression, pat_ty: &TermTy) -> HirExpression {
+    let cls_ref = Hir::const_ref(pat_ty.meta_ty(), pat_ty.fullname.to_const_fullname());
     Hir::method_call(
         ty::raw("Bool"),
         Hir::method_call(

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -109,7 +109,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 ret_ty,
             ))),
             HirSelfExpression => Ok(Some(self.gen_self_expression(ctx, &expr.ty))),
-            HirArrayLiteral { exprs } => self.gen_array_literal(ctx, exprs),
+            HirArrayLiteral { exprs } => self.gen_array_literal(ctx, &expr.ty, exprs),
             HirFloatLiteral { value } => Ok(Some(self.gen_float_literal(*value))),
             HirDecimalLiteral { value } => Ok(Some(self.gen_decimal_literal(*value))),
             HirStringLiteral { idx } => Ok(Some(self.gen_string_literal(idx))),
@@ -798,11 +798,14 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     fn gen_array_literal(
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
+        ary_ty: &TermTy,
         exprs: &'hir [HirExpression],
     ) -> Result<Option<SkObj<'run>>> {
+        let ary_cls_ty = ary_ty.meta_ty();
+        let ary_cls_obj = self.gen_const_ref(&ary_cls_ty.to_const_fullname());
         let ary = self.call_method_func(
             &method_fullname(&metaclass_fullname("Array"), "new"),
-            self.gen_const_ref(&toplevel_const("Array")),
+            self.bitcast(ary_cls_obj, &ty::meta("Array"), "as"),
             Default::default(),
             "ary",
         );

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -707,17 +707,11 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         // (If the class have its own `#initialize`, this is equal to `class_fullname`)
         init_cls_name: &ClassFullname,
         arity: usize,
-        const_is_obj: bool,
+        _const_is_obj: bool,
     ) {
         // Allocate memory
-        let obj = if const_is_obj {
-            // Normally class object can be retrieved via constants,
-            // but there is no such constant if `const_is_obj` is true.
-            let class_obj = SkClassObj(llvm_func_args[0]);
-            self._allocate_sk_obj(class_fullname, "addr", class_obj)
-        } else {
-            self.allocate_sk_obj(class_fullname, "addr")
-        };
+        let class_obj = SkClassObj(llvm_func_args[0]);
+        let obj = self._allocate_sk_obj(class_fullname, "addr", class_obj);
 
         // Call initialize
         let addr = if init_cls_name == class_fullname {

--- a/tests/sk/class_hierarchy.sk
+++ b/tests/sk/class_hierarchy.sk
@@ -12,4 +12,6 @@ unless metaclass.name == "Metaclass"; puts "ng Metaclass"; end
 unless metaclass.class == Metaclass; puts "ng metaclass.class"; end
 
 unless Array<Int>.new.class == Array<Int>; puts "ng Array<Int>"; end
+unless [1].class == Array<Int>; puts "ng [1].class"; end
+
 puts "ok"

--- a/tests/sk/class_hierarchy.sk
+++ b/tests/sk/class_hierarchy.sk
@@ -13,5 +13,6 @@ unless metaclass.class == Metaclass; puts "ng metaclass.class"; end
 
 unless Array<Int>.new.class == Array<Int>; puts "ng Array<Int>"; end
 unless [1].class == Array<Int>; puts "ng [1].class"; end
+unless Array<Int>.name == "Array<Int>"; puts "ng Array<Int>.name"; end
 
 puts "ok"

--- a/tests/sk/class_hierarchy.sk
+++ b/tests/sk/class_hierarchy.sk
@@ -11,4 +11,5 @@ unless Metaclass == metaclass; puts "ng Metaclass"; end
 unless metaclass.name == "Metaclass"; puts "ng Metaclass"; end
 unless metaclass.class == Metaclass; puts "ng metaclass.class"; end
 
+unless Array<Int>.new.class == Array<Int>; puts "ng Array<Int>"; end
 puts "ok"


### PR DESCRIPTION
With this PR, `[1].class` returns `#<class Array<Int>>` which was returning `#<class Array>`. 

CI fails because `Some<T>.new` in `Array#first` creates an instance of `#<class Maybe::Some<T>>`. This will be fixed in next PR.

