### PR TITLE
fix broken examples

### DIFF
--- a/examples/fib.sk
+++ b/examples/fib.sk
@@ -8,4 +8,5 @@ class A
   end
 end
 a = A.new
-putd a.fib(30)
+n = 30
+puts "fib(#{n}) = #{a.fib(n)}"

--- a/examples/mandel.sk
+++ b/examples/mandel.sk
@@ -2,19 +2,26 @@
 # How to run
 #   $ cargo run -- run examples/mandel.sk > a.pbm
 #   $ open a.pbm   # With Preview.app or something
+#
+# This is not much a good example because Shiika is not designed for such
+# CPU-intensive tasks. However this was good when I just started Shiika 
+# because this program requires little language constructs and yet produces
+# a fun result.
 size = 600
-
 puts "P4"
-puts "600 600"
+puts "#{size} #{size}"
 
-ITER = 49                           # Iterations - 1 for easy for..in looping
-LIMIT_SQUARED = 4.0                 # Presquared limit
+ITER = 49
+LIMIT_SQUARED = 4.0
 
 var byte_acc = 0
 var bit_num = 0
+out = MutableString.new
 
-count_size = size - 1               # Precomputed size for easy for..in looping
+count_size = size - 1
 
+var a = 0;
+var b = 0;
 var y=0; while y <= count_size
   var x=0; while x <= count_size
     var zr = 0.0
@@ -23,8 +30,6 @@ var y=0; while y <= count_size
     ci = (2.0*y.to_f/size.to_f)-1.0
     var escape = false
 
-    # To make use of the for..in code, we use a dummy variable,
-    # like one would in C
     var dummy = 0; while dummy <= ITER
       tr = zr*zr - zi*zi + cr
       ti = 2.0*zr*zi + ci
@@ -38,27 +43,24 @@ var y=0; while y <= count_size
       dummy = dummy + 1
     end
 
-    byte_acc = (byte_acc << 1) | (escape ? 0 : 1)
+    byte_acc = byte_acc.lshift(1).or(escape ? 0 : 1)
     bit_num = bit_num + 1
 
-    # Code is very similar for these cases, but using separate blocks
-    # ensures we skip the shifting when it's unnecessary, which is most cases.
     if bit_num == 8
-      putchar byte_acc
+      out.append_byte(byte_acc)
       byte_acc = 0
       bit_num = 0
-    else 
-      if x == count_size
-        byte_acc <<= (8 - bit_num)
-        putchar byte_acc
-        byte_acc = 0
-        bit_num = 0
-      else
-        0
-      end
+      a += 1
+    elsif x == count_size
+      byte_acc = byte_acc.lshift(8 - bit_num)
+      out.append_byte(byte_acc)
+      byte_acc = 0
+      bit_num = 0
+      b += 1
     end
 
     x += 1
   end
   y += 1
 end
+print out.to_s

--- a/examples/ray.sk
+++ b/examples/ray.sk
@@ -1,4 +1,7 @@
 # orig: http://qiita.com/doxas/items/477fda867da467116f8d
+# How to run
+#   $ cargo run -- run examples/ray.sk > a.ppm
+#   $ open a.ppm   # With Preview.app or something
 
 IMAGE_WIDTH = 512
 IMAGE_HEIGHT = 512
@@ -162,9 +165,7 @@ class Util
   end
 
   def self.print_col(c: Vec) -> Void
-    putd(Util.color(c.x)); putchar(32)
-    putd(Util.color(c.y)); putchar(32)
-    putd(Util.color(c.z)); putchar(10)
+    puts "#{Util.color(c.x)} #{Util.color(c.y)} #{Util.color(c.z)}"
   end
 
   def self.intersect(ray: Ray, i: Isect) -> Void
@@ -178,7 +179,7 @@ end
 # P3\n
 puts "P3"
 # W H\n
-putd(IMAGE_WIDTH); puts " "; putd(IMAGE_HEIGHT); puts ""
+puts "#{IMAGE_WIDTH} #{IMAGE_HEIGHT}"
 # D
 puts "255"
 

--- a/lib/skc_rustlib/src/builtin/object.rs
+++ b/lib/skc_rustlib/src/builtin/object.rs
@@ -2,8 +2,9 @@ use crate::builtin::class::SkClass;
 use crate::builtin::{SkBool, SkInt, SkStr};
 use plain::Plain;
 use shiika_ffi_macro::shiika_method;
-use std::io::{self, Write};
+use std::io::{stdout, Write};
 use std::mem;
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct SkObj(*const ShiikaObject);
@@ -55,12 +56,13 @@ pub extern "C" fn object_object_id(receiver: SkObj) -> SkInt {
 #[shiika_method("Object#print")]
 pub extern "C" fn object_print(_receiver: *const u8, s: SkStr) {
     //TODO: Return SkVoid
-    let _result = io::stdout().write_all(s.as_byteslice());
+    let _ = stdout().write_all(s.as_byteslice());
+    let _ = stdout().flush();
 }
 
 #[shiika_method("Object#puts")]
 pub extern "C" fn object_puts(_receiver: *const u8, s: SkStr) {
     //TODO: Return SkVoid
-    let _result = io::stdout().write_all(s.as_byteslice());
+    let _ = stdout().write_all(s.as_byteslice());
     println!("");
 }


### PR DESCRIPTION
This PR fixes examples/*.sk which used removed methods (putd, putchar).

This PR also make `Object#print` flush stdout for concenience.
(In the future there should be a method with better performance which prints without flushing)