### PR TITLE
targets: Add .0 for clang warning

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -4,7 +4,10 @@ pub fn default_triple() -> inkwell::targets::TargetTriple {
         // #281: get_default_triple returns `darwin` but clang shows warning for it
         let arch = info.cpu_info().architecture();
         let ver = info.os_info().os_version();
-        let s = format!("{}-apple-macosx{}", arch, ver);
+        // #281: Add .0
+        let n_dots = ver.chars().filter(|c| *c == '.').count();
+        let zero = if n_dots >= 2 { "" } else { ".0" };
+        let s = format!("{}-apple-macosx{}{}", arch, ver, zero);
         inkwell::targets::TargetTriple::create(&s)
     } else {
         inkwell::targets::TargetMachine::get_default_triple()


### PR DESCRIPTION
.os_version() returns "12.3" for example but clang expects "12.3.0"

fix #281