### PR TITLE
Infer block param

### DIFF
--- a/builtin/array.sk
+++ b/builtin/array.sk
@@ -42,7 +42,7 @@ class Array<T> : Enumerable<T>
       false
     else
       var ret = true
-      0.upto(self.length - 1) do |i: Int|
+      0.upto(self.length - 1) do |i|
         if self[i] != other[i]
           ret = false
           break
@@ -59,7 +59,7 @@ class Array<T> : Enumerable<T>
 
   # Add elements of `other` to the end of `self`
   def append(other: Array<T>)
-    other.each do |item: T|
+    other.each do |item|
       push(item)
     end
   end
@@ -67,7 +67,7 @@ class Array<T> : Enumerable<T>
   # Create shallow clone of `self`
   def clone -> Array<T>
     ret = Array<T>.new
-    each do |item: T|
+    each do |item|
       ret.push(item)
     end
     ret
@@ -76,7 +76,7 @@ class Array<T> : Enumerable<T>
   # Create an array which contains elements of `self` without first `n` elements.
   def drop(n: Int) -> Array<T>
     ret = Array<T>.new
-    n.upto(length - 1) do |i: Int|
+    n.upto(length - 1) do |i|
       ret.push(self[i])
     end
     ret
@@ -102,7 +102,7 @@ class Array<T> : Enumerable<T>
   # Returns a shallow copy of `self` which has first `n` elements (at most).
   def first_n(n: Int) -> Array<T>
     a = Array<T>.new
-    0.upto(n-1) do |i: Int|
+    0.upto(n-1) do |i|
       break if i >= length
       a.push(self[i])
     end
@@ -114,7 +114,7 @@ class Array<T> : Enumerable<T>
     var first = true
     ret = MutableString.new
     ret.append("[")
-    each do |item: T|
+    each do |item|
       if first
         first = false
       else
@@ -152,7 +152,7 @@ class Array<T> : Enumerable<T>
   # Create an array which contains items of `self` for which `f` does not return true
   def reject(f: Fn1<T, Bool>) -> Array<T>
     ret = Array<T>.new
-    each do |item: T|
+    each do |item|
       ret.push(item) unless f(item)
     end
     ret
@@ -165,7 +165,7 @@ class Array<T> : Enumerable<T>
   # Create a new array which has reversed elements of `self`
   def reverse -> Array<T>
     ret = Array<T>.new
-    reverse_each do |item: T|
+    reverse_each do |item|
       ret.push(item)
     end
     ret
@@ -250,7 +250,7 @@ class Array<T> : Enumerable<T>
   def split_at(idx: Int) -> Pair<Array<T>, Array<T>>
     a = Array<T>.new
     b = Array<T>.new
-    0.upto(length-1) do |i: Int|
+    0.upto(length-1) do |i|
       if i >= idx
         b.push(self[i])
       else

--- a/builtin/dict.sk
+++ b/builtin/dict.sk
@@ -12,7 +12,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
     # Set the value of specified key.
     def []=(key: KK, value: VV)
       var done = false
-      @pairs.each do |pair: Pair<KK, VV>|
+      @pairs.each do |pair|
         if pair.fst == key
           pair.snd = value
           done = true
@@ -26,7 +26,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
     # Get the value of specified key.
     def [](key: KK) -> Maybe<VV>
       var ret = None
-      @pairs.each do |pair: Pair<KK, VV>|
+      @pairs.each do |pair|
         if pair.fst == key
           ret = Some.new(pair.snd)
         end
@@ -37,7 +37,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
     # Return true if `self` has `key` (compared with `==`)
     def has_key?(key: KK) -> Bool
       var ret = false
-      @pairs.each do |pair: Pair<KK, VV>|
+      @pairs.each do |pair|
         if pair.fst == key
           ret = true
         end
@@ -48,7 +48,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
     # Return list of the keys
     def keys -> Array<KK>
       ret = Array<KK>.new
-      @pairs.each do |pair: Pair<KK, VV>|
+      @pairs.each do |pair|
         ret.push(pair.fst)
       end
       ret
@@ -57,7 +57,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
     # Return list of the values
     def values -> Array<VV>
       ret = Array<VV>.new
-      @pairs.each do |pair: Pair<KK, VV>|
+      @pairs.each do |pair|
         ret.push(pair.snd)
       end
       ret
@@ -70,7 +70,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
 
   def initialize
     @tables = Array<Dict::Table<K, V>>.new
-    N_TABLES.times{|_: Int| @tables.push(Dict::Table<K, V>.new) }
+    N_TABLES.times{|_| @tables.push(Dict::Table<K, V>.new) }
   end
 
   # Return the `Dict::Table` which contains the `key`
@@ -90,7 +90,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
 
   # Call `f` with each pair of `self`
   def each(f: Fn1<Pair<K, V>, Void>)
