### PR TITLE
Fix 424

### DIFF
--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -53,6 +53,7 @@ pub fn convert_method_call(
     let inf1 = if found.sig.typarams.len() > 0 && type_args.is_empty() {
         Some(method_call_inf::MethodCallInf1::new(&found.sig, *has_block))
     } else if *has_block {
+        type_checking::check_takes_block(&found.sig, locs)?;
         Some(method_call_inf::MethodCallInf1::infer_block(&found.sig))
     } else {
         None

--- a/lib/skc_ast2hir/src/type_system/type_checking.rs
+++ b/lib/skc_ast2hir/src/type_system/type_checking.rs
@@ -183,6 +183,22 @@ fn check_arg_type(
     Err(type_error(report))
 }
 
+/// Check the method takes a block
+pub fn check_takes_block(sig: &MethodSignature, locs: &LocationSpan) -> Result<()> {
+    if let Some(param) = sig.params.last() {
+        if param.ty.fn_x_info().is_some() {
+            return Ok(());
+        }
+    }
+
+    let msg = format!("the method {} does not take a block", sig);
+    let sub_msg = "This method does not take a block.";
+    let report = skc_error::build_report(msg, locs, |r, locs_span| {
+        r.with_label(Label::new(locs_span).with_message(sub_msg))
+    });
+    Err(type_error(report))
+}
+
 /// Check number of block parameters
 pub fn check_block_arity(
     block_taker: &BlockTaker, // for error message

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24,6 +24,15 @@ fn test_compile_and_run() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_no_panic() -> Result<()> {
+    let path = "tests/no_panic.sk";
+    // `compile` may return an Err here; it just should not panic.
+    let _ = runner::compile(path);
+    runner::cleanup(path)?;
+    Ok(())
+}
+
 /// Execute tests/sk/x.sk
 /// Fail if it prints something
 fn run_sk_test(path: &str) -> Result<()> {

--- a/tests/no_panic.sk
+++ b/tests/no_panic.sk
@@ -1,0 +1,9 @@
+# This file contains various errornous Shiika program.
+# The compiler should not panic and show compile error instead.
+
+# #424
+class A
+  def foo
+  end
+end
+A.new.foo{}


### PR DESCRIPTION
This PR fixes #424 and also adds `test_no_panic()` which asserts `compile` does not panic for Shiika programs like #424.