### PR TITLE
refactor: MethodFullname should have a TypeFullname 

### DIFF
--- a/lib/shiika_core/src/names/class_name.rs
+++ b/lib/shiika_core/src/names/class_name.rs
@@ -97,6 +97,12 @@ impl ClassFullname {
         type_fullname(&self.0)
     }
 
+    // Same as `to_type_fullname` but indicates need of refactoring (eg. `self`
+    // should be replaced with a TypeFullname)
+    pub fn to_type_fullname_(&self) -> TypeFullname {
+        type_fullname(&self.0)
+    }
+
     pub fn to_const_fullname(&self) -> ConstFullname {
         toplevel_const(&self.0)
     }

--- a/lib/shiika_core/src/names/method_name.rs
+++ b/lib/shiika_core/src/names/method_name.rs
@@ -1,4 +1,3 @@
-use super::class_name::*;
 use super::type_name::*;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
@@ -24,8 +23,8 @@ impl MethodFirstname {
 
 #[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]
 pub struct MethodFullname {
-    // class part (TODO: this should be TypeFullname)
-    pub class_name: ClassFullname,
+    // class/module part
+    pub type_name: TypeFullname,
     // method part
     pub first_name: MethodFirstname,
     // cache
@@ -38,22 +37,20 @@ impl Hash for MethodFullname {
     }
 }
 
-pub fn method_fullname(
-    class_name: &ClassFullname,
-    first_name_: impl Into<String>,
-) -> MethodFullname {
+pub fn method_fullname(type_name: TypeFullname, first_name_: impl Into<String>) -> MethodFullname {
     let first_name = first_name_.into();
     debug_assert!(!first_name.is_empty());
     debug_assert!(!first_name.starts_with('@'));
+    let full_name = type_name.0.clone() + "#" + &first_name;
     MethodFullname {
-        class_name: class_name.clone(),
-        full_name: class_name.0.clone() + "#" + &first_name,
+        type_name,
+        full_name,
         first_name: MethodFirstname(first_name),
     }
 }
 
 pub fn method_fullname_raw(cls: impl Into<String>, method: impl Into<String>) -> MethodFullname {
-    method_fullname(&class_fullname(cls), method)
+    method_fullname(type_fullname(cls), method)
 }
 
 impl std::fmt::Display for MethodFullname {
@@ -66,9 +63,5 @@ impl MethodFullname {
     /// Returns true if this method isn't an instance method
     pub fn is_class_method(&self) -> bool {
         self.full_name.starts_with("Meta:")
-    }
-
-    pub fn typename(&self) -> TypeFullname {
-        type_fullname(&self.class_name.0)
     }
 }

--- a/lib/shiika_core/src/ty.rs
+++ b/lib/shiika_core/src/ty.rs
@@ -53,7 +53,7 @@ pub fn spe_meta(base_name_: impl Into<String>, type_args: Vec<TermTy>) -> TermTy
 }
 
 /// Create the type of return value of `.new` method of the class
-pub fn return_type_of_new(classname: &ClassFullname, typarams: &[TyParam]) -> TermTy {
+pub fn return_type_of_new(classname: &TypeFullname, typarams: &[TyParam]) -> TermTy {
     if typarams.is_empty() {
         ty::raw(&classname.0)
     } else {

--- a/lib/skc_ast2hir/src/accessors.rs
+++ b/lib/skc_ast2hir/src/accessors.rs
@@ -42,7 +42,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
 
 fn create_getter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
     let sig = MethodSignature {
-        fullname: method_fullname(clsname, &ivar.accessor_name()),
+        fullname: method_fullname(clsname.to_type_fullname(), &ivar.accessor_name()),
         ret_ty: ivar.ty.clone(),
         params: vec![],
         typarams: vec![],
@@ -61,7 +61,7 @@ fn create_setter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
     let accessor_name = ivar.accessor_name();
     let setter_name = format!("{}=", accessor_name);
     let sig = MethodSignature {
-        fullname: method_fullname(clsname, &setter_name),
+        fullname: method_fullname(clsname.to_type_fullname(), &setter_name),
         ret_ty: ivar.ty.clone(),
         params: vec![MethodParam {
             name: ivar.accessor_name(),

--- a/lib/skc_ast2hir/src/class_dict.rs
+++ b/lib/skc_ast2hir/src/class_dict.rs
@@ -61,7 +61,8 @@ pub fn create_for_corelib<'hir_maker>(
 fn index_rust_method_sigs(rust_method_sigs: &[MethodSignature]) -> RustMethods {
     let mut rust_methods = HashMap::new();
     for sig in rust_method_sigs {
-        let v: &mut Vec<MethodSignature> = rust_methods.entry(sig.typename()).or_default();
+        let typename = sig.fullname.type_name.clone();
+        let v: &mut Vec<MethodSignature> = rust_methods.entry(typename).or_default();
         v.push(sig.clone());
     }
     rust_methods

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -80,7 +80,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
             Some(signature::signature_of_new(
                 &metaclass_fullname,
                 self._initializer_params(&inner_namespace, &typarams, &superclass, defs)?,
-                &ty::return_type_of_new(&fullname, &typarams),
+                &ty::return_type_of_new(&fullname.clone().into(), &typarams),
             ))
         };
 
@@ -555,7 +555,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         class_typarams: &[ty::TyParam],
     ) -> Result<MethodSignature> {
         let method_typarams = parse_typarams(&sig.typarams);
-        let fullname = method_fullname(class_fullname, &sig.name.0);
+        let fullname = method_fullname(class_fullname.to_type_fullname_(), &sig.name.0);
         let ret_ty = if let Some(typ) = &sig.ret_typ {
             self.resolve_typename(namespace, class_typarams, &method_typarams, typ)?
         } else {
@@ -702,7 +702,7 @@ fn enum_case_new_sig(
 /// Create signatures of getters of an enum case
 fn enum_case_getters(case_fullname: &ClassFullname, ivars: &[SkIVar]) -> MethodSignatures {
     let iter = ivars.iter().map(|ivar| MethodSignature {
-        fullname: method_fullname(case_fullname, &ivar.accessor_name()),
+        fullname: method_fullname(case_fullname.to_type_fullname(), &ivar.accessor_name()),
         ret_ty: ivar.ty.clone(),
         params: Default::default(),
         typarams: Default::default(),

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -869,7 +869,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         Ok(Hir::method_call(
             meta_spe_ty,
             base_expr,
-            method_fullname(&class_fullname("Class"), "<>"),
+            method_fullname_raw("Class", "<>"),
             vec![self.create_array_instance_(arg_exprs, ty::raw("Class"), LocationSpan::todo())],
         ))
     }

--- a/lib/skc_ast2hir/src/ctx_stack.rs
+++ b/lib/skc_ast2hir/src/ctx_stack.rs
@@ -181,7 +181,7 @@ impl CtxStack {
                 if method_ctx.signature.is_class_method() {
                     ty::meta(&class_ctx.namespace.string())
                 } else {
-                    let classname = &method_ctx.signature.fullname.class_name;
+                    let classname = &method_ctx.signature.fullname.type_name;
                     ty::return_type_of_new(classname, &class_ctx.typarams)
                 }
             } else {

--- a/lib/skc_ast2hir/src/hir_maker.rs
+++ b/lib/skc_ast2hir/src/hir_maker.rs
@@ -107,7 +107,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 Hir::method_call(
                     ty,
                     cls_obj,
-                    method_fullname(&metaclass_fullname(&name.0), "new"),
+                    method_fullname(metaclass_fullname(&name.0).into(), "new"),
                     vec![],
                 )
             } else {
@@ -401,7 +401,10 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             Default::default(),
         )?;
         let fullname = found.owner.as_class_fullname();
-        Ok((method_fullname(&fullname, "initialize"), fullname))
+        Ok((
+            method_fullname(fullname.clone().into(), "initialize"),
+            fullname,
+        ))
     }
 
     /// Register a constant defined in the toplevel

--- a/lib/skc_ast2hir/src/pattern_match.rs
+++ b/lib/skc_ast2hir/src/pattern_match.rs
@@ -274,7 +274,7 @@ fn extract_props(
         let ivar_ref = Hir::method_call(
             ty.clone(),
             value.clone(),
-            method_fullname(&pat_ty.base_class_name(), name),
+            method_fullname(pat_ty.base_class_name().into(), name),
             vec![],
         );
         components.append(&mut convert_match(mk, &ivar_ref, &patterns[i])?);

--- a/lib/skc_ast2hir/src/rustlib_methods.rs
+++ b/lib/skc_ast2hir/src/rustlib_methods.rs
@@ -10,13 +10,13 @@ use std::collections::HashMap;
 pub fn make_sk_methods(sigs: Vec<MethodSignature>) -> SkMethods {
     let mut sk_methods = HashMap::new();
     for signature in sigs {
-        let class_name = signature.fullname.class_name.clone();
+        let typename = signature.fullname.type_name.clone().as_class_fullname();
         let method = SkMethod {
             signature,
             body: SkMethodBody::RustLib,
             lvars: Default::default(),
         };
-        let v: &mut Vec<SkMethod> = sk_methods.entry(class_name).or_default();
+        let v: &mut Vec<SkMethod> = sk_methods.entry(typename).or_default();
         v.push(method);
     }
     sk_methods
@@ -49,7 +49,7 @@ fn make_hir_sig(
     ast_sig: &AstMethodSignature,
 ) -> MethodSignature {
     let class_typaram_names = class_typarams.iter().map(|x| &x.name).collect::<Vec<_>>();
-    let fullname = method_fullname(&type_name, &ast_sig.name.0);
+    let fullname = method_fullname(type_name.clone().into(), &ast_sig.name.0);
     let ret_ty = if let Some(typ) = &ast_sig.ret_typ {
         convert_typ(typ, &class_typaram_names)
     } else {

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -140,7 +140,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let bytesize = function.get_nth_param(1).unwrap().into_int_value();
         let args = vec![self.box_i8ptr(str_i8ptr), self.box_int(&bytesize)];
         let sk_str = self.call_method_func(
-            &method_fullname(&metaclass_fullname("String"), "new"),
+            &method_fullname(metaclass_fullname("String").into(), "new"),
             receiver,
             &args,
             "sk_str",

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -714,7 +714,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             let exit_status =
                 self.build_ivar_load(lambda_obj, FN_X_EXIT_STATUS_IDX, "@exit_status");
             let eq = self.gen_method_func_call(
-                &method_fullname(&class_fullname("Int"), "=="),
+                &method_fullname_raw("Int", "=="),
                 exit_status,
                 vec![self.box_int(&self.i64_type.const_int(EXIT_BREAK, false))],
             );
@@ -827,7 +827,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     fn get_nth_tyarg_of_self(&self, self_obj: SkObj<'run>, idx: usize) -> SkObj<'run> {
         let cls_obj = self.get_class_of_obj(self_obj);
         self.gen_method_func_call(
-            &method_fullname(&class_fullname("Class"), "_type_argument"),
+            &method_fullname_raw("Class", "_type_argument"),
             self.bitcast(cls_obj.as_sk_obj(), &ty::raw("Class"), "as"),
             vec![self.gen_decimal_literal(idx as i64)],
         )
@@ -868,7 +868,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let the_self = self.gen_self_expression(ctx, &ty::raw("Object"));
         let arg_values = vec![sk_ptr, the_self, self._gen_lambda_captures(ctx, captures)];
         self.gen_method_func_call(
-            &method_fullname(&metaclass_fullname(cls_name), "new"),
+            &method_fullname(metaclass_fullname(cls_name).into(), "new"),
             meta,
             arg_values,
         )
@@ -880,7 +880,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         captures: &'hir [HirLambdaCapture],
     ) -> SkObj<'run> {
         let ary = self.gen_method_func_call(
-            &method_fullname(&metaclass_fullname("Array"), "new"),
+            &method_fullname(metaclass_fullname("Array").into(), "new"),
             self.gen_const_ref(&toplevel_const("Array")),
             vec![],
         );
@@ -901,7 +901,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             };
             let obj = self.bitcast(item, &ty::raw("Object"), "capture_item");
             self.call_method_func(
-                &method_fullname(&class_fullname("Array"), "push"),
+                &method_fullname_raw("Array", "push"),
                 ary.clone(),
                 &[obj],
                 "_",
@@ -995,7 +995,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let captures = self._gen_get_lambda_captures(ctx);
         let item = self.gen_method_func_call(
-            &method_fullname(&class_fullname("Array"), "[]"),
+            &method_fullname_raw("Array", "[]"),
             captures,
             vec![self.gen_decimal_literal(*idx_in_captures as i64)],
         );
@@ -1036,7 +1036,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let captures = self._gen_get_lambda_captures(ctx);
         let ptr_ = self.gen_method_func_call(
-            &method_fullname(&class_fullname("Array"), "[]"),
+            &method_fullname_raw("Array", "[]"),
             captures,
             vec![self.gen_decimal_literal(*idx_in_captures as i64)],
         );
@@ -1104,7 +1104,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 .as_sk_obj();
             let wtable = SkObj(self.i8ptr_type.const_null().as_basic_value_enum());
             let metacls_obj = self.gen_method_func_call(
-                &method_fullname(&metaclass_fullname("Metaclass"), "_new"),
+                &method_fullname_raw("Metaclass", "_new"),
                 receiver,
                 vec![
                     self.gen_string_literal(str_literal_idx),
@@ -1120,7 +1120,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             let vtable = self.get_vtable_of_class(&fullname.meta_name()).as_sk_obj();
             let wtable = SkObj(self.i8ptr_type.const_null().as_basic_value_enum());
             let cls = self.gen_method_func_call(
-                &method_fullname(&metaclass_fullname("Class"), "_new"),
+                &method_fullname(metaclass_fullname("Class").into(), "_new"),
                 receiver,
                 vec![
                     self.gen_string_literal(str_literal_idx),

--- a/lib/skc_hir/src/signature.rs
+++ b/lib/skc_hir/src/signature.rs
@@ -18,15 +18,11 @@ impl fmt::Display for MethodSignature {
 
 impl MethodSignature {
     pub fn is_class_method(&self) -> bool {
-        self.fullname.class_name.is_meta()
+        self.fullname.type_name.is_meta()
     }
 
     pub fn first_name(&self) -> &MethodFirstname {
         &self.fullname.first_name
-    }
-
-    pub fn typename(&self) -> TypeFullname {
-        self.fullname.typename()
     }
 
     /// If this method takes a block, returns types of block params and block value.
@@ -102,7 +98,7 @@ pub fn signature_of_new(
     instance_ty: &TermTy,
 ) -> MethodSignature {
     MethodSignature {
-        fullname: method_fullname(metaclass_fullname, "new"),
+        fullname: method_fullname(metaclass_fullname.clone().into(), "new"),
         ret_ty: instance_ty.clone(),
         params: initialize_params,
         typarams: vec![],
@@ -115,7 +111,7 @@ pub fn signature_of_initialize(
     params: Vec<MethodParam>,
 ) -> MethodSignature {
     MethodSignature {
-        fullname: method_fullname(class_fullname, "initialize"),
+        fullname: method_fullname(class_fullname.clone().into(), "initialize"),
         ret_ty: ty::raw("Void"),
         params,
         typarams: vec![],


### PR DESCRIPTION
This PR replaces MethodFullname::class_name with ::type_name.