### PR TITLE
refactor: Changed content of Superclass

### DIFF
--- a/lib/shiika_core/src/ty/lit_ty.rs
+++ b/lib/shiika_core/src/ty/lit_ty.rs
@@ -54,4 +54,13 @@ impl LitTy {
     pub fn erasure(&self) -> Erasure {
         Erasure::new(self.base_name.clone(), self.is_meta)
     }
+
+    pub fn substitute(&self, class_tyargs: &[TermTy], method_tyargs: &[TermTy]) -> LitTy {
+        let args = self
+            .type_args
+            .iter()
+            .map(|t| t.substitute(class_tyargs, method_tyargs))
+            .collect();
+        LitTy::new(self.base_name.clone(), args, self.is_meta)
+    }
 }

--- a/lib/shiika_core/src/ty/term_ty.rs
+++ b/lib/shiika_core/src/ty/term_ty.rs
@@ -271,17 +271,7 @@ impl TermTy {
                     }
                 }
             },
-            TyRaw(LitTy {
-                base_name,
-                type_args,
-                is_meta,
-            }) => {
-                let args = type_args
-                    .iter()
-                    .map(|t| t.substitute(class_tyargs, method_tyargs))
-                    .collect();
-                ty::new(base_name, args, *is_meta)
-            }
+            TyRaw(lit_ty) => lit_ty.substitute(class_tyargs, method_tyargs).into(),
         }
     }
 

--- a/lib/skc_ast2hir/src/class_dict.rs
+++ b/lib/skc_ast2hir/src/class_dict.rs
@@ -96,5 +96,5 @@ impl<'hir_maker> ClassDict<'hir_maker> {
 ///     # no explicit initialize
 /// Foo will have `#initialize(a: Array<T>)`
 fn specialized_initialize(sig: &MethodSignature, superclass: &Superclass) -> MethodSignature {
-    sig.specialize(superclass.ty().tyargs(), &[])
+    sig.specialize(superclass.type_args(), &[])
 }

--- a/lib/skc_ast2hir/src/class_dict/build_wtable.rs
+++ b/lib/skc_ast2hir/src/class_dict/build_wtable.rs
@@ -68,7 +68,7 @@ fn check_signature_matches(
     mod_sig: &MethodSignature,
     sup: &Superclass,
 ) -> Result<()> {
-    let msig = mod_sig.specialize(sup.ty().tyargs(), Default::default());
+    let msig = mod_sig.specialize(sup.type_args(), Default::default());
     if !sig.equivalent_to(&msig) {
         return Err(error::program_error(&format!(
             "signature does not match:\n  class': {}\n  module's: {}",

--- a/lib/skc_ast2hir/src/class_dict/query.rs
+++ b/lib/skc_ast2hir/src/class_dict/query.rs
@@ -88,7 +88,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
                 if let Some(super_ty) = &sk_class.specialized_superclass(&class_tyargs) {
                     return self.lookup_method_(
                         receiver_type,
-                        super_ty,
+                        &super_ty.to_term_ty(),
                         method_name,
                         method_tyargs,
                     );
@@ -191,9 +191,9 @@ impl<'hir_maker> ClassDict<'hir_maker> {
     }
 
     /// Returns supertype of `ty` (except it is `Object`)
-    pub fn supertype(&self, ty: &TermTy) -> Option<TermTy> {
+    pub fn supertype(&self, ty: &TermTy) -> Option<LitTy> {
         match &ty.body {
-            TyBody::TyPara(TyParamRef { upper_bound, .. }) => Some(upper_bound.to_term_ty()),
+            TyBody::TyPara(TyParamRef { upper_bound, .. }) => Some(upper_bound.clone()),
             _ => self
                 .get_class(&ty.erasure().to_class_fullname())
                 .superclass
@@ -228,10 +228,9 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         self.get_class(classname).superclass.as_ref().map(|scls| {
             let ty = scls.ty();
             let ivars = &self.get_class(&ty.erasure().to_class_fullname()).ivars;
-            let tyargs = ty.tyargs();
             ivars
                 .iter()
-                .map(|(name, ivar)| (name.clone(), ivar.substitute(tyargs)))
+                .map(|(name, ivar)| (name.clone(), ivar.substitute(&ty.type_args)))
                 .collect()
         })
     }

--- a/lib/skc_hir/src/sk_type/sk_class.rs
+++ b/lib/skc_hir/src/sk_type/sk_class.rs
@@ -4,7 +4,7 @@ use crate::superclass::Superclass;
 use crate::{SkIVar, SkIVars};
 use serde::{Deserialize, Serialize};
 use shiika_core::names::ClassFullname;
-use shiika_core::ty::{TermTy, TyBody};
+use shiika_core::ty::{LitTy, TermTy, TyBody};
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -66,7 +66,7 @@ impl SkClass {
     /// Returns supertype of `self` with given `type_args`.
     /// eg. given `class B<Y, X> : A<X>` and `self` is `B` and `type_args` is `[Int, Bool]`,
     /// returns `A<Bool>`.
-    pub fn specialized_superclass(&self, type_args: &[TermTy]) -> Option<TermTy> {
+    pub fn specialized_superclass(&self, type_args: &[TermTy]) -> Option<LitTy> {
         self.superclass.as_ref().map(|sup| {
             let tyargs = sup
                 .type_args()

--- a/lib/skc_hir/src/superclass.rs
+++ b/lib/skc_hir/src/superclass.rs
@@ -1,32 +1,20 @@
 use serde::{Deserialize, Serialize};
-use shiika_core::{names::*, ty, ty::*};
+use shiika_core::{names::*, ty::*};
 
 /// Note that superclass can have type parameters eg.
 /// `class Foo<S, T> : Pair<S, Array<T>>`
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct Superclass(TermTy);
-// TODO: the content should be LitTy rather than TermTy
+pub struct Superclass(LitTy);
 
 impl Superclass {
     /// Create a `Superclass`
-    pub fn from_ty(t: TermTy) -> Superclass {
-        debug_assert!(matches!(t.body, TyBody::TyRaw { .. }));
+    pub fn from_ty(t: LitTy) -> Superclass {
         Superclass(t)
-    }
-
-    /// Create a (possiblly generic) `Superclass`
-    pub fn new(base_name: &ClassFullname, tyargs: Vec<TermTy>) -> Superclass {
-        let t = if tyargs.is_empty() {
-            ty::raw(&base_name.0)
-        } else {
-            ty::spe(&base_name.0, tyargs)
-        };
-        Superclass::from_ty(t)
     }
 
     /// Shortcut from a class name
     pub fn simple(s: &str) -> Superclass {
-        Superclass::from_ty(ty::raw(s))
+        Superclass::from_ty(LitTy::raw(s))
     }
 
     /// Default superclass (= Object)
@@ -34,15 +22,16 @@ impl Superclass {
         Superclass::simple("Object")
     }
 
-    pub fn ty(&self) -> &TermTy {
+    pub fn ty(&self) -> &LitTy {
         &self.0
     }
 
+    pub fn to_term_ty(&self) -> TermTy {
+        self.0.to_term_ty()
+    }
+
     pub fn type_args(&self) -> &[TermTy] {
-        match &self.0.body {
-            TyBody::TyRaw(lit_ty) => &lit_ty.type_args,
-            _ => panic!("broken Superclass"),
-        }
+        &self.0.type_args
     }
 
     pub fn erasure(&self) -> Erasure {


### PR DESCRIPTION
This PR fixes this TODO in superclass.rs.

> // TODO: the content should be LitTy rather than TermTy
