### PR TITLE
impl. unsafe_cast

### DIFF
--- a/builtin/object.sk
+++ b/builtin/object.sk
@@ -40,4 +40,10 @@ class Object
   def to_s -> String
     "#<#{self.class.name}:#{self.object_id}>"
   end
+
+  # Force the compiler to treat this object is an instance of `cls`.
+  # Usually you should not use this method unless to avoid compiler's bug, etc.
+  def unsafe_cast(cls: Class) -> Object
+    self
+  end
 end

--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -15,6 +15,7 @@ pub fn build(
 ) -> Result<HirExpression> {
     check_argument_types(mk, &found.sig, &receiver_hir, &mut arg_hirs)?;
     let specialized = receiver_hir.ty.is_specialized();
+    let first_arg_ty = arg_hirs.get(0).map(|x| x.ty.clone());
 
     let receiver = Hir::bit_cast(found.owner.erasure().to_term_ty(), receiver_hir);
     let args = if specialized {
@@ -27,7 +28,9 @@ pub fn build(
     };
 
     let hir = build_hir(&found, receiver, args);
-    if specialized {
+    if found.sig.fullname.full_name == "Object#unsafe_cast" {
+        Ok(Hir::bit_cast(first_arg_ty.unwrap().instance_ty(), hir))
+    } else if specialized {
         Ok(Hir::bit_cast(found.sig.ret_ty, hir))
     } else {
         Ok(hir)


### PR DESCRIPTION
This PR adds `Object#unsafe_cast`. It does nothing at runtime but forces the receiver type recognized by the compiler.

## Motivation

For workarounds of compiler bugs.

In the future, this may be useful with some meta-programming stuffs. Also, may require being enclosed by "unsafe block" (like Rust).