### PR TITLE
Move `Object#panic` to rustlib

### DIFF
--- a/builtin/object.sk
+++ b/builtin/object.sk
@@ -32,11 +32,6 @@ class Object
     puts obj.inspect
   end
 
-  def panic(msg: String) -> Never
-    puts msg
-    exit 1
-  end
-
   def to_s -> String
     "#<#{self.class.name}:#{self.object_id}>"
   end

--- a/lib/skc_rustlib/provided_methods.json5
+++ b/lib/skc_rustlib/provided_methods.json5
@@ -49,6 +49,7 @@
   ["Object", "class -> Class"],
   ["Object", "exit(code: Int) -> Never"],
   ["Object", "object_id -> Int"],
+  ["Object", "panic(msg: String) -> Never"],
   ["Object", "print(str: String)"],
   ["Object", "puts(str: String)"],
   ["String", "chars -> Array<String>"],

--- a/lib/skc_rustlib/src/builtin/object.rs
+++ b/lib/skc_rustlib/src/builtin/object.rs
@@ -58,6 +58,11 @@ pub extern "C" fn object_object_id(receiver: SkObj) -> SkInt {
     }
 }
 
+#[shiika_method("Object#panic")]
+pub extern "C" fn object_panic(_receiver: *const u8, s: SkStr) {
+    panic!("{}", s.as_str());
+}
+
 #[shiika_method("Object#print")]
 pub extern "C" fn object_print(_receiver: *const u8, s: SkStr) {
     //TODO: Return SkVoid


### PR DESCRIPTION
This PR moves `Object#panic` from ./builtin to skc_rustlib. By calling Rust's `panic!`, backtrace is shown with `RUST_BACKTRACE=1`. Example:

```
/Users/yhara/proj/shiika % RUST_BACKTRACE=1 cargo run -- run ~/proj/BidirectionalTypechecking/bidi.sk
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `/Users/yhara/tmp/cargo_target/debug/shiika run /Users/yhara/proj/BidirectionalTypechecking/bidi.sk`
warning: overriding the module target triple with arm64-apple-macosx12.0.0 [-Woverride-module]
1 warning generated.
warning: overriding the module target triple with arm64-apple-macosx12.0.0 [-Woverride-module]
1 warning generated.
thread '<unnamed>' panicked at 'no matching clause found', lib/skc_rustlib/src/builtin/object.rs:63:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/e092d0b6b43f2de967af0887873151bb1c0b18d3/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/e092d0b6b43f2de967af0887873151bb1c0b18d3/library/core/src/panicking.rs:142:14
   2: core::panicking::panic_display
             at /rustc/e092d0b6b43f2de967af0887873151bb1c0b18d3/library/core/src/panicking.rs:72:5
   3: Object_panic
             at ./lib/skc_rustlib/src/builtin/object.rs:63:5
   4: _lambda_3_in_Sexp::Parser#_read_list
   5: _Object_loop
   6: _Sexp_Parser___read__list
   7: _lambda_2_in_Sexp::Parser#_read_item
   8: _Object_loop
   9: _Sexp_Parser___read__item
  10: _lambda_3_in_Sexp::Parser#_read_list
  11: _Object_loop
  12: _Sexp_Parser___read__list
  13: _lambda_2_in_Sexp::Parser#_read_item
  14: _Object_loop
  15: _Sexp_Parser___read__item
  16: _Sexp_Parser_parse
  17: _Meta_Sexp_parse
  18: _Meta_Bidi_parse
  19: _user_main
  20: _main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
fatal runtime error: failed to initiate panic, error 5
```