### PR TITLE
Add Shiika::Internal::Ptr.p

### DIFF
--- a/lib/skc_rustlib/provided_methods.json5
+++ b/lib/skc_rustlib/provided_methods.json5
@@ -66,6 +66,7 @@
   ["Shiika::Internal::Ptr", "read -> Int"],
   ["Shiika::Internal::Ptr", "store(value: Object)"],
   ["Shiika::Internal::Ptr", "write(byte: Int)"],
+  ["Meta:Shiika::Internal::Ptr", "p(value: Object, len: Int)"],
   ["Meta:Time::Instant", "now -> Time::Instant"],
   ["Time", "to_plain -> Time::PlainDateTime"],
 ]

--- a/lib/skc_rustlib/src/builtin/shiika_internal_ptr.rs
+++ b/lib/skc_rustlib/src/builtin/shiika_internal_ptr.rs
@@ -2,7 +2,7 @@
 //!
 //! Should be removed once `Array`, etc. is re-implemented in skc_rustlib.
 use crate::builtin::object::ShiikaObject;
-use crate::builtin::{SkInt, SkStr};
+use crate::builtin::{SkClass, SkInt, SkStr};
 use shiika_ffi_macro::shiika_method;
 use std::convert::TryInto;
 use std::os::raw::c_void;
@@ -88,5 +88,16 @@ pub extern "C" fn shiika_internal_ptr_write(receiver: SkPtr, byte: SkInt) {
     unsafe {
         let p = receiver.unbox_mut();
         *p = byte.val().try_into().unwrap();
+    }
+}
+
+#[shiika_method("Meta:Shiika::Internal::Ptr#p")]
+pub extern "C" fn meta_shiika_internal_ptr_p(_receiver: SkClass, value: *const u64, len: SkInt) {
+    unsafe {
+        let n = len.val() as usize;
+        for i in 0..n {
+            let v = value.add(i);
+            println!("0x{:x}: {:x} ", v as u64, *v);
+        }
     }
 }


### PR DESCRIPTION
This PR adds `Shiika::Internal::Ptr.p` for debugging memory corruption bugs.

## Example

`Shiika::Internal::Ptr.p(1, 3)`

shows

```
0x101456580: 1010462d0    # Addr of the vtable
0x101456588: 101453e40    # Addr of #<class Int>
0x101456590: 1   # The wrapped value
```