-    @tables.each do |table: Dict::Table<K, V>|
+    @tables.each do |table|
       table.each(f)
     end
   end
@@ -103,7 +103,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
   # Return list of the keys
   def keys -> Array<K>
     ret = Array<K>.new
-    @tables.each do |table: Dict::Table<K, V>|
+    @tables.each do |table|
       ret.append(table.keys)
     end
     ret
@@ -112,7 +112,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
   # Return list of the values
   def values -> Array<V>
     ret = Array<V>.new
-    @tables.each do |table: Dict::Table<K, V>|
+    @tables.each do |table|
       ret.append(table.values)
     end
     ret

--- a/builtin/enumerable.sk
+++ b/builtin/enumerable.sk
@@ -7,7 +7,7 @@ module Enumerable<E>
     ret = Array<Pair<A, B>>.new
     match [a.length, b.length].min
     when Maybe::Some(n)
-      0.upto(n-1) do |i: Int|
+      0.upto(n-1) do |i|
         ret.push(Pair<A, B>.new(a[i], b[i]))
       end
     end
@@ -17,7 +17,7 @@ module Enumerable<E>
   # Return true if `f` returns true for all element of `self`
   def all?(f: Fn1<E, Bool>) -> Bool
     var ret = true
-    self.each do |elem: E|
+    self.each do |elem|
       unless f(elem)
         ret = false
         break
@@ -29,7 +29,7 @@ module Enumerable<E>
   # Return true if `f` returns true for an element of `self`
   def any?(f: Fn1<E, Bool>) -> Bool
     var ret = false
-    each do |item: E|
+    each do |item|
       ret = true if f(item)
     end
     ret
@@ -46,7 +46,7 @@ module Enumerable<E>
   # Calculate a value by passing `sum` and `item` to `f` for each element
   def fold<SUM>(initial_sum: SUM, f: Fn2<SUM, E, SUM>) -> SUM
     var sum = initial_sum
-    each do |item: E|
+    each do |item|
       sum = f(sum, item)
     end
     sum
@@ -55,7 +55,7 @@ module Enumerable<E>
   # Return true if `self` contains `item` (compared by `==`)
   def includes?(item: E) -> Bool
     var ret = false
-    each do |x: E|
+    each do |x|
       if x == item; ret = true; end
     end
     ret
@@ -65,7 +65,7 @@ module Enumerable<E>
   def position(pred: Fn1<E, Bool>) -> Maybe<Int>
     var i = 0
     var ret = Maybe::None
-    each do |x: E|
+    each do |x|
       if pred(x)
         ret = Maybe::Some.new(i)
         break
@@ -79,7 +79,7 @@ module Enumerable<E>
   def join(separator: String) -> String
     var first = true
     ret = MutableString.new
-    each do |item: E|
+    each do |item|
       if first
         first = false
       else
@@ -93,7 +93,7 @@ module Enumerable<E>
   # Create a new array by calling `f` with each element
   def map<R>(f: Fn1<E, R>) -> Array<R>
     ret = Array<R>.new
-    self.each do |item: E|
+    self.each do |item|
       ret.push(f(item))
     end
     ret
@@ -102,7 +102,7 @@ module Enumerable<E>
   # Return true if `f` returns false for all element of `self`
   def none?(f: Fn1<E, Bool>) -> Bool
     var ret = true
-    each do |item: E|
+    each do |item|
       ret = false if f(item)
     end
     ret
@@ -111,7 +111,7 @@ module Enumerable<E>
   # Create an array which contains items of `self` for which `f` returns true
   def select(f: Fn1<E, Bool>) -> Array<E>
     ret = Array<E>.new
-    each do |item: E|
+    each do |item|
       ret.push(item) if f(item)
     end
     ret
@@ -120,7 +120,7 @@ module Enumerable<E>
   # Creates an array which contains all items of `self` 
   def to_a -> Array<E>
     ret = Array<E>.new
-    each do |item: E|
+    each do |item|
       ret.push(item)
     end
     ret
@@ -129,7 +129,7 @@ module Enumerable<E>
   # TODO: these methods should only available when `E: Comparable`
   def min -> Maybe<E>
     var ret = Maybe::None.unsafe_cast(Maybe<E>)
-    each do |item: E|
+    each do |item|
       match ret
       when Maybe::None
         ret = Maybe::Some<E>.new(item).unsafe_cast(Maybe<E>)
@@ -141,7 +141,7 @@ module Enumerable<E>
   end
   def max -> Maybe<E>
     var ret = Maybe::None.unsafe_cast(Maybe<E>)
-    each do |item: E|
+    each do |item|
       match ret
       when Maybe::None
         ret = Maybe::Some<E>.new(item).unsafe_cast(Maybe<E>)

--- a/builtin/int.sk
+++ b/builtin/int.sk
@@ -68,7 +68,7 @@ class Int
       ret.append("-") 
       i = 1
     end
