### PR TITLE
Add proc macro for calling Shiika method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -670,6 +670,7 @@ version = "0.1.0"
 name = "shiika_ffi_macro"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "shiika_ffi",
  "syn",

--- a/lib/shiika_ffi_macro/Cargo.toml
+++ b/lib/shiika_ffi_macro/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 shiika_ffi = { path = "../shiika_ffi" }
 syn = { version = "1.0.82", features = ["full"] }
 quote = "1.0"
+proc-macro2 = "1.0.43"

--- a/lib/shiika_ffi_macro/README.md
+++ b/lib/shiika_ffi_macro/README.md
@@ -1,3 +1,3 @@
 # shiika_ffi_macro
 
-This crate provides `#[shiika_method(...)]` attribute which expands into `#[export_name = "..."]`.
+This crate provides Rust macros to deal with Shiika objects and methods.

--- a/lib/shiika_ffi_macro/src/lib.rs
+++ b/lib/shiika_ffi_macro/src/lib.rs
@@ -1,17 +1,19 @@
+mod shiika_method_ref;
 use proc_macro::TokenStream;
 use quote::quote;
 use shiika_ffi::mangle_method;
+use shiika_method_ref::ShiikaMethodRef;
 use syn::parse_macro_input;
 
-// Export this function as the name callable as Shiika method.
-//
-// ## Example
-//
-// ```rust
-// #[shiika_method("Class#_initialize_rustlib")]
-// #[allow(non_snake_case)]
-// pub extern "C" fn class__initialize_rustlib(
-// ```
+/// Export this function as the name callable as Shiika method.
+///
+/// ## Example
+///
+/// ```rust
+/// #[shiika_method("Class#_initialize_rustlib")]
+/// #[allow(non_snake_case)]
+/// pub extern "C" fn class__initialize_rustlib(
+/// ```
 #[proc_macro_attribute]
 pub fn shiika_method(args: TokenStream, input: TokenStream) -> TokenStream {
     let method_name = parse_macro_input!(args as syn::LitStr);
@@ -21,6 +23,36 @@ pub fn shiika_method(args: TokenStream, input: TokenStream) -> TokenStream {
     let gen = quote! {
         #[export_name = #mangled_name]
         #function_definition
+    };
+    gen.into()
+}
+
+/// Define a wrapper function to call Shiika method.
+///
+/// ## Example
+/// ```rust
+/// shiika_method_ref!(
+///     "Meta:Class#new", // Shiika method name
+///     fn(receiver: *const u8) -> SkAry<SkObj>, // Type of the function
+///     "meta_class_new" // Name of the function
+/// );
+/// ```
+#[proc_macro]
+pub fn shiika_method_ref(input: TokenStream) -> TokenStream {
+    let spec = parse_macro_input!(input as ShiikaMethodRef);
+    let mangled_name = spec.mangled_name();
+    let parameters = &spec.parameters;
+    let return_type = &spec.ret_ty;
+    let wrapper_name = spec.wrapper_name();
+    let args = spec.forwaring_args();
+    let gen = quote! {
+        extern "C" {
+            #[allow(improper_ctypes)]
+            fn #mangled_name(#parameters) -> #return_type;
+        }
+        pub fn #wrapper_name(#parameters) -> #return_type {
+            unsafe { #mangled_name(#args) }
+        }
     };
     gen.into()
 }

--- a/lib/shiika_ffi_macro/src/shiika_method_ref.rs
+++ b/lib/shiika_ffi_macro/src/shiika_method_ref.rs
@@ -1,0 +1,53 @@
+use proc_macro2::{Ident, Span};
+use shiika_ffi::mangle_method;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{parenthesized, Field, Result, Token};
+
+/// Helper struct for `shiika_method_ref` macro
+pub struct ShiikaMethodRef {
+    pub method_name: syn::LitStr,
+    pub parameters: Punctuated<Field, Token![,]>,
+    pub ret_ty: syn::Type,
+    pub rust_func_name: syn::LitStr,
+}
+
+impl Parse for ShiikaMethodRef {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let method_name = input.parse()?;
+        let _: Token![,] = input.parse()?;
+        let _: Token![fn] = input.parse()?;
+        let content;
+        let _: syn::token::Paren = parenthesized!(content in input);
+        let parameters = content.parse_terminated(Field::parse_named)?;
+        let _: Token![->] = input.parse()?;
+        let ret_ty = input.parse()?;
+        let _: Token![,] = input.parse()?;
+        let rust_func_name = input.parse()?;
+        Ok(ShiikaMethodRef {
+            method_name,
+            parameters,
+            ret_ty,
+            rust_func_name,
+        })
+    }
+}
+
+impl ShiikaMethodRef {
+    /// Returns mangled llvm func name (eg. `Meta_Class_new`)
+    pub fn mangled_name(&self) -> Ident {
+        Ident::new(&mangle_method(&self.method_name.value()), Span::call_site())
+    }
+
+    /// Returns user-specified func name. (eg. `meta_class_new`)
+    pub fn wrapper_name(&self) -> Ident {
+        Ident::new(&self.rust_func_name.value(), Span::call_site())
+    }
+
+    /// Returns list of parameters for forwarding function call (eg. `a, b, c`)
+    pub fn forwaring_args(&self) -> Punctuated<Ident, Token![,]> {
+        self.parameters.iter().map(|field| {
+            field.ident.clone().expect("Field::ident is None. why?")
+        }).collect()
+    }
+}

