### PR TITLE
impl. method tyargs inferrence

### DIFF
--- a/lib/shiika_core/src/ty.rs
+++ b/lib/shiika_core/src/ty.rs
@@ -70,6 +70,14 @@ pub fn typarams_to_tyargs(typarams: &[TyParam]) -> Vec<TermTy> {
         .collect()
 }
 
+pub fn typarams_to_typaram_refs(typarams: &[TyParam], kind: TyParamKind) -> Vec<TyParamRef> {
+    typarams
+        .iter()
+        .enumerate()
+        .map(|(i, t)| typaram_ref(&t.name, kind.clone(), i))
+        .collect()
+}
+
 /// Shortcut for Array<T>
 pub fn ary(type_arg: TermTy) -> TermTy {
     spe("Array", vec![type_arg])
@@ -99,4 +107,11 @@ fn tyargs_str(type_args: &[TermTy]) -> String {
             .join(",");
         format!("<{}>", &s)
     }
+}
+
+pub fn fn_ty(arg_tys: Vec<TermTy>, ret_ty: TermTy) -> TermTy {
+    let name = format!("Fn{}", arg_tys.len());
+    let mut type_args = arg_tys;
+    type_args.push(ret_ty);
+    ty::spe(name, type_args)
 }

--- a/lib/shiika_core/src/ty/lit_ty.rs
+++ b/lib/shiika_core/src/ty/lit_ty.rs
@@ -13,6 +13,12 @@ pub struct LitTy {
     pub is_meta: bool,
 }
 