-    a.reverse_each do |b: Int|
+    a.reverse_each do |b|
       ret.write_byte(i, b)
       i += 1
     end

--- a/builtin/result.sk
+++ b/builtin/result.sk
@@ -2,6 +2,10 @@ enum Result<V>
   case Ok(value: V)
   case Fail(err: Error)
 
+  def self.fail<V>(msg: String) -> Fail<V>
+    Fail<V>.new(Error.new(msg))
+  end
+
   def fail? -> Bool
     match self
     when Fail(_) then true
@@ -13,6 +17,13 @@ enum Result<V>
     match self
     when Ok(_) then true
     else false
+    end
+  end
+
+  def inspect -> String
+    match self
+    when Ok(v) then "#<Ok(\{v})>"
+    when Fail(e) then "#<Fail(\{e})>"
     end
   end
 end

--- a/builtin/string.sk
+++ b/builtin/string.sk
@@ -22,7 +22,7 @@ class String
   # Create a string by repeating `self` for `n` times
   def *(n: Int) -> String
     ret = MutableString.new
-    n.times do |_: Int|
+    n.times do |_|
       ret.append(self)
     end
     ret._unsafe_to_s
@@ -47,7 +47,7 @@ class String
   # Create an array of bytes of `self`
   def bytes -> Array<Int>
     ret = Array<Int>.new
-    each_byte do |b: Int|
+    each_byte do |b|
       ret.push(b)
     end
     ret
@@ -55,7 +55,7 @@ class String
 
   # Call `f` for each byte
   def each_byte(f: Fn1<Int, Void>) 
-    @bytesize.times do |i: Int|
+    @bytesize.times do |i|
       f(nth_byte(i))
     end
   end
@@ -63,7 +63,7 @@ class String
   # Call `f` for each char
   # TODO: support multibyte
   def each_char(f: Fn1<String, Void>)
-    @bytesize.times do |i: Int|
+    @bytesize.times do |i|
       f(slice_bytes(i, 1))
     end
   end

--- a/lib/shiika_ast/src/lib.rs
+++ b/lib/shiika_ast/src/lib.rs
@@ -100,6 +100,12 @@ pub struct Param {
 }
 
 #[derive(Debug, PartialEq, Clone)]
+pub struct BlockParam {
+    pub name: String,
+    pub opt_typ: Option<UnresolvedTypeName>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
 pub struct AstExpression {
     pub body: AstExpressionBody,
     pub primary: bool,
@@ -160,7 +166,7 @@ pub enum AstExpressionBody {
         may_have_paren_wo_args: bool,
     },
     LambdaExpr {
-        params: Vec<Param>,
+        params: Vec<BlockParam>,
         exprs: Vec<AstExpression>,
         /// true if this is from `fn(){}`. false if this is a block (do-end/{})
         is_fn: bool,
@@ -411,7 +417,11 @@ pub fn bin_op_expr(left: AstExpression, op: &str, right: AstExpression) -> AstEx
     })
 }
 
