### PR TITLE
Each lambda captures should have its own LLVM type

### DIFF
--- a/builtin/fn.sk
+++ b/builtin/fn.sk
@@ -5,7 +5,7 @@ class Fn
   def initialize(
     @func: Shiika::Internal::Ptr,
     @the_self: Object,
-    @captures: Array<Shiika::Internal::Ptr>,
+    @captures: Shiika::Internal::Ptr,
   )
     let @exit_status = EXIT_NORMAL
   end

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -346,7 +346,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         readonly: &bool,
         locs: &LocationSpan,
     ) -> Result<HirExpression> {
-        if self._lookup_var(name, locs.clone()).is_some() {
+        if self._lookup_var(name, locs.clone())?.is_some() {
             return Err(error::lvar_redeclaration(name, locs));
         }
         let expr = self.convert_expr(rhs)?;
@@ -363,14 +363,20 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         locs: &LocationSpan,
     ) -> Result<HirExpression> {
         let expr = self.convert_expr(rhs)?;
-        if let Some(mut lvar_info) = self._find_var(name, locs.clone(), true)? {
+        if let (Some(mut lvar_info), opt_cidx) = self._find_var(name, locs.clone(), true)? {
             if lvar_info.ty != expr.ty {
                 if let Some(t) = self
                     .class_dict
                     .nearest_common_ancestor(&lvar_info.ty, &expr.ty)
                 {
                     // Upgrade lvar type (eg. from `None` to `Maybe<Int>`)
-                    lvar_info.ty = t;
+                    lvar_info.ty = t.clone();
+                    if let Some(cidx) = opt_cidx {
+                        self.ctx_stack
+                            .lambda_ctx_mut()
+                            .unwrap()
+                            .update_capture_ty(cidx, t);
+                    }
                 } else {
                     return Err(type_checking::invalid_reassign_error(
                         &lvar_info.ty,
@@ -580,7 +586,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
     /// Generate local variable reference or method call with implicit receiver(self)
     fn convert_bare_name(&mut self, name: &str, locs: &LocationSpan) -> Result<HirExpression> {
         // Found a local variable
-        if let Some(lvar_info) = self._find_var(name, locs.clone(), false)? {
+        if let (Some(lvar_info), _) = self._find_var(name, locs.clone(), false)? {
             return Ok(lvar_info.ref_expr());
         }
 
@@ -600,8 +606,9 @@ impl<'hir_maker> HirMaker<'hir_maker> {
     }
 
     /// Return the variable of the given name, if any
-    fn _lookup_var(&mut self, name: &str, locs: LocationSpan) -> Option<LVarInfo> {
-        self._find_var(name, locs, false).unwrap()
+    fn _lookup_var(&mut self, name: &str, locs: LocationSpan) -> Result<Option<LVarInfo>> {
+        let (lvar, _) = self._find_var(name, locs, false)?;
+        Ok(lvar)
     }
 
     /// Find the variable of the given name.
@@ -611,23 +618,27 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         name: &str,
         locs: LocationSpan,
         updating: bool,
-    ) -> Result<Option<LVarInfo>> {
+    ) -> Result<(Option<LVarInfo>, Option<usize>)> {
         if self.ctx_stack.lambda_ctx().is_some() {
             let (mut found, opt_cap) = self.__find_var(true, name, locs, updating)?;
-            if let Some(cap) = opt_cap {
+            let opt_cidx = if let Some(cap) = opt_cap {
                 let lambda_ctx = self.ctx_stack.lambda_ctx_mut().unwrap();
                 if let Some(existing) = lambda_ctx.check_already_captured(&cap) {
                     found.as_mut().map(|x| x.set_cidx(existing));
+                    Some(existing)
                 } else {
                     let cidx = lambda_ctx.captures.len();
                     lambda_ctx.push_lambda_capture(cap);
                     found.as_mut().map(|x| x.set_cidx(cidx));
+                    Some(cidx)
                 }
-            }
-            Ok(found)
+            } else {
+                None
+            };
+            Ok((found, opt_cidx))
         } else {
             let (found, _) = self.__find_var(false, name, locs, updating)?;
-            Ok(found)
+            Ok((found, None))
         }
     }
 

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -563,21 +563,34 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 // The variable is in this scope
                 match cap.detail {
                     LambdaCaptureDetail::CapLVar { name } => {
-                        ret.push(HirLambdaCapture::CaptureLVar { name, ty: cap.ty });
+                        ret.push(HirLambdaCapture {
+                            ty: cap.ty,
+                            upcast_needed: cap.upcast_needed,
+                            detail: HirLambdaCaptureDetail::CaptureLVar { name },
+                        });
                     }
                     LambdaCaptureDetail::CapFnArg { idx } => {
-                        ret.push(HirLambdaCapture::CaptureArg { idx, ty: cap.ty });
+                        ret.push(HirLambdaCapture {
+                            ty: cap.ty,
+                            upcast_needed: cap.upcast_needed,
+                            detail: HirLambdaCaptureDetail::CaptureArg { idx },
+                        });
                     }
                 }
             } else {
                 // The variable is in outer scope
                 let ty = cap.ty.clone();
+                let upcast_needed = cap.upcast_needed;
                 let cidx = self
                     .ctx_stack
                     .lambda_ctx_mut()
                     .unwrap()
                     .push_lambda_capture(cap);
-                ret.push(HirLambdaCapture::CaptureFwd { cidx, ty });
+                ret.push(HirLambdaCapture {
+                    ty,
+                    upcast_needed,
+                    detail: HirLambdaCaptureDetail::CaptureFwd { cidx },
+                });
             }
         }
         ret
@@ -663,6 +676,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                     let cap = LambdaCapture {
                         ctx_depth: opt_depth,
                         ty: lvar.ty.clone(),
+                        upcast_needed: false,
                         detail: LambdaCaptureDetail::CapLVar {
                             name: name.to_string(),
                         },
@@ -695,6 +709,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                     let cap = LambdaCapture {
                         ctx_depth: opt_depth,
                         ty: param.ty.clone(),
+                        upcast_needed: false,
                         detail: LambdaCaptureDetail::CapFnArg { idx },
                     };
                     let lvar_info = LVarInfo {

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -557,10 +557,10 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 // The variable is in this scope
                 match cap.detail {
                     LambdaCaptureDetail::CapLVar { name } => {
-                        ret.push(HirLambdaCapture::CaptureLVar { name });
+                        ret.push(HirLambdaCapture::CaptureLVar { name, ty: cap.ty });
                     }
                     LambdaCaptureDetail::CapFnArg { idx } => {
-                        ret.push(HirLambdaCapture::CaptureArg { idx });
+                        ret.push(HirLambdaCapture::CaptureArg { idx, ty: cap.ty });
                     }
                 }
             } else {

--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -20,7 +20,7 @@ pub fn convert_method_call(
 ) -> Result<HirExpression> {
     // Check if this is a lambda invocation
     if receiver_expr.is_none() {
-        if let Some(lvar) = mk._lookup_var(&method_name.0, locs.clone()) {
+        if let Some(lvar) = mk._lookup_var(&method_name.0, locs.clone())? {
             if lvar.ty.fn_x_info().is_some() {
                 return convert_lambda_invocation(mk, lvar.ref_expr(), arg_exprs, has_block, locs);
             }

--- a/lib/skc_ast2hir/src/hir_maker_context.rs
+++ b/lib/skc_ast2hir/src/hir_maker_context.rs
@@ -123,8 +123,9 @@ impl LambdaCtx {
     }
 
     pub fn update_capture_ty(&mut self, cidx: usize, ty: TermTy) {
-        let cap = self.captures[cidx];
+        let cap = &mut self.captures[cidx];
         cap.ty = ty;
+        cap.upcast_needed = true;
     }
 
     /// Returns cidx if `cap` is already in the `captuers`.
@@ -160,6 +161,7 @@ pub struct LambdaCapture {
     /// None if the lvar does not belong to a lambda (method argument, etc.)
     pub ctx_depth: Option<usize>,
     pub ty: TermTy,
+    pub upcast_needed: bool,
     pub detail: LambdaCaptureDetail,
 }
 

--- a/lib/skc_ast2hir/src/hir_maker_context.rs
+++ b/lib/skc_ast2hir/src/hir_maker_context.rs
@@ -122,6 +122,11 @@ impl LambdaCtx {
         self.captures.len() - 1
     }
 
+    pub fn update_capture_ty(&mut self, cidx: usize, ty: TermTy) {
+        let cap = self.captures[cidx];
+        cap.ty = ty;
+    }
+
     /// Returns cidx if `cap` is already in the `captuers`.
     pub fn check_already_captured(&self, cap: &LambdaCapture) -> Option<usize> {
         self.captures.iter().position(|x| x.equals(cap))

--- a/lib/skc_codegen/src/code_gen_context.rs
+++ b/lib/skc_codegen/src/code_gen_context.rs
@@ -25,7 +25,7 @@ pub struct CodeGenContext<'hir: 'run, 'run> {
 #[derive(Debug, PartialEq)]
 pub enum FunctionOrigin {
     Method,
-    Lambda,
+    Lambda { name: String },
     Other,
 }
 
@@ -62,5 +62,12 @@ impl<'hir, 'run> CodeGenContext<'hir, 'run> {
             .collect();
         std::mem::swap(&mut new_lvars, &mut self.lvars);
         new_lvars
+    }
+
+    pub fn lambda_name(&self) -> Option<&str> {
+        match &self.function_origin {
+            FunctionOrigin::Lambda { name } => Some(name),
+            _ => None,
+        }
     }
 }

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -1028,9 +1028,8 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(block);
 
         let captures = self._gen_get_lambda_captures(ctx);
-        let ptr = captures.load(self, *idx_in_captures).into_pointer_value();
         let value = self.gen_expr(ctx, rhs)?.unwrap();
-        self.builder.build_store(ptr, value.0);
+        captures.reassign(self, *idx_in_captures, value.clone());
 
         let block = self.context.append_basic_block(
             ctx.function,

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -1,10 +1,92 @@
-use crate::utils::{llvm_func_name, LlvmFuncName};
+use crate::utils::{lambda_capture_struct_name, LlvmFuncName};
+use crate::values::{I8Ptr, SkObj};
 use crate::CodeGen;
 use anyhow::Result;
 use either::Either::*;
+use inkwell::types::BasicType;
 use shiika_core::ty::*;
 use skc_hir::HirExpressionBase::*;
 use skc_hir::*;
+
+/// A lambda capture
+#[derive(Debug)]
+pub struct LambdaCapture<'run> {
+    /// Pointer to the struct
+    raw: inkwell::values::PointerValue<'run>,
+}
+
+impl<'run> LambdaCapture<'run> {
+    /// Returns LLVM struct type for a lambda
+    pub fn get_struct_type<'ictx>(gen: &CodeGen, name: &str) -> inkwell::types::StructType<'ictx> {
+        gen.context
+            .get_struct_type(&lambda_capture_struct_name(name))
+            .unwrap()
+    }
+
+    pub fn struct_ptr_type<'ictx>(gen: &CodeGen, name: &str) -> inkwell::types::PointerType<'ictx> {
+        Self::get_struct_type(gen, name).ptr_type(inkwell::AddressSpace::Generic)
+    }
+
+    fn new(
+        gen: &CodeGen,
+        lambda_name: String,
+        raw: inkwell::values::PointerValue<'run>,
+    ) -> LambdaCapture<'run> {
+        debug_assert!(raw.get_type() == Self::struct_ptr_type(gen, &lambda_name));
+        LambdaCapture { raw }
+    }
+
+    pub fn from_boxed(
+        gen: &CodeGen<'_, 'run, '_>,
+        boxed: SkObj<'run>,
+        name: &str,
+    ) -> LambdaCapture<'run> {
+        LambdaCapture::from_void_ptr(gen, gen.unbox_i8ptr(boxed), name)
+    }
+
+    pub fn from_void_ptr(
+        gen: &CodeGen<'_, 'run, '_>,
+        p: I8Ptr<'run>,
+        name: &str,
+    ) -> LambdaCapture<'run> {
+        let t = Self::struct_ptr_type(gen, name);
+        LambdaCapture::new(gen, name.to_string(), p.cast_to(gen, t))
+    }
+
+    /// Box `self` with Shiika::Internal::Ptr
+    pub fn boxed(&self, gen: &CodeGen<'_, 'run, '_>) -> SkObj<'run> {
+        self.to_void_ptr(gen).boxed(gen)
+    }
+
+    /// Returns the address of `self` as void pointer
+    fn to_void_ptr(&self, gen: &CodeGen<'_, 'run, '_>) -> I8Ptr<'run> {
+        I8Ptr::cast(gen, self.to_struct_ptr())
+    }
+
+    /// Returns the address of `self`
+    fn to_struct_ptr(&self) -> inkwell::values::PointerValue<'run> {
+        self.raw
+    }
+
+    /// Store `value` at the given index
+    pub fn store(&self, gen: &CodeGen, idx: usize, value: inkwell::values::BasicValueEnum<'run>) {
+        gen.build_llvm_struct_set_(
+            self.to_struct_ptr(),
+            idx,
+            value,
+            &format!("capture_{}th", idx),
+        );
+    }
+
+    /// Load the value at the given index
+    pub fn load(
+        &self,
+        gen: &CodeGen<'_, 'run, '_>,
+        idx: usize,
+    ) -> inkwell::values::BasicValueEnum<'run> {
+        gen.build_llvm_struct_ref_(self.to_struct_ptr(), idx, "load")
+    }
+}
 
 impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
     /// Find all lambdas in a hir and create the body of the corresponding llvm function
@@ -117,7 +199,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 lvars,
                 ..
             } => {
-                self.gen_lambda_func(&llvm_func_name(name), params, exprs, ret_ty, lvars)?;
+                self.gen_lambda_func(&name, params, exprs, ret_ty, lvars)?;
                 self.gen_lambda_funcs_in_exprs(&exprs.exprs)?;
             }
             HirSelfExpression => (),
@@ -137,12 +219,170 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
     fn gen_lambda_func(
         &self,
-        func_name: &LlvmFuncName,
+        name: &str,
         params: &'hir [MethodParam],
         exprs: &'hir HirExpressions,
         ret_ty: &TermTy,
         lvars: &[(String, TermTy)],
     ) -> Result<()> {
-        self.gen_llvm_func_body(func_name, params, Right(exprs), lvars, ret_ty, true)
+        let func_name = LlvmFuncName(name.to_string());
+        self.gen_llvm_func_body(
+            &func_name,
+            params,
+            Right(exprs),
+            lvars,
+            ret_ty,
+            Some(name.to_string()),
+        )
+    }
+
+    /// TODO: refactor (preprocess in MIR)
+    pub(super) fn gen_lambda_capture_structs(&self, hir: &'hir Hir) -> Result<()> {
+        for methods in hir.sk_methods.values() {
+            for method in methods {
+                if let SkMethodBody::Normal { exprs } = &method.body {
+                    self.gen_lambda_capture_structs_in_exprs(&exprs.exprs)?;
+                }
+            }
+        }
+
+        for expr in &hir.const_inits {
+            self.gen_lambda_capture_structs_in_expr(expr)?;
+        }
+
+        self.gen_lambda_capture_structs_in_exprs(&hir.main_exprs.exprs)?;
+        Ok(())
+    }
+
+    fn gen_lambda_capture_structs_in_exprs(&self, exprs: &'hir [HirExpression]) -> Result<()> {
+        for expr in exprs {
+            self.gen_lambda_capture_structs_in_expr(expr)?;
+        }
+        Ok(())
+    }
+
+    fn gen_lambda_capture_structs_in_expr(&self, expr: &'hir HirExpression) -> Result<()> {
+        match &expr.node {
+            HirLogicalNot { expr } => self.gen_lambda_capture_structs_in_expr(expr)?,
+            HirLogicalAnd { left, right } => {
+                self.gen_lambda_capture_structs_in_expr(left)?;
+                self.gen_lambda_capture_structs_in_expr(right)?;
+            }
+            HirLogicalOr { left, right } => {
+                self.gen_lambda_capture_structs_in_expr(left)?;
+                self.gen_lambda_capture_structs_in_expr(right)?;
+            }
+            HirIfExpression {
+                cond_expr,
+                then_exprs,
+                else_exprs,
+            } => {
+                self.gen_lambda_capture_structs_in_expr(cond_expr)?;
+                self.gen_lambda_capture_structs_in_exprs(&then_exprs.exprs)?;
+                self.gen_lambda_capture_structs_in_exprs(&else_exprs.exprs)?;
+            }
+            HirMatchExpression {
+                cond_assign_expr,
+                clauses,
+            } => {
+                self.gen_lambda_capture_structs_in_expr(cond_assign_expr)?;
+                for clause in clauses {
+                    self.gen_lambda_capture_structs_in_exprs(&clause.body_hir.exprs)?;
+                }
+            }
+            HirWhileExpression {
+                cond_expr,
+                body_exprs,
+            } => {
+                self.gen_lambda_capture_structs_in_expr(cond_expr)?;
+                self.gen_lambda_capture_structs_in_exprs(&body_exprs.exprs)?;
+            }
+            HirBreakExpression { .. } => (),
+            HirReturnExpression { arg, .. } => self.gen_lambda_capture_structs_in_expr(arg)?,
+            HirLVarAssign { rhs, .. } => self.gen_lambda_capture_structs_in_expr(rhs)?,
+            HirIVarAssign { rhs, .. } => self.gen_lambda_capture_structs_in_expr(rhs)?,
+            HirConstAssign { rhs, .. } => self.gen_lambda_capture_structs_in_expr(rhs)?,
+            HirMethodCall {
+                receiver_expr,
+                arg_exprs,
+                ..
+            } => {
+                self.gen_lambda_capture_structs_in_expr(receiver_expr)?;
+                for expr in arg_exprs {
+                    self.gen_lambda_capture_structs_in_expr(expr)?;
+                }
+            }
+            HirModuleMethodCall {
+                receiver_expr,
+                arg_exprs,
+                ..
+            } => {
+                self.gen_lambda_capture_structs_in_expr(receiver_expr)?;
+                for expr in arg_exprs {
+                    self.gen_lambda_capture_structs_in_expr(expr)?;
+                }
+            }
+            HirLambdaInvocation {
+                lambda_expr,
+                arg_exprs,
+            } => {
+                self.gen_lambda_capture_structs_in_expr(lambda_expr)?;
+                for expr in arg_exprs {
+                    self.gen_lambda_capture_structs_in_expr(expr)?;
+                }
+            }
+            HirArgRef { .. } => (),
+            HirLVarRef { .. } => (),
+            HirIVarRef { .. } => (),
+            HirTVarRef { .. } => (),
+            HirConstRef { .. } => (),
+            HirLambdaExpr {
+                name,
+                exprs,
+                captures,
+                ..
+            } => {
+                self.gen_lambda_capture_struct(name, captures)?;
+                self.gen_lambda_capture_structs_in_exprs(&exprs.exprs)?;
+            }
+            HirSelfExpression => (),
+            HirFloatLiteral { .. } => (),
+            HirDecimalLiteral { .. } => (),
+            HirStringLiteral { .. } => (),
+            HirBooleanLiteral { .. } => (),
+
+            HirLambdaCaptureRef { .. } => (),
+            HirLambdaCaptureWrite { rhs, .. } => self.gen_lambda_capture_structs_in_expr(rhs)?,
+            HirBitCast { expr } => self.gen_lambda_capture_structs_in_expr(expr)?,
+            HirClassLiteral { .. } => (),
+            HirParenthesizedExpr { exprs } => {
+                self.gen_lambda_capture_structs_in_exprs(&exprs.exprs)?
+            }
+        }
+        Ok(())
+    }
+
+    fn gen_lambda_capture_struct(&self, name: &str, captures: &[HirLambdaCapture]) -> Result<()> {
+        let struct_name = lambda_capture_struct_name(name);
+        let struct_type = self.context.opaque_struct_type(&struct_name);
+        let body = captures
+            .iter()
+            .map(|cap| self.capture_ty(cap))
+            .collect::<Vec<_>>();
+        struct_type.set_body(&body, false);
+        Ok(()) // REFACTOR: not needed to be a Result
+    }
+
+    fn capture_ty(&self, cap: &HirLambdaCapture) -> inkwell::types::BasicTypeEnum {
+        match cap {
+            // Local vars are captured by reference
+            HirLambdaCapture::CaptureLVar { ty, .. } => self
+                .llvm_type(ty)
+                .ptr_type(inkwell::AddressSpace::Generic)
+                .as_basic_type_enum(),
+            // Method args are captured by value (because they are not writable)
+            HirLambdaCapture::CaptureArg { ty, .. } => self.llvm_type(ty),
+            HirLambdaCapture::CaptureFwd { ty, .. } => self.llvm_type(ty),
+        }
     }
 }

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -71,7 +71,7 @@ impl<'run> LambdaCapture<'run> {
 
     /// Store `value` at the given index
     pub fn store(&self, gen: &CodeGen, idx: usize, value: inkwell::values::BasicValueEnum<'run>) {
-        gen.build_llvm_struct_set_(
+        gen.build_llvm_struct_set(
             self.to_struct_ptr(),
             idx,
             value,
@@ -85,7 +85,7 @@ impl<'run> LambdaCapture<'run> {
         gen: &CodeGen<'_, 'run, '_>,
         idx: usize,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        gen.build_llvm_struct_ref_(self.to_struct_ptr(), idx, "load")
+        gen.build_llvm_struct_ref(self.to_struct_ptr(), idx, "load")
     }
 
     /// Given there is a pointer stored at `idx`, update its value.

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -374,15 +374,15 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
     }
 
     fn capture_ty(&self, cap: &HirLambdaCapture) -> inkwell::types::BasicTypeEnum {
-        match cap {
+        match &cap.detail {
             // Local vars are captured by reference
-            HirLambdaCapture::CaptureLVar { ty, .. } => self
-                .llvm_type(ty)
+            HirLambdaCaptureDetail::CaptureLVar { .. } => self
+                .llvm_type(&cap.ty)
                 .ptr_type(inkwell::AddressSpace::Generic)
                 .as_basic_type_enum(),
             // Method args are captured by value (because they are not writable)
-            HirLambdaCapture::CaptureArg { ty, .. } => self.llvm_type(ty),
-            HirLambdaCapture::CaptureFwd { ty, .. } => self.llvm_type(ty),
+            HirLambdaCaptureDetail::CaptureArg { .. } => self.llvm_type(&cap.ty),
+            HirLambdaCaptureDetail::CaptureFwd { .. } => self.llvm_type(&cap.ty),
         }
     }
 }

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -108,6 +108,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         self.define_class_class();
         self.gen_imports(imports);
         self.gen_type_structs(&hir.sk_types);
+        self.gen_lambda_capture_structs(hir)?;
         self.gen_string_literals(&hir.str_literals);
         self.gen_constant_ptrs(&hir.constants);
         self.gen_boxing_funcs();
@@ -572,7 +573,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             Left(&method.body),
             &method.lvars,
             &method.signature.ret_ty,
-            false,
+            None,
         )
     }
 
@@ -585,8 +586,9 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         body: Either<&'hir SkMethodBody, &'hir HirExpressions>,
         lvars: &[(String, TermTy)],
         ret_ty: &TermTy,
-        is_lambda: bool,
+        lambda_name: Option<String>,
     ) -> Result<()> {
+        let is_lambda = lambda_name.is_some();
         // LLVM function
         // (Function for lambdas are created in gen_lambda_expr)
         let function = self.get_llvm_func(func_name);
@@ -653,7 +655,9 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 self.gen_shiika_function_body(
                     function,
                     Some(params),
-                    FunctionOrigin::Lambda,
+                    FunctionOrigin::Lambda {
+                        name: lambda_name.unwrap(),
+                    },
                     ret_ty,
                     exprs,
                     lvar_ptrs,

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -34,7 +34,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Load value of an instance variable
     pub fn build_ivar_load(&self, object: SkObj<'run>, idx: usize, name: &str) -> SkObj<'run> {
-        SkObj(self.build_llvm_struct_ref(object, OBJ_HEADER_SIZE + idx, name))
+        SkObj(self.build_object_struct_ref(object, OBJ_HEADER_SIZE + idx, name))
     }
 
     /// Store value into an instance variable
@@ -56,28 +56,28 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         value: inkwell::values::BasicValueEnum<'a>,
         name: &str,
     ) {
-        self.build_llvm_struct_set(object, OBJ_HEADER_SIZE + idx, value, name)
+        self.build_object_struct_set(object, OBJ_HEADER_SIZE + idx, value, name)
     }
 
     /// Get the vtable of an object as i8ptr
     pub fn get_vtable_of_obj(&self, object: SkObj<'run>) -> VTableRef<'run> {
-        VTableRef(self.build_llvm_struct_ref(object, OBJ_VTABLE_IDX, "vtable"))
+        VTableRef(self.build_object_struct_ref(object, OBJ_VTABLE_IDX, "vtable"))
     }
 
     /// Get the class object of an object as `*Class`
     pub fn get_class_of_obj(&self, object: SkObj<'run>) -> SkClassObj<'run> {
-        SkClassObj(self.build_llvm_struct_ref(object, OBJ_CLASS_IDX, "class"))
+        SkClassObj(self.build_object_struct_ref(object, OBJ_CLASS_IDX, "class"))
     }
 
     /// Set `class_obj` to the class object field of `object`
     pub fn set_class_of_obj(&self, object: &SkObj<'run>, class_obj: SkClassObj<'run>) {
         let cast = self.bitcast(SkObj(class_obj.0), &ty::raw("Class"), "class");
-        self.build_llvm_struct_set(object, OBJ_CLASS_IDX, cast.0, "my_class");
+        self.build_object_struct_set(object, OBJ_CLASS_IDX, cast.0, "my_class");
     }
 
     /// Set `vtable` to `object`
     pub fn set_vtable_of_obj(&self, object: &SkObj<'run>, vtable: VTableRef<'run>) {
-        self.build_llvm_struct_set(object, OBJ_VTABLE_IDX, vtable.0, "vtable");
+        self.build_object_struct_set(object, OBJ_VTABLE_IDX, vtable.0, "vtable");
     }
 
     /// Get vtable of the class of the given name
@@ -119,59 +119,50 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .unwrap()
     }
 
-    /// Load value of nth element of llvm struct
-    fn build_llvm_struct_ref(
+    /// Load value of the nth element of the llvm struct of a Shiika object
+    fn build_object_struct_ref(
         &self,
         object: SkObj<'run>,
         idx: usize,
         name: &str,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        let obj_ptr = object.0.into_pointer_value();
-        let obj_ptr_ty = obj_ptr.get_type();
+        let ptr = object.0.into_pointer_value();
+        self.build_llvm_struct_ref(ptr, idx, name)
+    }
+
+    /// Load value of the nth element of a llvm struct
+    pub fn build_llvm_struct_ref(
+        &self,
+        struct_ptr: inkwell::values::PointerValue<'run>,
+        idx: usize,
+        name: &str,
+    ) -> inkwell::values::BasicValueEnum<'run> {
         let ptr = self
             .builder
-            .build_struct_gep(
-                obj_ptr,
-                idx as u32,
-                &format!("addr_{}", name),
-            )
+            .build_struct_gep(struct_ptr, idx as u32, &format!("addr_{}", name))
             .unwrap_or_else(|_| {
-                let pointee_ty = obj_ptr_ty.get_element_type();
                 panic!(
-                    "build_llvm_struct_ref: elem not found (idx: {}, name: {}, pointee_ty: {:?}, object: {:?})",
-                    &idx, &name, &pointee_ty, &object
+                    "build_llvm_struct_ref: elem not found (idx: {}, name: {}, struct_ptr: {:?})",
+                    &idx, &name, &struct_ptr
                 )
             });
         self.builder.build_load(ptr, name)
     }
 
-    /// Set value to nth element of llvm struct
-    /// REFACTOR: merge this into build_llvm_struct_set_
-    pub fn build_llvm_struct_set<'a>(
+    /// Set the value the nth element of llvm struct of a Shiika object
+    fn build_object_struct_set<'a>(
         &'a self,
         object: &'a SkObj<'a>,
         idx: usize,
         value: inkwell::values::BasicValueEnum<'a>,
         name: &str,
     ) {
-        let ptr = self
-            .builder
-            .build_struct_gep(
-                object.0.into_pointer_value(),
-                idx as u32,
-                &format!("addr_{}", name),
-            )
-            .unwrap_or_else(|_| {
-                panic!(
-                    "build_llvm_struct_set: elem not found (idx in struct: {}, register name: {}, object: {:?})",
-                    &idx, &name, &object
-                )
-            });
-        self.builder.build_store(ptr, value);
+        let ptr = object.0.into_pointer_value();
+        self.build_llvm_struct_set(ptr, idx, value, name);
     }
 
-    /// Same as build_llvm_struct_set but takes PointerValue
-    pub fn build_llvm_struct_set_<'a>(
+    /// Set the value the nth element of llvm struct
+    pub fn build_llvm_struct_set<'a>(
         &'a self,
         struct_ptr: inkwell::values::PointerValue<'a>,
         idx: usize,
@@ -192,23 +183,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 )
             });
         self.builder.build_store(ptr, value);
-    }
-    pub fn build_llvm_struct_ref_(
-        &self,
-        struct_ptr: inkwell::values::PointerValue<'run>,
-        idx: usize,
-        name: &str,
-    ) -> inkwell::values::BasicValueEnum<'run> {
-        let ptr = self
-            .builder
-            .build_struct_gep(struct_ptr, idx as u32, &format!("addr_{}", name))
-            .unwrap_or_else(|_| {
-                panic!(
-                    "build_llvm_struct_ref: elem not found (idx: {}, name: {}, struct_ptr: {:?})",
-                    &idx, &name, &struct_ptr
-                )
-            });
-        self.builder.build_load(ptr, name)
     }
 
     /// Generate call of malloc and returns a ptr to Shiika object

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -43,6 +43,36 @@ impl<'run> VTableRef<'run> {
     }
 }
 
-/// i8*
+/// i8* (REFACTOR: rename to VoidPtr)
 #[derive(Debug)]
 pub struct I8Ptr<'run>(pub inkwell::values::PointerValue<'run>);
+
+impl<'run> I8Ptr<'run> {
+    /// Create a void pointer with bitcast
+    pub fn cast(
+        gen: &CodeGen<'_, 'run, '_>,
+        p: inkwell::values::PointerValue<'run>,
+    ) -> I8Ptr<'run> {
+        I8Ptr(
+            gen.builder
+                .build_bitcast(p, gen.i8ptr_type, "cast")
+                .into_pointer_value(),
+        )
+    }
+
+    /// Box `self` with `Shiika::Internal::Ptr`
+    pub fn boxed(self, gen: &CodeGen<'_, 'run, '_>) -> SkObj<'run> {
+        gen.box_i8ptr(self.0.into())
+    }
+
+    /// Returns `PointerValue` cast to `t`
+    pub fn cast_to(
+        self,
+        gen: &CodeGen<'_, 'run, '_>,
+        t: inkwell::types::PointerType<'run>,
+    ) -> inkwell::values::PointerValue<'run> {
+        gen.builder
+            .build_bitcast(self.0, t, "cast_to")
+            .into_pointer_value()
+    }
+}

--- a/lib/skc_corelib/src/fn_x.rs
+++ b/lib/skc_corelib/src/fn_x.rs
@@ -42,7 +42,7 @@ fn ivars() -> HashMap<String, SkIVar> {
         SkIVar {
             name: "@captures".to_string(),
             idx: 2,
-            ty: ty::ary(ty::raw("Shiika::Internal::Ptr")),
+            ty: ty::raw("Shiika::Internal::Ptr"),
             readonly: true,
         },
     );

--- a/lib/skc_hir/src/lib.rs
+++ b/lib/skc_hir/src/lib.rs
@@ -228,13 +228,13 @@ pub enum HirExpressionBase {
     //
     // Special opecodes (does not appear in a source program directly)
     //
-    /// Refer a variable in `captures`
+    /// Refer a variable in the `captures` of the current lambda
     HirLambdaCaptureRef {
         idx: usize,
         /// Whether this capture is a readonly one (i.e. passed by value)
         readonly: bool,
     },
-    /// Reassign to a variable in `captures`
+    /// Reassign to a variable in the `captures` of the current lambda
     HirLambdaCaptureWrite {
         cidx: usize,
         rhs: Box<HirExpression>,
@@ -263,9 +263,9 @@ pub enum HirExpressionBase {
 #[derive(Debug, Clone)]
 pub enum HirLambdaCapture {
     /// Local variable
-    CaptureLVar { name: String },
+    CaptureLVar { name: String, ty: TermTy },
     /// Method/Function argument
-    CaptureArg { idx: usize },
+    CaptureArg { idx: usize, ty: TermTy },
     /// Variable in the current `captures`
     /// `ty` is needed for bitcast
     CaptureFwd { cidx: usize, ty: TermTy },

--- a/lib/skc_hir/src/lib.rs
+++ b/lib/skc_hir/src/lib.rs
@@ -261,14 +261,21 @@ pub enum HirExpressionBase {
 
 /// Denotes which variable to include in the `captures`
 #[derive(Debug, Clone)]
-pub enum HirLambdaCapture {
+pub struct HirLambdaCapture {
+    pub ty: TermTy,
+    pub upcast_needed: bool,
+    pub detail: HirLambdaCaptureDetail,
+}
+
+#[derive(Debug, Clone)]
+pub enum HirLambdaCaptureDetail {
     /// Local variable
-    CaptureLVar { name: String, ty: TermTy },
+    CaptureLVar { name: String },
     /// Method/Function argument
-    CaptureArg { idx: usize, ty: TermTy },
+    CaptureArg { idx: usize },
     /// Variable in the current `captures`
     /// `ty` is needed for bitcast
-    CaptureFwd { cidx: usize, ty: TermTy },
+    CaptureFwd { cidx: usize },
 }
 
 /// Denotes what a `break` escapes from


### PR DESCRIPTION
Currently lambda captures are represented in Shiika Array (`Array<Object>`). It means that LLVM cannot check its length nor the item types. This PR makes it easier to debug bugs like #432.

- codegen
  - [x] Declare type of captures (like `%shiika_lambda_1_captures = type { %String*, %Int*, %Bool* }`
  - [x] Use it in `_gen_lambda_captures`
  - [x] Fix where getting the value from captures (gen_lambda_capture_ref)
- mir
  - maybe we want to preprocess lambdas because we do not want to traverse the HIR twice (once for creating lambda funcs, once for lambda captures)