+impl From<LitTy> for TermTy {
+    fn from(x: LitTy) -> Self {
+        x.into_term_ty()
+    }
+}
+
 impl LitTy {
     pub fn new(base_name: String, type_args: Vec<TermTy>, is_meta_: bool) -> LitTy {
         let is_meta = if base_name == "Metaclass" {

--- a/lib/shiika_core/src/ty/typaram_ref.rs
+++ b/lib/shiika_core/src/ty/typaram_ref.rs
@@ -22,6 +22,12 @@ pub enum TyParamKind {
     Method,
 }
 
+impl From<TyParamRef> for TermTy {
+    fn from(x: TyParamRef) -> Self {
+        x.into_term_ty()
+    }
+}
+
 impl TyParamRef {
     pub fn dbg_str(&self) -> String {
         let k = match &self.kind {

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -588,7 +588,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             .class_dict
             .lookup_method(&self_expr.ty, &method_firstname(name), &[]);
         if let Ok(found) = result {
-            method_call::build(self, found, self_expr, Default::default())
+            method_call::build_simple(self, found, self_expr)
         } else {
             Err(error::program_error(&format!(
                 "variable or method `{}' was not found",

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -500,10 +500,6 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         is_fn: &bool,
         locs: &LocationSpan,
     ) -> Result<HirExpression> {
-        // This method only handles `fn(){}` because blocks are handled in
-        // convert_method_call.
-        debug_assert!(is_fn);
-
         let namespace = self.ctx_stack.const_scopes().next().unwrap();
         let hir_params = params::convert_block_params(
             &self.class_dict,

--- a/lib/skc_ast2hir/src/convert_exprs/block.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/block.rs
@@ -1,6 +1,7 @@
 use crate::convert_exprs::params;
 use crate::hir_maker::{extract_lvars, HirMaker};
 use crate::hir_maker_context::HirMakerContext;
+use crate::type_inference::method_call_inf;
 use crate::type_system::type_checking;
 use anyhow::Result;
 use shiika_ast::{AstExpression, AstExpressionBody, LocationSpan};
@@ -45,6 +46,7 @@ impl<'hir_maker> BlockTaker<'hir_maker> {
 pub fn convert_block(
     mk: &mut HirMaker,
     block_taker: &BlockTaker,
+    inf: &method_call_inf::MethodCallInf2,
     arg_expr: &AstExpression,
 ) -> Result<HirExpression> {
     match &arg_expr.body {
@@ -54,21 +56,23 @@ pub fn convert_block(
             is_fn,
         } => {
             debug_assert!(!is_fn);
-            _convert_block(mk, block_taker, params, exprs)
+            _convert_block(mk, block_taker, inf, params, exprs)
         }
         _ => panic!("expected LambdaExpr but got {:?}", arg_expr),
     }
 }
 
 /// Convert a block to HirLambdaExpr
-/// Types of block parameters are inferred from `block_ty` (arg_ty1, arg_ty2, ..., ret_ty)
+/// Types of block parameters are inferred from `block_ty` (arg_ty1, arg_ty2, ..., ret_ty) if not
+/// specified.
 fn _convert_block(
     mk: &mut HirMaker,
     block_taker: &BlockTaker,
+    inf: &method_call_inf::MethodCallInf2,
     params: &[shiika_ast::BlockParam],
     body_exprs: &[AstExpression],
 ) -> Result<HirExpression> {
-    type_checking::check_block_arity(block_taker, params)?;
+    type_checking::check_block_arity(block_taker, inf, params)?;
 
     let namespace = mk.ctx_stack.const_scopes().next().unwrap();
     let hir_params = params::convert_block_params(
@@ -77,7 +81,7 @@ fn _convert_block(
         params,
         &mk.ctx_stack.current_class_typarams(),
         &mk.ctx_stack.current_method_typarams(),
-        block_ty_of(block_taker),
+        Some(inf),
     )?;
 
     // Convert lambda body
@@ -101,16 +105,4 @@ pub fn lambda_ty(params: &[MethodParam], ret_ty: &TermTy) -> TermTy {
     let mut tyargs = params.iter().map(|x| x.ty.clone()).collect::<Vec<_>>();
     tyargs.push(ret_ty.clone());
     ty::spe(&format!("Fn{}", params.len()), tyargs)
-}
-
-/// Returns the type of block accepted by the method or fn.
-fn block_ty_of<'a>(block_taker: &'a BlockTaker) -> &'a [TermTy] {
-    match block_taker {
-        BlockTaker::Method { sig, .. } => sig.block_ty().unwrap(),
-        BlockTaker::Function { fn_ty, .. } => {
-            let tys = fn_ty.fn_x_info().unwrap();
-            let last_arg_ty = tys.get(tys.len() - 2).unwrap();
-            last_arg_ty.fn_x_info().unwrap()
-        }
-    }
 }

--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -57,7 +57,7 @@ pub fn convert_method_call(
     } else {
         None
     };
-    let msg = format!("{:?}", inf1);
+    let msg = format!("Type inferrence failed: {:?}", inf1);
     let (arg_hirs, inf3) = convert_method_args(
         mk,
         inf1,

--- a/lib/skc_ast2hir/src/lib.rs
+++ b/lib/skc_ast2hir/src/lib.rs
@@ -7,6 +7,7 @@ mod hir_maker;
 mod hir_maker_context;
 mod method_dict;
 mod pattern_match;
+mod type_inference;
 mod type_system;
 use crate::class_dict::type_index;
 use crate::hir_maker::HirMaker;

--- a/lib/skc_ast2hir/src/type_inference.rs
+++ b/lib/skc_ast2hir/src/type_inference.rs
@@ -133,14 +133,11 @@ fn unify(mut equations: Vec<Equation>, ans: &mut Answer) -> Result<()> {
                     equations.push(Equation(l.clone(), r.clone()));
                 }
             }
-            Equation(TmpTy::Literal { .. }, TmpTy::Literal { .. }) => {
-                return Err(type_error(format!("not equal: {} vs {}", &eq.0, &eq.1)));
-            }
-            Equation(TmpTy::TyParamRef(_), TmpTy::Literal { .. }) => {
-                return Err(type_error(format!("not equal: {:?}", &eq)))
-            }
-            Equation(_, TmpTy::TyParamRef(_)) => {
-                equations.push(eq.swap());
+            _ => {
+                // Skip this equation because it is not useful for resolving
+                // `Unknown`s. (Note that this function is not used for type
+                // checking at the moment)
+                continue;
             }
         }
     }

--- a/lib/skc_ast2hir/src/type_inference.rs
+++ b/lib/skc_ast2hir/src/type_inference.rs
@@ -1,0 +1,148 @@
+pub mod method_call_inf;
+mod tmp_ty;
+use crate::error::type_error;
+use anyhow::{Context, Result};
+use shiika_core::ty::{LitTy, TermTy};
+use std::collections::HashMap;
+use std::fmt;
+pub use tmp_ty::TmpTy;
+
+type Id = usize;
+
+#[derive(Debug)]
+struct Equation(TmpTy, TmpTy);
+
+impl Equation {
+    /// Returns swapped version of self
+    fn swap(self) -> Equation {
+        Equation(self.1, self.0)
+    }
+
+    /// Resolve `Unknown(id)` with `t`
+    fn substitute(&self, id: &Id, t: &TmpTy) -> Equation {
+        Equation(self.0.substitute(id, t), self.1.substitute(id, t))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Answer(HashMap<Id, TmpTy>);
+
+impl fmt::Display for Answer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let items = self
+            .0
+            .iter()
+            .map(|(id, t)| format!("'{}={}", id, t))
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "{{{}}}", items)
+    }
+}
+
+impl Answer {
+    /// Introduce new knowledge (Unknown(id) = t) to `self`.
+    fn merge(&mut self, id: Id, t: TmpTy) {
+        let mut h = self
+            .0
+            .drain()
+            .map(|(id2, t2)| (id2, t2.substitute(&id, &t)))
+            .collect::<HashMap<_, _>>();
+        h.insert(id, t);
+        self.0 = h
+    }
+
+    /// Apply `self` to TmpTy's
+    fn apply_to_vec(&self, tmp_tys: &[TmpTy]) -> Result<Vec<TermTy>> {
+        tmp_tys.iter().map(|tt| self.apply_to(tt)).collect()
+    }
+
+    /// Creates a `TermTy` by applying `self` to the `Unknown`s in `t`.
+    /// Returns `Err` if could not remove all `Unknown`s.
+    fn apply_to(&self, t: &TmpTy) -> Result<TermTy> {
+        self._apply_to(t)
+            .context(format!("t: {}, answer: {}", t, self))
+    }
+
+    fn _apply_to(&self, t: &TmpTy) -> Result<TermTy> {
+        match t {
+            TmpTy::Unknown(id) => {
+                if self.0.contains_key(id) {
+                    Answer(Default::default())._apply_to(self.0.get(id).unwrap())
+                } else {
+                    Err(type_error(format!(
+                        "could not infer type parameter '{}",
+                        id
+                    )))
+                }
+            }
+            TmpTy::Literal {
+                base_name,
+                type_args,
+                is_meta,
+            } => {
+                let args = type_args
+                    .iter()
+                    .map(|a| self._apply_to(a))
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(LitTy::new(base_name.clone(), args, *is_meta).into())
+            }
+            TmpTy::TyParamRef(r) => Ok(r.clone().into()),
+        }
+    }
+}
+
+/// Calculates `Answer` by unifying the equations.
+fn unify(mut equations: Vec<Equation>, ans: &mut Answer) -> Result<()> {
+    while let Some(eq) = equations.pop() {
+        match eq {
+            Equation(ty1, ty2) if ty1 == ty2 => {
+                continue;
+            }
+            Equation(TmpTy::Unknown(id), ty2) => {
+                if ty2.contains(id) {
+                    return Err(type_error(format!(
+                        "loop detected (id: {}, ty2: {:?})",
+                        id, ty2
+                    )));
+                }
+                equations = equations
+                    .iter()
+                    .map(|eq| eq.substitute(&id, &ty2))
+                    .collect();
+                ans.merge(id, ty2);
+            }
+            Equation(_, TmpTy::Unknown(_)) => {
+                equations.push(eq.swap());
+            }
+            Equation(
+                TmpTy::Literal {
+                    base_name,
+                    type_args,
+                    is_meta,
+                },
+                TmpTy::Literal {
+                    base_name: base_name2,
+                    type_args: type_args2,
+                    is_meta: is_meta2,
+                },
+            ) if base_name == base_name2
+                && is_meta == is_meta2
+                && type_args.len() == type_args2.len() =>
+            {
+                for (l, r) in type_args.iter().zip(type_args2.iter()) {
+                    equations.push(Equation(l.clone(), r.clone()));
+                }
+            }
+            Equation(TmpTy::Literal { .. }, TmpTy::Literal { .. }) => {
+                return Err(type_error(format!("not equal: {} vs {}", &eq.0, &eq.1)));
+            }
+            Equation(TmpTy::TyParamRef(_), TmpTy::Literal { .. }) => {
+                return Err(type_error(format!("not equal: {:?}", &eq)))
+            }
+            Equation(_, TmpTy::TyParamRef(_)) => {
+                equations.push(eq.swap());
+            }
+        }
+    }
+    Ok(())
+}

--- a/lib/skc_ast2hir/src/type_inference/method_call_inf.rs
+++ b/lib/skc_ast2hir/src/type_inference/method_call_inf.rs
@@ -32,15 +32,17 @@ impl MethodCallInf1 {
         }
     }
 
-    /// Same as `new` but slightly simpler because `fn`s does not have
-    /// type parameters.
-    pub fn for_fn(fn_ty: &TermTy, has_block: bool) -> MethodCallInf1 {
-        let fn_x_info = fn_ty.fn_x_info().unwrap();
-        let mut method_arg_tys = TmpTy::from_vec(&fn_x_info);
-        let method_ret_ty = method_arg_tys.pop().unwrap();
+    pub fn infer_block(sig: &MethodSignature) -> MethodCallInf1 {
+        let vars = [];
+        let method_arg_tys = sig
+            .params
+            .iter()
+            .map(|param| TmpTy::make(&param.ty, &vars))
+            .collect::<Vec<_>>();
+        let method_ret_ty = TmpTy::make(&sig.ret_ty, &vars);
 
         MethodCallInf1 {
-            has_block,
+            has_block: true,
             method_arg_tys,
             method_ret_ty,
             answer: Default::default(),

--- a/lib/skc_ast2hir/src/type_inference/method_call_inf.rs
+++ b/lib/skc_ast2hir/src/type_inference/method_call_inf.rs
@@ -1,0 +1,205 @@
+use crate::type_inference::{unify, Answer, Equation, TmpTy};
+use anyhow::Result;
+use shiika_core::ty;
+use shiika_core::ty::{TermTy, TyParamKind};
+use skc_hir::MethodSignature;
+
+/// Phase 1
+#[derive(Debug)]
+pub struct MethodCallInf1 {
+    has_block: bool,
+    pub method_arg_tys: Vec<TmpTy>,
+    pub method_ret_ty: TmpTy,
+    pub answer: Answer,
+}
+
+impl MethodCallInf1 {
+    pub fn new(sig: &MethodSignature, has_block: bool) -> MethodCallInf1 {
+        let tprefs = ty::typarams_to_typaram_refs(&sig.typarams, TyParamKind::Method);
+        let vars = tprefs.into_iter().enumerate().collect::<Vec<_>>();
+        let method_arg_tys = sig
+            .params
+            .iter()
+            .map(|param| TmpTy::make(&param.ty, &vars))
+            .collect::<Vec<_>>();
+        let method_ret_ty = TmpTy::make(&sig.ret_ty, &vars);
+
+        MethodCallInf1 {
+            has_block,
+            method_arg_tys,
+            method_ret_ty,
+            answer: Default::default(),
+        }
+    }
+
+    /// Same as `new` but slightly simpler because `fn`s does not have
+    /// type parameters.
+    pub fn for_fn(fn_ty: &TermTy, has_block: bool) -> MethodCallInf1 {
+        let fn_x_info = fn_ty.fn_x_info().unwrap();
+        let mut method_arg_tys = TmpTy::from_vec(&fn_x_info);
+        let method_ret_ty = method_arg_tys.pop().unwrap();
+
+        MethodCallInf1 {
+            has_block,
+            method_arg_tys,
+            method_ret_ty,
+            answer: Default::default(),
+        }
+    }
+
+    pub fn pre_block_arg_tys(&self) -> &[TmpTy] {
+        debug_assert!(&self.has_block);
+        let tys = &self.method_arg_tys;
+        &tys[..tys.len() - 1]
+    }
+
+    pub fn block_param_tys(&self) -> &[TmpTy] {
+        debug_assert!(&self.has_block);
+        let block_ty = self.method_arg_tys.last().unwrap();
+        let tys = block_ty.type_args().unwrap();
+        &tys[..tys.len() - 1]
+    }
+
+    pub fn block_ret_ty(&self) -> &TmpTy {
+        debug_assert!(&self.has_block);
+        let block_ty = self.method_arg_tys.last().unwrap();
+        let block_param_tys = block_ty.type_args().unwrap();
+        block_param_tys.last().unwrap()
+    }
+}
+
+/// Phase 2
+/// Block parameter types are solved.
+/// Only used when block exists.
+#[derive(Debug)]
+pub struct MethodCallInf2 {
+    pub solved_pre_block_arg_tys: Vec<TermTy>,
+    pub block_ret_ty: TmpTy,
+    pub method_ret_ty: TmpTy,
+    pub solved_block_param_tys: Vec<TermTy>,
+    pub answer: Answer,
+}
+
+impl MethodCallInf2 {
+    fn new(
+        inf: MethodCallInf1,
+        solved_pre_block_arg_tys: Vec<TermTy>,
+        solved_block_param_tys: Vec<TermTy>,
+    ) -> MethodCallInf2 {
+        debug_assert!(&inf.has_block);
+        MethodCallInf2 {
+            solved_pre_block_arg_tys,
+            block_ret_ty: inf.block_ret_ty().clone(),
+            method_ret_ty: inf.method_ret_ty,
+            solved_block_param_tys,
+            answer: inf.answer,
+        }
+    }
+}
+
+/// Phase 3 (All solved)
+pub struct MethodCallInf3 {
+    pub solved_method_arg_tys: Vec<TermTy>,
+    solved_method_ret_ty: TermTy,
+}
+
+impl MethodCallInf3 {
+    fn with_block(
+        inf: MethodCallInf2,
+        solved_method_ret_ty: TermTy,
+        solved_block_ret_ty: TermTy,
+    ) -> MethodCallInf3 {
+        let solved_block_ty = ty::fn_ty(inf.solved_block_param_tys, solved_block_ret_ty);
+        let mut solved_method_arg_tys = inf.solved_pre_block_arg_tys;
+        solved_method_arg_tys.push(solved_block_ty);
+        MethodCallInf3 {
+            solved_method_arg_tys,
+            solved_method_ret_ty,
+        }
+    }
+
+    fn without_block(
+        solved_method_arg_tys: Vec<TermTy>,
+        solved_method_ret_ty: TermTy,
+    ) -> MethodCallInf3 {
+        MethodCallInf3 {
+            solved_method_arg_tys,
+            solved_method_ret_ty,
+        }
+    }
+}
+
+pub fn infer_block_param(
+    mut inf: MethodCallInf1,
+    pre_block_arg_tys: &[&TermTy],
+) -> Result<MethodCallInf2> {
+    let equations = inf
+        .method_arg_tys
+        .iter()
+        .zip(pre_block_arg_tys.iter())
+        .map(|(l, r)| Equation(l.clone(), TmpTy::from(r)))
+        .collect::<Vec<_>>();
+    unify(equations, &mut inf.answer)?;
+    let solved_pre_block_arg_tys = inf.answer.apply_to_vec(&inf.pre_block_arg_tys())?;
+    let solved_block_param_tys = inf.answer.apply_to_vec(&inf.block_param_tys())?;
+    Ok(MethodCallInf2::new(
+        inf,
+        solved_pre_block_arg_tys,
+        solved_block_param_tys,
+    ))
+}
+
+pub fn infer_method_param(
+    mut inf: MethodCallInf1,
+    pre_block_arg_tys: &[&TermTy],
+) -> Result<MethodCallInf2> {
+    let equations = inf
+        .method_arg_tys
+        .iter()
+        .zip(pre_block_arg_tys.iter())
+        .map(|(l, r)| Equation(l.clone(), TmpTy::from(r)))
+        .collect::<Vec<_>>();
+    unify(equations, &mut inf.answer)?;
+    let solved_pre_block_arg_tys = inf.answer.apply_to_vec(&inf.pre_block_arg_tys())?;
+    let solved_block_param_tys = inf.answer.apply_to_vec(&inf.block_param_tys())?;
+    Ok(MethodCallInf2::new(
+        inf,
+        solved_pre_block_arg_tys,
+        solved_block_param_tys,
+    ))
+}
+
+pub fn infer_result_ty_with_block(
+    mut inf: MethodCallInf2,
+    block_ty: &TermTy,
+) -> Result<MethodCallInf3> {
+    let equations = vec![Equation(
+        inf.block_ret_ty.clone(),
+        TmpTy::from(&block_ty.tyargs().last().unwrap()),
+    )];
+    unify(equations, &mut inf.answer)?;
+    let solved_method_ret_ty = inf.answer.apply_to(&inf.method_ret_ty)?;
+    let solved_block_ret_ty = inf.answer.apply_to(&inf.block_ret_ty)?;
+    Ok(MethodCallInf3::with_block(
+        inf,
+        solved_method_ret_ty,
+        solved_block_ret_ty,
+    ))
+}
+
+pub fn infer_result_ty_without_block(
+    inf: &mut MethodCallInf1,
+    arg_tys: &[&TermTy],
+) -> Result<MethodCallInf3> {
+    let equations = inf
+        .method_arg_tys
+        .iter()
+        .zip(arg_tys.iter())
+        .map(|(l, r)| Equation(l.clone(), TmpTy::from(r)))
+        .collect::<Vec<_>>();
+    unify(equations, &mut inf.answer)?;
+    Ok(MethodCallInf3::without_block(
+        inf.answer.apply_to_vec(&inf.method_arg_tys)?,
+        inf.answer.apply_to(&inf.method_ret_ty)?,
+    ))
+}

--- a/lib/skc_ast2hir/src/type_inference/tmp_ty.rs
+++ b/lib/skc_ast2hir/src/type_inference/tmp_ty.rs
@@ -1,0 +1,142 @@
+use crate::type_inference::Id;
+use shiika_core::ty;
+use shiika_core::ty::{TermTy, TyBody, TyParamRef};
+use std::fmt;
+
+/// Type information that appears temporarily during type inference.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum TmpTy {
+    /// This type is unknown and should be inferred from other parts of the program.
+    Unknown(Id),
+    /// Mostly the same as `ty::LitTy` but may contain `Unknown` as a type argument.
+    Literal {
+        base_name: String,
+        type_args: Vec<TmpTy>,
+        /// `true` if values of this type are classes
+        is_meta: bool,
+    },
+    /// Just wraps `ty::TyParamRef`
+    TyParamRef(ty::TyParamRef),
+}
+
+impl fmt::Display for TmpTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}
+
+impl Default for TmpTy {
+    /// Zero-value for TmpTy
+    /// (We could use `Option` but I didn't want to `unwrap` everywhere)
+    fn default() -> Self {
+        TmpTy::Unknown(0)
+    }
+}
+
+impl TmpTy {
+    /// Make a TmpTy from a TermTy by replacing TyParamRef's with `Unknown`s.
+    pub fn make(t: &TermTy, vars: &[(Id, TyParamRef)]) -> TmpTy {
+        match &t.body {
+            TyBody::TyRaw(lit_ty) => TmpTy::Literal {
+                base_name: lit_ty.base_name.clone(),
+                type_args: lit_ty
+                    .type_args
+                    .iter()
+                    .map(|arg| Self::make(arg, vars))
+                    .collect(),
+                is_meta: lit_ty.is_meta,
+            },
+            TyBody::TyPara(tp_ref1) => {
+                let found = vars.iter().find(|(_, tp_ref2)| *tp_ref1 == *tp_ref2);
+                if let Some((id, _)) = found {
+                    TmpTy::Unknown(*id)
+                } else {
+                    TmpTy::TyParamRef(tp_ref1.clone())
+                }
+            }
+        }
+    }
+
+    /// Just convert a TermTy to TmpTy
+    pub fn from(t: &TermTy) -> TmpTy {
+        Self::make(t, Default::default())
+    }
+
+    /// Convert TermTy's to TmpTy's
+    pub fn from_vec(ts: &[TermTy]) -> Vec<TmpTy> {
+        ts.iter().map(Self::from).collect()
+    }
+
+    /// Returns true if `Unknown(id)` appears in self
+    pub fn contains(&self, id: Id) -> bool {
+        match self {
+            TmpTy::Unknown(id2) => id == *id2,
+            TmpTy::Literal { type_args, .. } => type_args.iter().any(|t| t.contains(id)),
+            TmpTy::TyParamRef(_) => false,
+        }
+    }
+
+    /// Resolve `Unknown(id)` with `t`
+    pub fn substitute(&self, id: &Id, t: &TmpTy) -> TmpTy {
+        match self {
+            TmpTy::Unknown(id2) => {
+                if id == id2 {
+                    t.clone()
+                } else {
+                    self.clone()
+                }
+            }
+            TmpTy::Literal {
+                base_name,
+                type_args,
+                is_meta,
+            } => {
+                let new_args = type_args.iter().map(|x| x.substitute(id, t)).collect();
+                TmpTy::Literal {
+                    base_name: base_name.clone(),
+                    type_args: new_args,
+                    is_meta: *is_meta,
+                }
+            }
+            TmpTy::TyParamRef(_) => self.clone(),
+        }
+    }
+
+    /// Returns human-readable representation
+    pub fn to_string(&self) -> String {
+        match self {
+            TmpTy::Unknown(id) => format!("'{}", id),
+            TmpTy::Literal {
+                base_name,
+                type_args,
+                is_meta,
+            } => {
+                let m = if *is_meta && base_name != "Metaclass" {
+                    "Meta:"
+                } else {
+                    ""
+                };
+                let args = if type_args.is_empty() {
+                    "".to_string()
+                } else {
+                    "<".to_string()
+                        + &type_args
+                            .iter()
+                            .map(|t| t.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                        + ">"
+                };
+                format!("{}{}{}", m, base_name, args)
+            }
+            TmpTy::TyParamRef(tp_ref) => tp_ref.name.clone(),
+        }
+    }
+
+    pub fn type_args(&self) -> Option<&[TmpTy]> {
+        match self {
+            TmpTy::Literal { type_args, .. } => Some(type_args),
+            _ => None,
+        }
+    }
+}

--- a/lib/skc_ast2hir/src/type_inference/tmp_ty.rs
+++ b/lib/skc_ast2hir/src/type_inference/tmp_ty.rs
@@ -62,11 +62,6 @@ impl TmpTy {
         Self::make(t, Default::default())
     }
 
-    /// Convert TermTy's to TmpTy's
-    pub fn from_vec(ts: &[TermTy]) -> Vec<TmpTy> {
-        ts.iter().map(Self::from).collect()
-    }
-
     /// Returns true if `Unknown(id)` appears in self
     pub fn contains(&self, id: Id) -> bool {
         match self {

--- a/lib/skc_hir/src/signature.rs
+++ b/lib/skc_hir/src/signature.rs
@@ -12,7 +12,7 @@ pub struct MethodSignature {
 
 impl fmt::Display for MethodSignature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.fullname)
+        write!(f, "{}", self.full_string())
     }
 }
 
@@ -65,6 +65,31 @@ impl MethodSignature {
             return false;
         }
         true
+    }
+
+    pub fn full_string(&self) -> String {
+        let typarams = if self.typarams.is_empty() {
+            "".to_string()
+        } else {
+            "<".to_string()
+                + &self
+                    .typarams
+                    .iter()
+                    .map(|x| format!("{}", &x.name))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+                + ">"
+        };
+        let params = self
+            .params
+            .iter()
+            .map(|x| format!("{}: {}", &x.name, &x.ty))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "{}{}({}) -> {}",
+            &self.fullname, typarams, params, &self.ret_ty
+        )
     }
 }
 


### PR DESCRIPTION
With this PR,

    [1,2,3].map<String>{|i| i.to_s}

can just be

    [1,2,3].map{|i| i.to_s}
