### PR TITLE
Const name mangling

### DIFF
--- a/lib/shiika_ffi/src/lib.rs
+++ b/lib/shiika_ffi/src/lib.rs
@@ -26,3 +26,14 @@ pub fn mangle_method(method_name: &str) -> String {
         s
     }
 }
+
+pub fn mangle_const(const_name: &str) -> String {
+    let s = const_name
+        // Replace '_' to use '_' as delimiter
+        .replace('_', "__")
+        // Trim the first "::"
+        .trim_start_matches("::")
+        // Replace symbols to make the global variable accesible from Rust
+        .replace("::", "_");
+    format!("shiika_const_{}", &s)
+}

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -491,9 +491,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         rhs: &'hir HirExpression,
     ) -> Result<Option<SkObj<'run>>> {
         let value = self.gen_expr(ctx, rhs)?.unwrap();
+        let name = llvm_const_name(fullname);
         let ptr = self
             .module
-            .get_global(&fullname.0)
+            .get_global(&name)
             .unwrap_or_else(|| panic!("[BUG] global for Constant `{}' not created", fullname.0))
             .as_pointer_value();
         self.builder.build_store(ptr, value.0);
@@ -649,9 +650,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Get the address of a Shiika constant and returns it as an integer
     pub fn get_const_addr_int(&self, fullname: &ConstFullname) -> inkwell::values::IntValue<'run> {
+        let name = llvm_const_name(fullname);
         let ptr = self
             .module
-            .get_global(&fullname.0)
+            .get_global(&name)
             .unwrap_or_else(|| panic!("[BUG] global for Constant `{}' not created", fullname))
             .as_pointer_value();
         ptr.const_to_int(self.i64_type)
@@ -834,11 +836,12 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     }
 
     pub fn gen_const_ref(&self, fullname: &ConstFullname) -> SkObj<'run> {
+        let name = llvm_const_name(fullname);
         let ptr = self
             .module
-            .get_global(&fullname.0)
+            .get_global(&name)
             .unwrap_or_else(|| panic!("[BUG] global for Constant `{}' not created", fullname));
-        SkObj(self.builder.build_load(ptr.as_pointer_value(), &fullname.0))
+        SkObj(self.builder.build_load(ptr.as_pointer_value(), &name))
     }
 
     fn gen_lambda_expr(

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -232,8 +232,8 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
     /// Declare `external global` for each imported constant
     fn gen_import_constants(&self, imported_constants: &HashMap<ConstFullname, TermTy>) {
         for (fullname, ty) in imported_constants {
-            let name = &fullname.0;
-            let global = self.module.add_global(self.llvm_type(ty), None, name);
+            let name = llvm_const_name(fullname);
+            let global = self.module.add_global(self.llvm_type(ty), None, &name);
             global.set_linkage(inkwell::module::Linkage::External);
             // @init_::XX
             let fn_type = self.void_type.fn_type(&[], false);
@@ -473,8 +473,8 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
     /// Generate llvm global that holds Shiika constants
     fn gen_constant_ptrs(&self, constants: &HashMap<ConstFullname, TermTy>) {
         for (fullname, ty) in constants {
-            let name = &fullname.0;
-            let global = self.module.add_global(self.llvm_type(ty), None, name);
+            let name = llvm_const_name(fullname);
+            let global = self.module.add_global(self.llvm_type(ty), None, &name);
             let null = self.llvm_type(ty).into_pointer_type().const_null();
             global.set_initializer(&null);
         }

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -4,7 +4,7 @@ use inkwell::types::*;
 use inkwell::values::*;
 use inkwell::AddressSpace;
 use shiika_core::{names::*, ty, ty::*};
-use shiika_ffi::mangle_method;
+use shiika_ffi::{mangle_const, mangle_method};
 
 /// Number of elements before ivars
 const OBJ_HEADER_SIZE: usize = 2;
@@ -177,7 +177,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Load a class object
     pub fn load_class_object(&self, class_fullname: &ClassFullname) -> SkClassObj<'run> {
-        let class_const_name = format!("::{}", class_fullname.0);
+        let class_const_name = llvm_const_name(&class_fullname.to_const_fullname());
         let class_obj_addr = self
             .module
             .get_global(&class_const_name)
@@ -337,4 +337,9 @@ pub(super) fn llvm_vtable_const_name(classname: &ClassFullname) -> String {
 /// Returns llvm function name of the given method
 pub fn method_func_name(method_name: &MethodFullname) -> LlvmFuncName {
     LlvmFuncName(mangle_method(&method_name.full_name))
+}
+
+/// Returns llvm function name of the given constant
+pub fn llvm_const_name(name: &ConstFullname) -> String {
+    mangle_const(&name.0)
 }


### PR DESCRIPTION
This PR removes colons(`::`) from linker-level name of Shiika constants so that it can be referred with Rust's `extern`.