### PR TITLE
impl. parenthesized function call

### DIFF
--- a/lib/shiika_ast/src/lib.rs
+++ b/lib/shiika_ast/src/lib.rs
@@ -148,6 +148,7 @@ pub struct UnresolvedTypeName {
 #[derive(Debug, PartialEq, Clone)]
 pub struct AstExpression {
     pub body: AstExpressionBody,
+    /// Can invoke method with `.foo`
     pub primary: bool,
     pub locs: LocationSpan,
 }
@@ -205,6 +206,11 @@ pub enum AstExpressionBody {
         rhs: Box<AstExpression>,
     },
     MethodCall(AstMethodCall),
+    LambdaInvocation {
+        fn_expr: Box<AstExpression>,
+        arg_exprs: Vec<AstExpression>,
+        has_block: bool,
+    },
     LambdaExpr {
         params: Vec<BlockParam>,
         exprs: Vec<AstExpression>,

--- a/lib/shiika_parser/src/ast_builder.rs
+++ b/lib/shiika_parser/src/ast_builder.rs
@@ -235,6 +235,25 @@ impl AstBuilder {
         )
     }
 
+    pub fn lambda_invocation(
+        &self,
+        fn_expr: AstExpression,
+        arg_exprs: Vec<AstExpression>,
+        has_block: bool,
+        begin: Location,
+        end: Location,
+    ) -> AstExpression {
+        self.primary_expression(
+            begin,
+            end,
+            AstExpressionBody::LambdaInvocation {
+                fn_expr: Box::new(fn_expr),
+                arg_exprs,
+                has_block,
+            },
+        )
+    }
+
     pub fn lambda_expr(
         &self,
         params: Vec<BlockParam>,

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -139,6 +139,21 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 &expr.locs,
             ),
 
+            AstExpressionBody::LambdaInvocation {
+                fn_expr,
+                arg_exprs,
+                has_block,
+            } => {
+                let hir_fn_expr = self.convert_expr(fn_expr)?;
+                method_call::convert_lambda_invocation(
+                    self,
+                    hir_fn_expr,
+                    arg_exprs,
+                    has_block,
+                    &expr.locs,
+                )
+            }
+
             AstExpressionBody::LambdaExpr {
                 params,
                 exprs,
@@ -421,7 +436,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         locs: &LocationSpan,
     ) -> Result<HirExpression> {
         if !self.ctx_stack.in_initializer() {
-            return Err(error::ivar_decl_outside_initializer(name, locs))
+            return Err(error::ivar_decl_outside_initializer(name, locs));
         }
         let expr = self.convert_expr(rhs)?;
         let base_ty = self.ctx_stack.self_ty().erasure_ty();

--- a/tests/sk/ivar.sk
+++ b/tests/sk/ivar.sk
@@ -8,4 +8,16 @@ unless a.i == 1 then puts "ng 1" end
 a.i = 2
 unless a.i == 2 then puts "ng 2" end
 
+# Store function to ivar and call it
+class IvarFn
+  def initialize
+    let @inc = fn(x: Int){ x + 1 }
+  end
+
+  def foo -> Int
+    (@inc)(2)
+  end
+end
+unless IvarFn.new.foo == 3; puts "ng IvarFn"; end
+
 puts "ok"


### PR DESCRIPTION
This PR adds new syntax `(expr)(args, ...)` for example, `(@f)(1)` where `@f` is a function (instance of `Fn1`).