### PR TITLE
Check number of type arguments

### DIFF
--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -837,6 +837,12 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             type_args.push(cls_expr.ty.as_type_argument());
             arg_exprs.push(cls_expr);
         }
+
+        let sk_type = self
+            .class_dict
+            .get_type(&base_expr.ty.instance_ty().fullname.to_type_fullname());
+        type_checking::check_class_specialization(&sk_type, &arg_exprs, &locs)?;
+
         let meta_spe_ty = base_expr.ty.specialized_ty(type_args);
         Ok(Hir::method_call(
             meta_spe_ty,

--- a/tests/sk/enum.sk
+++ b/tests/sk/enum.sk
@@ -5,8 +5,8 @@ f(a)
 f(b)
 unless a.value == 1; puts "ng Some#value"; end
 
-let o = Ok<Int, Error>.new(0)
-let e = Fail<Int, Error>.new(Error.new("fail"))
+let o = Ok<Int>.new(0)
+let e = Fail<Int>.new(Error.new("fail"))
 
 # Class method of enum
 enum EnumWithClassMethod


### PR DESCRIPTION
This PR raises error (instead of crashing) for program like this:

```
Dict<Int>.new   # should be Dict<String, Int>
```