--- a/lib/skc_rustlib/src/builtin/array.rs
+++ b/lib/skc_rustlib/src/builtin/array.rs
@@ -1,12 +1,6 @@
 use crate::builtin::{SkInt, SkObj};
+use crate::sk_methods::meta_array_new;
 use shiika_ffi_macro::shiika_method;
-
-extern "C" {
-    /// `Array.new`
-    /// `receiver` should be the class `Array` but currently may be just `null`.
-    #[allow(improper_ctypes)]
-    fn Meta_Array_new(receiver: *const u8) -> SkAry<SkObj>;
-}
 
 #[repr(C)]
 #[derive(Debug)]
@@ -23,12 +17,10 @@ struct ShiikaArray<T> {
 impl<T> SkAry<T> {
     /// Call `Array.new`.
     pub fn new<U>() -> SkAry<U> {
-        unsafe {
-            let sk_ary = Meta_Array_new(std::ptr::null());
-            // Force cast because external function (Meta_Array_new)
-            // cannot have type a parameter.
-            SkAry(sk_ary.0 as *mut ShiikaArray<U>)
-        }
+        let sk_ary = meta_array_new(std::ptr::null());
+        // Force cast because external function (Meta_Array_new)
+        // cannot have type a parameter.
+        SkAry(sk_ary.0 as *mut ShiikaArray<U>)
     }
 
     pub fn as_vec(&self) -> &Vec<T> {

--- a/lib/skc_rustlib/src/builtin/class.rs
+++ b/lib/skc_rustlib/src/builtin/class.rs
@@ -2,20 +2,12 @@
 mod witness_table;
 use crate::builtin::class::witness_table::WitnessTable;
 use crate::builtin::{SkAry, SkInt, SkStr};
+use crate::sk_methods::meta_class_new;
 use shiika_ffi_macro::shiika_method;
 use std::collections::HashMap;
 #[repr(C)]
 #[derive(Debug)]
 pub struct SkClass(*mut ShiikaClass);
-
-extern "C" {
-    // SkClass contains *mut of `HashMap`, which is not `repr(C)`.
-    // I think it's ok because the hashmap is not accessible in Shiika.
-    // TODO: is there a better way?
-    // TODO: macro to convert "Meta:Class#new" into this name
-    #[allow(improper_ctypes)]
-    fn Meta_Class_new(receiver: *const u8) -> SkClass;
-}
 
 impl SkClass {
     pub fn new(ptr: *mut ShiikaClass) -> SkClass {
@@ -86,7 +78,7 @@ pub extern "C" fn meta_class__new(
     metacls_obj: SkClass,
     erasure_cls: SkClass,
 ) -> SkClass {
-    let cls_obj = unsafe { Meta_Class_new(std::ptr::null()) };
+    let cls_obj = meta_class_new(std::ptr::null());
     unsafe {
         (*cls_obj.0).vtable = vtable;
         (*cls_obj.0).name = name;

--- a/lib/skc_rustlib/src/lib.rs
+++ b/lib/skc_rustlib/src/lib.rs
@@ -1,2 +1,3 @@
 mod allocator;
 mod builtin;
+mod sk_methods;

--- a/lib/skc_rustlib/src/sk_methods.rs
+++ b/lib/skc_rustlib/src/sk_methods.rs
@@ -1,0 +1,12 @@
+//! This module provides Rust bindings for llvm functions for Shiika methods.
+//!
+use crate::builtin::{SkAry, SkObj};
+
+// Is it possible to generate this from `"Meta:Array.new"` by proc macro?
+extern "C" {
+    #[allow(improper_ctypes)]
+    pub fn Meta_Array_new(receiver: *const u8) -> SkAry<SkObj>;
+}
+pub fn meta_array_new(receiver: *const u8) -> SkAry<SkObj> {
+    unsafe { Meta_Array_new(receiver) }
+}

--- a/lib/skc_rustlib/src/sk_methods.rs
+++ b/lib/skc_rustlib/src/sk_methods.rs
@@ -1,6 +1,6 @@
 //! This module provides Rust bindings for llvm functions for Shiika methods.
 //!
-use crate::builtin::{SkAry, SkObj};
+use crate::builtin::{SkAry, SkClass, SkObj};
 
 // Is it possible to generate this from `"Meta:Array.new"` by proc macro?
 extern "C" {
@@ -9,4 +9,12 @@ extern "C" {
 }
 pub fn meta_array_new(receiver: *const u8) -> SkAry<SkObj> {
     unsafe { Meta_Array_new(receiver) }
+}
+
+extern "C" {
+    #[allow(improper_ctypes)]
+    fn Meta_Class_new(receiver: *const u8) -> SkClass;
+}
+pub fn meta_class_new(receiver: *const u8) -> SkClass {
+    unsafe { Meta_Class_new(receiver) }
 }

--- a/lib/skc_rustlib/src/sk_methods.rs
+++ b/lib/skc_rustlib/src/sk_methods.rs
@@ -1,20 +1,25 @@
 //! This module provides Rust bindings for llvm functions for Shiika methods.
 //!
 use crate::builtin::{SkAry, SkClass, SkObj};
+use shiika_ffi_macro::shiika_method_ref;
 
-// Is it possible to generate this from `"Meta:Array.new"` by proc macro?
-extern "C" {
-    #[allow(improper_ctypes)]
-    pub fn Meta_Array_new(receiver: *const u8) -> SkAry<SkObj>;
-}
-pub fn meta_array_new(receiver: *const u8) -> SkAry<SkObj> {
-    unsafe { Meta_Array_new(receiver) }
-}
+// This macro call expands into:
+//
+//    extern "C" {
+//        #[allow(improper_ctypes)]
+//        fn Meta_Array_new(receiver: *const u8) -> SkAry<SkObj>;
+//    }
+//    pub fn meta_array_new(receiver: *const u8) -> SkAry<SkObj> {
+//        unsafe { Meta_Array_new(receiver) }
+//    }
+shiika_method_ref!(
+    "Meta:Array#new",
+    fn(receiver: *const u8) -> SkAry<SkObj>,
+    "meta_array_new"
+);
 
-extern "C" {
-    #[allow(improper_ctypes)]
-    fn Meta_Class_new(receiver: *const u8) -> SkClass;
-}
-pub fn meta_class_new(receiver: *const u8) -> SkClass {
-    unsafe { Meta_Class_new(receiver) }
-}
+shiika_method_ref!(
+    "Meta:Class#new",
+    fn(receiver: *const u8) -> SkClass,
+    "meta_class_new"
+);


### PR DESCRIPTION
This PR adds proc macro `shiika_method_ref` so that changes of mangling rule does not affect Shiika libraries written in Rust.