### PR TITLE
refactor: Stop pushing the same item to captures

### DIFF
--- a/lib/skc_ast2hir/src/convert_exprs/lvar.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/lvar.rs
@@ -1,0 +1,61 @@
+use shiika_ast::*;
+use shiika_core::ty::*;
+use skc_hir::*;
+
+/// Result of looking up a lvar
+#[derive(Debug)]
+pub(super) struct LVarInfo {
+    pub ty: TermTy,
+    pub detail: LVarDetail,
+    /// The position of this lvar in the source text
+    pub locs: LocationSpan,
+}
+#[derive(Debug)]
+pub(super) enum LVarDetail {
+    /// Found in the current scope
+    CurrentScope { name: String },
+    /// Found in the current method/lambda argument
+    Argument { idx: usize },
+    /// Found in outer scope
+    OuterScope {
+        /// Index of the lvar in `captures`
+        cidx: usize,
+        readonly: bool,
+    },
+    /// Same as `OuterScope` but `cidx` is not yet resolved.
+    OuterScope_ { readonly: bool },
+}
+
+impl LVarInfo {
+    /// Returns HirExpression to refer this lvar
+    pub fn ref_expr(self) -> HirExpression {
+        match self.detail {
+            LVarDetail::CurrentScope { name } => Hir::lvar_ref(self.ty, name, self.locs),
+            LVarDetail::Argument { idx } => Hir::arg_ref(self.ty, idx, self.locs),
+            LVarDetail::OuterScope { cidx, readonly } => {
+                Hir::lambda_capture_ref(self.ty, cidx, readonly, self.locs)
+            }
+            LVarDetail::OuterScope_ { .. } => panic!("[BUG] OuterScope_ leak"),
+        }
+    }
+
+    /// Returns HirExpression to update this lvar
+    pub fn assign_expr(self, expr: HirExpression) -> HirExpression {
+        match self.detail {
+            LVarDetail::CurrentScope { name, .. } => Hir::lvar_assign(name, expr, self.locs),
+            LVarDetail::Argument { .. } => panic!("[BUG] Cannot reassign argument"),
+            LVarDetail::OuterScope { cidx, .. } => Hir::lambda_capture_write(cidx, expr, self.locs),
+            LVarDetail::OuterScope_ { .. } => panic!("[BUG] OuterScope_ leak"),
+        }
+    }
+
+    /// Set `cidx` with the given value
+    pub fn set_cidx(&mut self, cidx: usize) {
+        match self.detail {
+            LVarDetail::OuterScope_ { readonly } => {
+                self.detail = LVarDetail::OuterScope { cidx, readonly }
+            }
+            _ => panic!("[BUG] Not LVarDetail::OuterScope_"),
+        }
+    }
+}

--- a/lib/skc_ast2hir/src/ctx_stack.rs
+++ b/lib/skc_ast2hir/src/ctx_stack.rs
@@ -214,13 +214,6 @@ impl CtxStack {
         }
     }
 
-    /// Push a LambdaCapture to captures
-    pub fn push_lambda_capture(&mut self, cap: LambdaCapture) -> usize {
-        let lambda_ctx = self.lambda_ctx_mut().expect("not in lambda");
-        lambda_ctx.captures.push(cap);
-        lambda_ctx.captures.len() - 1
-    }
-
     /// Returns type parameter of the current class
     pub fn current_class_typarams(&self) -> Vec<TyParam> {
         if let Some(class_ctx) = self.class_ctx() {

--- a/lib/skc_ast2hir/src/hir_maker_context.rs
+++ b/lib/skc_ast2hir/src/hir_maker_context.rs
@@ -115,6 +115,19 @@ pub struct LambdaCtx {
     pub has_break: bool,
 }
 
+impl LambdaCtx {
+    /// Push a LambdaCapture to captures
+    pub fn push_lambda_capture(&mut self, cap: LambdaCapture) -> usize {
+        self.captures.push(cap);
+        self.captures.len() - 1
+    }
+
+    /// Returns cidx if `cap` is already in the `captuers`.
+    pub fn check_already_captured(&self, cap: &LambdaCapture) -> Option<usize> {
+        self.captures.iter().position(|x| x.equals(cap))
+    }
+}
+
 /// Indicates we're in a while expr
 #[derive(Debug)]
 pub struct WhileCtx;
@@ -149,4 +162,27 @@ pub struct LambdaCapture {
 pub enum LambdaCaptureDetail {
     CapLVar { name: String },
     CapFnArg { idx: usize },
+}
+
+impl LambdaCapture {
+    fn equals(&self, other: &LambdaCapture) -> bool {
+        if self.ctx_depth != other.ctx_depth {
+            return false;
+        }
+        let equals = match (&self.detail, &other.detail) {
+            (
+                LambdaCaptureDetail::CapLVar { name },
+                LambdaCaptureDetail::CapLVar { name: name2 },
+            ) => name == name2,
+            (
+                LambdaCaptureDetail::CapFnArg { idx },
+                LambdaCaptureDetail::CapFnArg { idx: idx2 },
+            ) => idx == idx2,
+            _ => false,
+        };
+        if equals {
+            debug_assert!(self.ty == other.ty);
+        }
+        equals
+    }
 }


### PR DESCRIPTION
This PR implements `LambdaCapture::equals`. Given this program,

```sk
...
  def foo
    let a = 1
    let f = fn(){ 
      p a
      p a
    }
```

current code pushes reference to `a` to the `captures` twice because it appears twice in the lambda. This is ridiculous and this PR fixes it.