-pub fn lambda_expr(params: Vec<Param>, exprs: Vec<AstExpression>, is_fn: bool) -> AstExpression {
+pub fn lambda_expr(
+    params: Vec<BlockParam>,
+    exprs: Vec<AstExpression>,
+    is_fn: bool,
+) -> AstExpression {
     primary_expression(AstExpressionBody::LambdaExpr {
         params,
         exprs,

--- a/lib/shiika_ast/src/lib.rs
+++ b/lib/shiika_ast/src/lib.rs
@@ -163,6 +163,7 @@ pub enum AstExpressionBody {
         method_name: MethodFirstname,
         arg_exprs: Vec<AstExpression>,
         type_args: Vec<AstExpression>,
+        has_block: bool,
         may_have_paren_wo_args: bool,
     },
     LambdaExpr {
@@ -340,6 +341,7 @@ pub fn assignment(lhs: AstExpression, rhs: AstExpression) -> AstExpression {
                 method_name: method_name.append("="),
                 arg_exprs,
                 type_args: vec![],
+                has_block: false,
                 may_have_paren_wo_args: false,
             }
         }
@@ -378,6 +380,7 @@ pub fn method_call(
     arg_exprs: Vec<AstExpression>,
     type_args: Vec<AstExpression>,
     primary: bool,
+    has_block: bool,
     may_have_paren_wo_args: bool,
 ) -> AstExpression {
     AstExpression {
@@ -387,6 +390,7 @@ pub fn method_call(
             method_name: method_firstname(method_name),
             arg_exprs,
             type_args,
+            has_block,
             may_have_paren_wo_args,
         },
         locs: LocationSpan::todo(),
@@ -403,6 +407,7 @@ pub fn unary_expr(expr: AstExpression, op: &str) -> AstExpression {
         method_name: method_firstname(op),
         arg_exprs: vec![],
         type_args: vec![],
+        has_block: false,
         may_have_paren_wo_args: false,
     })
 }
@@ -413,6 +418,7 @@ pub fn bin_op_expr(left: AstExpression, op: &str, right: AstExpression) -> AstEx
         method_name: method_firstname(op),
         arg_exprs: vec![right],
         type_args: vec![],
+        has_block: false,
         may_have_paren_wo_args: false,
     })
 }
@@ -447,7 +453,11 @@ pub fn non_primary_expression(body: AstExpressionBody) -> AstExpression {
 
 /// Extend `foo.bar` to `foo.bar args`
 /// (expr must be a MethodCall or a BareName)
-pub fn set_method_call_args(expr: AstExpression, args: Vec<AstExpression>) -> AstExpression {
+pub fn set_method_call_args(
+    expr: AstExpression,
+    args: Vec<AstExpression>,
+    has_block: bool,
+) -> AstExpression {
     match expr.body {
         AstExpressionBody::MethodCall {
             receiver_expr,
@@ -470,6 +480,7 @@ pub fn set_method_call_args(expr: AstExpression, args: Vec<AstExpression>) -> As
                     method_name,
                     arg_exprs: args,
                     type_args,
+                    has_block,
                     may_have_paren_wo_args: false,
                 },
                 locs: LocationSpan::todo(),
@@ -482,6 +493,7 @@ pub fn set_method_call_args(expr: AstExpression, args: Vec<AstExpression>) -> As
                 method_name: method_firstname(s),
                 arg_exprs: args,
                 type_args: vec![],
+                has_block,
                 may_have_paren_wo_args: false,
             },
             locs: LocationSpan::todo(),

--- a/lib/shiika_core/src/ty/term_ty.rs
+++ b/lib/shiika_core/src/ty/term_ty.rs
@@ -118,8 +118,8 @@ impl TermTy {
         }
     }
 
-    // Returns ret_ty if this is any of Fn0, .., Fn9
-    pub fn fn_x_info(&self) -> Option<TermTy> {
+    // If this is any of Fn0, .., Fn9, returns its type arguments.
+    pub fn fn_x_info(&self) -> Option<&[TermTy]> {
         match &self.body {
             TyRaw(LitTy {
                 base_name,
@@ -131,8 +131,7 @@ impl TermTy {
                 }
                 for i in 0..=9 {
                     if *base_name == format!("Fn{}", i) {
-                        let ret_ty = type_args.last().unwrap().clone();
-                        return Some(ret_ty);
+                        return Some(type_args);
                     }
                 }
                 None

--- a/lib/shiika_parser/src/definition_parser.rs
+++ b/lib/shiika_parser/src/definition_parser.rs
@@ -617,7 +617,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_typ(&mut self) -> Result<UnresolvedTypeName, Error> {
+    pub(super) fn parse_typ(&mut self) -> Result<UnresolvedTypeName, Error> {
         match self.current_token() {
             Token::UpperWord(s) => {
                 let head = s.to_string();

--- a/lib/skc_ast2hir/src/class_dict/found_method.rs
+++ b/lib/skc_ast2hir/src/class_dict/found_method.rs
@@ -1,34 +1,31 @@
+use shiika_core::names::TypeFullname;
 use shiika_core::ty::TermTy;
 use skc_hir::{MethodSignature, SkType};
 
 #[derive(Debug, Clone)]
-pub struct FoundMethod<'hir_maker> {
+pub struct FoundMethod {
     /// A Shiika class or Shiika module
-    pub owner: &'hir_maker SkType,
+    pub owner: TypeFullname,
     /// The signature of the method
     pub sig: MethodSignature,
     /// Index in the method list of `owner` (used for module method call via wtable)
     pub method_idx: Option<usize>,
 }
 
-impl<'hir_maker> FoundMethod<'hir_maker> {
-    pub fn class(owner: &'hir_maker SkType, sig: MethodSignature) -> FoundMethod<'hir_maker> {
+impl FoundMethod {
+    pub fn class(owner: &SkType, sig: MethodSignature) -> FoundMethod {
         debug_assert!(owner.is_class());
         FoundMethod {
-            owner,
+            owner: owner.fullname(),
             sig,
             method_idx: None,
         }
     }
 
-    pub fn module(
-        owner: &'hir_maker SkType,
-        sig: MethodSignature,
-        idx: usize,
-    ) -> FoundMethod<'hir_maker> {
+    pub fn module(owner: &SkType, sig: MethodSignature, idx: usize) -> FoundMethod {
         debug_assert!(!owner.is_class());
         FoundMethod {
-            owner,
+            owner: owner.fullname(),
             sig,
             method_idx: Some(idx),
         }
@@ -38,18 +35,18 @@ impl<'hir_maker> FoundMethod<'hir_maker> {
         self.sig = self.sig.specialize(class_tyargs, method_tyargs);
     }
 
-    pub fn set_class(&self, owner: &'hir_maker SkType) -> FoundMethod<'hir_maker> {
+    pub fn set_class(&self, owner: &SkType) -> FoundMethod {
         debug_assert!(owner.is_class());
         FoundMethod {
-            owner,
+            owner: owner.fullname(),
             ..self.clone()
         }
     }
 
-    pub fn set_module(&self, owner: &'hir_maker SkType) -> FoundMethod<'hir_maker> {
+    pub fn set_module(&self, owner: &SkType) -> FoundMethod {
         debug_assert!(!owner.is_class());
         FoundMethod {
-            owner,
+            owner: owner.fullname(),
             ..self.clone()
         }
     }

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -1,5 +1,6 @@
 use crate::class_dict::build_wtable::build_wtable;
 use crate::class_dict::*;
+use crate::convert_exprs::params;
 use crate::error;
 use crate::parse_typarams;
 use anyhow::Result;
@@ -220,7 +221,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             defs.iter().find(|d| d.is_initializer())
         {
             // Has explicit initializer definition
-            self.convert_params(namespace, &sig.params, typarams, Default::default())
+            params::convert_params(self, namespace, &sig.params, typarams, Default::default())
         } else {
             // Inherit #initialize from superclass
             let found = self
@@ -518,7 +519,8 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         Ok(MethodSignature {
             fullname,
             ret_ty,
-            params: self.convert_params(
+            params: params::convert_params(
+                self,
                 namespace,
                 &sig.params,
                 class_typarams,
@@ -528,31 +530,9 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         })
     }
 
-    /// Convert ast params to hir params
-    pub fn convert_params(
-        &self,
-        namespace: &Namespace,
-        ast_params: &[shiika_ast::Param],
-        class_typarams: &[ty::TyParam],
-        method_typarams: &[ty::TyParam],
-    ) -> Result<Vec<MethodParam>> {
-        let mut hir_params = vec![];
-        for param in ast_params {
-            hir_params.push(MethodParam {
-                name: param.name.to_string(),
-                ty: self._resolve_typename(
-                    namespace,
-                    class_typarams,
-                    method_typarams,
-                    &param.typ,
-                )?,
-            });
-        }
-        Ok(hir_params)
-    }
-
     /// Resolve the given type name to fullname
-    fn _resolve_typename(
+    // TODO: Remove `_`
+    pub fn _resolve_typename(
         &self,
         namespace: &Namespace,
         class_typarams: &[ty::TyParam],

--- a/lib/skc_ast2hir/src/class_dict/query.rs
+++ b/lib/skc_ast2hir/src/class_dict/query.rs
@@ -16,11 +16,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             .and_then(|sk_type| self._find_method(sk_type, method_name))
     }
 
-    fn _find_method(
-        &self,
-        sk_type: &'hir_maker SkType,
-        method_name: &MethodFirstname,
-    ) -> Option<FoundMethod<'hir_maker>> {
+    fn _find_method(&self, sk_type: &SkType, method_name: &MethodFirstname) -> Option<FoundMethod> {
         match sk_type {
             SkType::Class(sk_class) => sk_class
                 .base

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -1,4 +1,4 @@
-mod block;
+pub mod block;
 mod method_call;
 pub mod params;
 use crate::class_expr;

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -1,4 +1,6 @@
+mod block;
 mod method_call;
+pub mod params;
 use crate::class_expr;
 use crate::error;
 use crate::hir_maker::extract_lvars;
@@ -105,8 +107,15 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 method_name,
                 arg_exprs,
                 type_args,
+                has_block,
                 ..
-            } => self.convert_method_call(receiver_expr, method_name, arg_exprs, type_args),
+            } => self.convert_method_call(
+                receiver_expr,
+                method_name,
+                arg_exprs,
+                has_block,
+                type_args,
+            ),
 
             AstExpressionBody::LambdaExpr {
                 params,
@@ -443,18 +452,25 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         receiver_expr: &Option<Box<AstExpression>>,
         method_name: &MethodFirstname,
         arg_exprs: &[AstExpression],
+        has_block: &bool,
         type_args: &[AstExpression],
     ) -> Result<HirExpression> {
-        let arg_hirs = arg_exprs
-            .iter()
-            .map(|arg_expr| self.convert_expr(arg_expr))
-            .collect::<Result<Vec<_>, _>>()?;
-
         // Check if this is a lambda invocation
         if receiver_expr.is_none() {
             if let Some(lvar) = self._lookup_var(&method_name.0) {
-                if let Some(ret_ty) = lvar.ty.fn_x_info() {
-                    return Ok(Hir::lambda_invocation(ret_ty, lvar.ref_expr(), arg_hirs));
+                if let Some(tys) = lvar.ty.fn_x_info() {
+                    let arg_hirs = method_call::convert_method_args(
+                        self,
+                        &block::BlockTaker::Function(&lvar.ty),
+                        arg_exprs,
+                        has_block, // true if `f(){ ... }`, for example.
+                    )?;
+                    let ret_ty = tys.last().unwrap();
+                    return Ok(Hir::lambda_invocation(
+                        ret_ty.clone(),
+                        lvar.ref_expr(),
+                        arg_hirs,
+                    ));
                 }
             }
         }
@@ -465,15 +481,19 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             _ => self.convert_self_expr(&LocationSpan::todo()),
         };
         let mut method_tyargs = vec![];
-        for arg in type_args {
-            method_tyargs.push(self._resolve_method_tyarg(arg)?);
+        for tyarg in type_args {
+            method_tyargs.push(self._resolve_method_tyarg(tyarg)?);
         }
-        let found = self.class_dict.lookup_method(
-            &receiver_hir.ty,
-            method_name,
-            method_tyargs.as_slice(),
+        let found = self
+            .class_dict
+            .lookup_method(&receiver_hir.ty, method_name, method_tyargs.as_slice())?
+            .clone();
+        let arg_hirs = method_call::convert_method_args(
+            self,
+            &block::BlockTaker::Method(found.sig.clone()),
+            arg_exprs,
+            has_block,
         )?;
-        // Check the arguments and create HirMethodCall or HirModuleMethodCall
         method_call::build(self, found, receiver_hir, arg_hirs)
     }
 
@@ -490,16 +510,22 @@ impl<'hir_maker> HirMaker<'hir_maker> {
 
     pub(super) fn convert_lambda_expr(
         &mut self,
-        params: &[shiika_ast::Param],
+        params: &[shiika_ast::BlockParam],
         exprs: &[AstExpression],
         is_fn: &bool,
     ) -> Result<HirExpression> {
+        // This method only handles `fn(){}` because blocks are handled in
+        // convert_method_call.
+        debug_assert!(is_fn);
+
         let namespace = self.ctx_stack.const_scopes().next().unwrap();
-        let hir_params = self.class_dict.convert_params(
+        let hir_params = params::convert_block_params(
+            &self.class_dict,
             &namespace,
             params,
             &self.ctx_stack.current_class_typarams(),
             &self.ctx_stack.current_method_typarams(),
+            Default::default(),
         )?;
 
         // Convert lambda body
@@ -508,7 +534,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         let hir_exprs = self.convert_exprs(exprs)?;
         let mut lambda_ctx = self.ctx_stack.pop_lambda_ctx();
         Ok(Hir::lambda_expr(
-            lambda_ty(&hir_params, &hir_exprs.ty),
+            block::lambda_ty(&hir_params, &hir_exprs.ty),
             self.create_lambda_name(),
             hir_params,
             hir_exprs,
@@ -910,10 +936,4 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         self.str_literals.push(content.to_string());
         idx
     }
-}
-
-fn lambda_ty(params: &[MethodParam], ret_ty: &TermTy) -> TermTy {
-    let mut tyargs = params.iter().map(|x| x.ty.clone()).collect::<Vec<_>>();
-    tyargs.push(ret_ty.clone());
-    ty::spe(&format!("Fn{}", params.len()), tyargs)
 }

--- a/lib/skc_ast2hir/src/convert_exprs/block.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/block.rs
@@ -1,0 +1,83 @@
+use crate::convert_exprs::params;
+use crate::hir_maker::{extract_lvars, HirMaker};
+use crate::hir_maker_context::HirMakerContext;
+use crate::type_system::type_checking;
+use anyhow::Result;
+use shiika_ast::{AstExpression, AstExpressionBody};
+use shiika_core::ty::{self, TermTy};
+use skc_hir::{Hir, HirExpression, MethodParam, MethodSignature};
+
+/// Type information of the method or fn which takes the block.
+#[derive(Debug)]
+pub enum BlockTaker<'hir_maker> {
+    Method(MethodSignature),
+    Function(&'hir_maker TermTy),
+}
+
+/// Convert a block to HirLambdaExpr.
+/// `arg_expr` must be a LambdaExpr.
+pub fn convert_block(
+    mk: &mut HirMaker,
+    block_taker: &BlockTaker,
+    arg_expr: &AstExpression,
+) -> Result<HirExpression> {
+    match &arg_expr.body {
+        AstExpressionBody::LambdaExpr {
+            params,
+            exprs,
+            is_fn,
+        } => {
+            debug_assert!(!is_fn);
+            _convert_block(mk, block_taker, params, exprs)
+        }
+        _ => panic!("expected LambdaExpr but got {:?}", arg_expr),
+    }
+}
+
+/// Convert a block to HirLambdaExpr
+/// Types of block parameters are inferred from `block_ty` (arg_ty1, arg_ty2, ..., ret_ty)
+fn _convert_block(
+    mk: &mut HirMaker,
+    block_taker: &BlockTaker,
+    params: &[shiika_ast::BlockParam],
+    body_exprs: &[AstExpression],
+) -> Result<HirExpression> {
+    let method_sig = if let BlockTaker::Method(sig) = block_taker {
+        sig
+    } else {
+        todo!();
+    };
+    type_checking::check_block_arity(method_sig, params)?;
+
+    let namespace = mk.ctx_stack.const_scopes().next().unwrap();
+    let block_ty = method_sig.block_ty().unwrap();
+    let hir_params = params::convert_block_params(
+        &mk.class_dict,
+        &namespace,
+        params,
+        &mk.ctx_stack.current_class_typarams(),
+        &mk.ctx_stack.current_method_typarams(),
+        block_ty,
+    )?;
+
+    // Convert lambda body
+    mk.ctx_stack
+        .push(HirMakerContext::lambda(false, hir_params.clone()));
+    let hir_exprs = mk.convert_exprs(body_exprs)?;
+    let mut lambda_ctx = mk.ctx_stack.pop_lambda_ctx();
+    Ok(Hir::lambda_expr(
+        lambda_ty(&hir_params, &hir_exprs.ty),
+        mk.create_lambda_name(),
+        hir_params,
+        hir_exprs,
+        mk._resolve_lambda_captures(lambda_ctx.captures), // hir_captures
+        extract_lvars(&mut lambda_ctx.lvars),             // lvars
+        lambda_ctx.has_break,
+    ))
+}
+
+pub fn lambda_ty(params: &[MethodParam], ret_ty: &TermTy) -> TermTy {
+    let mut tyargs = params.iter().map(|x| x.ty.clone()).collect::<Vec<_>>();
+    tyargs.push(ret_ty.clone());
+    ty::spe(&format!("Fn{}", params.len()), tyargs)
+}

--- a/lib/skc_ast2hir/src/convert_exprs/params.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/params.rs
@@ -1,0 +1,73 @@
+//! Handles method parameters and block parameters.
+//!
+//! - Method parameters always has type annotations.
+//! - Block parameters may not have type annotations. In this case, the type
+//!   is inferred from the method signature.
+//!   eg:
+//!
+//! ```sk
+//! [1,2,3].each{|i| p i}
+//! # `i` is inferred as `Int` from the signature of `Array<Int>#each`.
+//! ```
+use crate::class_dict::ClassDict;
+use crate::convert_exprs::MethodParam;
+use anyhow::Result;
+use shiika_core::names::Namespace;
+use shiika_core::ty::{self, TermTy};
+
+/// Convert `shiika_ast::Param`s to hir params.
+pub fn convert_params(
+    class_dict: &ClassDict,
+    namespace: &Namespace,
+    ast_params: &[shiika_ast::Param],
+    class_typarams: &[ty::TyParam],
+    method_typarams: &[ty::TyParam],
+) -> Result<Vec<MethodParam>> {
+    let mut hir_params = vec![];
+    for param in ast_params {
+        let ty =
+            class_dict._resolve_typename(namespace, class_typarams, method_typarams, &param.typ)?;
+        hir_params.push(MethodParam {
+            name: param.name.to_string(),
+            ty: ty.clone(),
+        });
+    }
+    Ok(hir_params)
+}
+
+/// Convert `shiika_ast::BlockParam`s to hir params.
+/// Type annotation is optional for block parameters. If not provided, it will
+/// be inferred from the signature of the method that takes the block.
+pub fn convert_block_params(
+    class_dict: &ClassDict,
+    namespace: &Namespace,
+    ast_params: &[shiika_ast::BlockParam],
+    class_typarams: &[ty::TyParam],
+    // Blocks cannot have type parameters. However, it is allowed to refer to
+    // the typarams of the current method.
+    method_typarams: &[ty::TyParam],
+    // `[arg1_ty, arg2_ty, ..., ret_ty]`
+    type_hint: &[TermTy],
+) -> Result<Vec<MethodParam>> {
+    let mut hir_params = vec![];
+    for (i, param) in ast_params.iter().enumerate() {
+        let hir_param = if let Some(typ) = &param.opt_typ {
+            // Has type annotation `typ`
+            let ty =
+                class_dict._resolve_typename(namespace, class_typarams, method_typarams, typ)?;
+            MethodParam {
+                name: param.name.to_string(),
+                ty: ty.clone(),
+            }
+        } else {
+            // Infer from hint
+            let ty = type_hint.get(i).expect("type hint not found");
+            MethodParam {
+                name: param.name.to_string(),
+                ty: ty.clone(),
+            }
+        };
+        hir_params.push(hir_param);
+    }
+    Ok(hir_params)
+}

--- a/lib/skc_ast2hir/src/hir_maker.rs
+++ b/lib/skc_ast2hir/src/hir_maker.rs
@@ -377,7 +377,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             &method_firstname("initialize"),
             Default::default(),
         )?;
-        let fullname = found.owner.base().fullname_();
+        let fullname = found.owner.as_class_fullname();
         Ok((method_fullname(&fullname, "initialize"), fullname))
     }
 

--- a/lib/skc_ast2hir/src/type_system/subtyping.rs
+++ b/lib/skc_ast2hir/src/type_system/subtyping.rs
@@ -76,8 +76,8 @@ fn class_conforms_to_class(c: &ClassDict, ty1: &TermTy, ty2: &TermTy) -> bool {
 
 /// Returns if `ty` is a void-returning function (eg. `Fn1<Int, Void>`)
 fn is_void_fn(ty: &TermTy) -> bool {
-    if let Some(ret_ty) = ty.fn_x_info() {
-        ret_ty.is_void_type()
+    if let Some(tys) = ty.fn_x_info() {
+        tys.last().unwrap().is_void_type()
     } else {
         false
     }

--- a/lib/skc_ast2hir/src/type_system/type_checking.rs
+++ b/lib/skc_ast2hir/src/type_system/type_checking.rs
@@ -1,4 +1,5 @@
 use crate::class_dict::ClassDict;
+use crate::convert_exprs::block::BlockTaker;
 use crate::error::type_error;
 use anyhow::Result;
 use ariadne::{Label, Report, ReportKind, Source};
@@ -180,13 +181,19 @@ fn check_arg_type(
 }
 
 /// Check number of block parameters
-pub fn check_block_arity(sig: &MethodSignature, params: &[shiika_ast::BlockParam]) -> Result<()> {
-    let block_ty = sig.block_ty().unwrap();
-    if params.len() != block_ty.len() - 1 {
+pub fn check_block_arity(
+    block_taker: &BlockTaker,
+    params: &[shiika_ast::BlockParam],
+) -> Result<()> {
+    let expected = match block_taker {
+        BlockTaker::Method(sig) => sig.block_ty().unwrap().len() - 1,
+        BlockTaker::Function(fn_ty) => fn_ty.fn_x_info().unwrap().len() - 1,
+    };
+    if params.len() != expected {
         return Err(type_error!(
             "the block of {} takes {} args but got {}",
-            sig.fullname,
-            sig.params.len(),
+            block_taker,
+            expected,
             params.len()
         ));
     }

--- a/lib/skc_ast2hir/src/type_system/type_checking.rs
+++ b/lib/skc_ast2hir/src/type_system/type_checking.rs
@@ -2,6 +2,7 @@ use crate::class_dict::ClassDict;
 use crate::error::type_error;
 use anyhow::Result;
 use ariadne::{Label, Report, ReportKind, Source};
+use shiika_ast;
 use shiika_core::{ty, ty::*};
 use skc_hir::*;
 use std::fs;
@@ -176,4 +177,18 @@ fn check_arg_type(
         .write((&path, src), &mut report)
         .unwrap();
     return Err(type_error(String::from_utf8_lossy(&report).to_string()));
+}
+
+/// Check number of block parameters
+pub fn check_block_arity(sig: &MethodSignature, params: &[shiika_ast::BlockParam]) -> Result<()> {
+    let block_ty = sig.block_ty().unwrap();
+    if params.len() != block_ty.len() - 1 {
+        return Err(type_error!(
+            "the block of {} takes {} args but got {}",
+            sig.fullname,
+            sig.params.len(),
+            params.len()
+        ));
+    }
+    Ok(())
 }

--- a/lib/skc_hir/src/signature.rs
+++ b/lib/skc_hir/src/signature.rs
@@ -18,6 +18,11 @@ impl MethodSignature {
         &self.fullname.first_name
     }
 
+    /// If this method takes a block, returns types of block params and block value.
+    pub fn block_ty(&self) -> Option<&[TermTy]> {
+        self.params.last().and_then(|param| param.ty.fn_x_info())
+    }
+
     /// Substitute type parameters with type arguments
     pub fn specialize(&self, class_tyargs: &[TermTy], method_tyargs: &[TermTy]) -> MethodSignature {
         MethodSignature {

--- a/lib/skc_hir/src/signature.rs
+++ b/lib/skc_hir/src/signature.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use shiika_core::{names::*, ty, ty::*};
+use std::fmt;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MethodSignature {
@@ -7,6 +8,12 @@ pub struct MethodSignature {
     pub ret_ty: TermTy,
     pub params: Vec<MethodParam>,
     pub typarams: Vec<TyParam>,
+}
+
+impl fmt::Display for MethodSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.fullname)
+    }
 }
 
 impl MethodSignature {


### PR DESCRIPTION
With this PR, type annotations are no more mandatory for block parameters. For example: d304868f646af4bd612da040a7725ebf52186e3d