### PR TITLE
new feature: Method call with named arguments

### DIFF
--- a/lib/shiika_ast/src/lib.rs
+++ b/lib/shiika_ast/src/lib.rs
@@ -208,7 +208,7 @@ pub enum AstExpressionBody {
     MethodCall(AstMethodCall),
     LambdaInvocation {
         fn_expr: Box<AstExpression>,
-        arg_exprs: Vec<AstExpression>,
+        args: Vec<AstCallArg>,
         has_block: bool,
     },
     LambdaExpr {
@@ -243,7 +243,7 @@ pub enum AstExpressionBody {
 pub struct AstMethodCall {
     pub receiver_expr: Option<Box<AstExpression>>, // Box is needed for E0072 "has infinite size" error
     pub method_name: MethodFirstname,
-    pub arg_exprs: Vec<AstExpression>,
+    pub args: Vec<AstCallArg>,
     pub type_args: Vec<AstExpression>,
     pub has_block: bool,
     pub may_have_paren_wo_args: bool,
@@ -251,7 +251,30 @@ pub struct AstMethodCall {
 
 impl AstMethodCall {
     pub fn first_arg_cloned(&self) -> AstExpression {
-        self.arg_exprs[0].clone()
+        self.args[0].expr.clone()
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct AstCallArg {
+    pub name: Option<String>,
+    pub expr: AstExpression,
+}
+
+impl AstCallArg {
+    pub fn new(name: String, expr: AstExpression) -> AstCallArg {
+        AstCallArg {
+            name: Some(name),
+            expr,
+        }
+    }
+
+    pub fn noname(expr: AstExpression) -> AstCallArg {
+        AstCallArg { name: None, expr }
+    }
+
+    pub fn has_name(&self) -> bool {
+        self.name.is_some()
     }
 }
 

--- a/lib/shiika_ast/src/lib.rs
+++ b/lib/shiika_ast/src/lib.rs
@@ -209,7 +209,6 @@ pub enum AstExpressionBody {
     LambdaInvocation {
         fn_expr: Box<AstExpression>,
         args: AstCallArgs,
-        has_block: bool,
     },
     LambdaExpr {
         params: Vec<BlockParam>,
@@ -245,7 +244,6 @@ pub struct AstMethodCall {
     pub method_name: MethodFirstname,
     pub args: AstCallArgs,
     pub type_args: Vec<AstExpression>,
-    pub has_block: bool,
     pub may_have_paren_wo_args: bool,
 }
 
@@ -293,6 +291,10 @@ impl AstCallArgs {
     pub fn set_block(&mut self, block_expr: AstExpression) {
         debug_assert!(self.block.is_none());
         self.block = Some(Box::new(block_expr))
+    }
+
+    pub fn has_block(&self) -> bool {
+        self.block.is_some()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/lib/shiika_ast/src/token.rs
+++ b/lib/shiika_ast/src/token.rs
@@ -9,6 +9,7 @@ pub enum Token {
     IVar(String),
     Number(String),
     Str(String),
+    KeyName(String), // Such as `foo:`
     StrWithInterpolation {
         head: String,  // Contents before `#{'
         inspect: bool, // true if `\{}', which calls .inspect instead of .to_s
@@ -138,6 +139,7 @@ impl Token {
             Token::IVar(_) => true,
             Token::Number(_) => true,
             Token::Str(_) => true,
+            Token::KeyName(_) => false,
             Token::StrWithInterpolation { .. } => true,
             // Symbols
             Token::LParen => true,       //  (

--- a/lib/shiika_parser/src/ast_builder.rs
+++ b/lib/shiika_parser/src/ast_builder.rs
@@ -1,6 +1,6 @@
 use shiika_ast::{
-    AstExpression, AstExpressionBody, AstMatchClause, AstMethodCall, BlockParam, Location,
-    LocationSpan, Token, UnresolvedTypeName,
+    AstCallArg, AstExpression, AstExpressionBody, AstMatchClause, AstMethodCall, BlockParam,
+    Location, LocationSpan, Token, UnresolvedTypeName,
 };
 use shiika_core::names::{method_firstname, UnresolvedConstName};
 use std::path::{Path, PathBuf};
@@ -221,13 +221,17 @@ impl AstBuilder {
         begin: Location,
         end: Location,
     ) -> AstExpression {
+        let args = arg_exprs
+            .into_iter()
+            .map(|e| AstCallArg::noname(e))
+            .collect();
         self.non_primary_expression(
             begin,
             end,
             AstExpressionBody::MethodCall(AstMethodCall {
                 receiver_expr: receiver_expr.map(Box::new),
                 method_name: method_firstname(method_name),
-                arg_exprs,
+                args,
                 type_args: Default::default(),
                 has_block: false,
                 may_have_paren_wo_args: false,
@@ -238,7 +242,7 @@ impl AstBuilder {
     pub fn lambda_invocation(
         &self,
         fn_expr: AstExpression,
-        arg_exprs: Vec<AstExpression>,
+        args: Vec<AstCallArg>,
         has_block: bool,
         begin: Location,
         end: Location,
@@ -248,7 +252,7 @@ impl AstBuilder {
             end,
             AstExpressionBody::LambdaInvocation {
                 fn_expr: Box::new(fn_expr),
-                arg_exprs,
+                args,
                 has_block,
             },
         )
@@ -401,7 +405,7 @@ impl AstBuilder {
             AstExpressionBody::MethodCall(AstMethodCall {
                 receiver_expr: Some(Box::new(left)),
                 method_name: method_firstname(op),
-                arg_exprs: vec![right],
+                args: vec![AstCallArg::noname(right)],
                 type_args: vec![],
                 has_block: false,
                 may_have_paren_wo_args: false,
@@ -427,11 +431,11 @@ impl AstBuilder {
                 rhs: Box::new(rhs),
             },
             AstExpressionBody::MethodCall(mut x) => {
-                x.arg_exprs.push(rhs);
+                x.args.push(AstCallArg::noname(rhs));
                 AstExpressionBody::MethodCall(AstMethodCall {
                     receiver_expr: x.receiver_expr,
                     method_name: x.method_name.append("="),
-                    arg_exprs: x.arg_exprs,
+                    args: x.args,
                     type_args: Default::default(),
                     has_block: false,
                     may_have_paren_wo_args: false,
@@ -448,24 +452,24 @@ impl AstBuilder {
     pub fn set_method_call_args(
         &self,
         expr: AstExpression,
-        args: Vec<AstExpression>,
+        args: Vec<AstCallArg>,
         has_block: bool,
     ) -> AstExpression {
         let begin = &expr.locs;
-        let end = &args.last().unwrap().locs.clone();
+        let end = &args.last().unwrap().expr.locs.clone();
         match expr.body {
             AstExpressionBody::MethodCall(x) => {
-                if !x.arg_exprs.is_empty() {
+                if !x.args.is_empty() {
                     panic!(
                         "[BUG] cannot extend because arg_exprs is not empty: {:?}",
-                        x.arg_exprs
+                        x.args
                     );
                 }
                 self.non_primary_expression_(
                     begin,
                     end,
                     AstExpressionBody::MethodCall(AstMethodCall {
-                        arg_exprs: args,
+                        args,
                         may_have_paren_wo_args: false,
                         ..x
                     }),
@@ -477,7 +481,7 @@ impl AstBuilder {
                 AstExpressionBody::MethodCall(AstMethodCall {
                     receiver_expr: None,
                     method_name: method_firstname(s),
-                    arg_exprs: args,
+                    args,
                     type_args: vec![],
                     has_block,
                     may_have_paren_wo_args: false,

--- a/lib/shiika_parser/src/ast_builder.rs
+++ b/lib/shiika_parser/src/ast_builder.rs
@@ -233,7 +233,6 @@ impl AstBuilder {
                 method_name: method_firstname(method_name),
                 args,
                 type_args: Default::default(),
-                has_block: false,
                 may_have_paren_wo_args: false,
             }),
         )
@@ -243,7 +242,6 @@ impl AstBuilder {
         &self,
         fn_expr: AstExpression,
         args: AstCallArgs,
-        has_block: bool,
         begin: Location,
         end: Location,
     ) -> AstExpression {
@@ -253,7 +251,6 @@ impl AstBuilder {
             AstExpressionBody::LambdaInvocation {
                 fn_expr: Box::new(fn_expr),
                 args,
-                has_block,
             },
         )
     }
@@ -407,7 +404,6 @@ impl AstBuilder {
                 method_name: method_firstname(op),
                 args: AstCallArgs::single_unnamed(right),
                 type_args: vec![],
-                has_block: false,
                 may_have_paren_wo_args: false,
             }),
         )
@@ -437,7 +433,6 @@ impl AstBuilder {
                     method_name: x.method_name.append("="),
                     args: x.args,
                     type_args: Default::default(),
-                    has_block: false,
                     may_have_paren_wo_args: false,
                 })
             }
@@ -449,12 +444,7 @@ impl AstBuilder {
     /// Extend `foo.bar` to `foo.bar args`, or
     ///        `foo`     to `foo args`.
     /// (expr must be a MethodCall or a BareName and args must not be empty)
-    pub fn set_method_call_args(
-        &self,
-        expr: AstExpression,
-        args: AstCallArgs,
-        has_block: bool,
-    ) -> AstExpression {
+    pub fn set_method_call_args(&self, expr: AstExpression, args: AstCallArgs) -> AstExpression {
         let begin = &expr.locs;
         let end = &args.locs().unwrap();
         match expr.body {
@@ -475,7 +465,6 @@ impl AstBuilder {
                     method_name: method_firstname(s),
                     args,
                     type_args: vec![],
-                    has_block,
                     may_have_paren_wo_args: false,
                 }),
             ),

--- a/lib/shiika_parser/src/definition_parser.rs
+++ b/lib/shiika_parser/src/definition_parser.rs
@@ -591,7 +591,7 @@ impl<'a> Parser<'a> {
                             return Err(parse_error!(self, "@ is only used in `initialize'"));
                         }
                     }
-                    Token::LowerWord(_) => params.push(self.parse_param()?),
+                    Token::KeyName(_) => params.push(self.parse_param()?),
                     token => {
                         return Err(parse_error!(
                             self,
@@ -630,7 +630,7 @@ impl<'a> Parser<'a> {
 
         // Name
         match self.current_token() {
-            Token::LowerWord(s) => {
+            Token::KeyName(s) => {
                 name = s.to_string();
                 self.consume_token()?;
                 is_iparam = false;
@@ -648,10 +648,10 @@ impl<'a> Parser<'a> {
                 ))
             }
         }
-        self.skip_ws()?;
-
         // `:'
-        self.expect(Token::Colon)?;
+        if is_iparam {
+            self.expect(Token::Colon)?;
+        }
         self.skip_ws()?;
 
         // Type

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -85,31 +85,19 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 method_name,
                 args,
                 type_args,
-                has_block,
                 ..
             }) => method_call::convert_method_call(
                 self,
                 receiver_expr,
                 method_name,
                 args,
-                has_block,
                 type_args,
                 &expr.locs,
             ),
 
-            AstExpressionBody::LambdaInvocation {
-                fn_expr,
-                args,
-                has_block,
-            } => {
+            AstExpressionBody::LambdaInvocation { fn_expr, args } => {
                 let hir_fn_expr = self.convert_expr(fn_expr)?;
-                method_call::convert_lambda_invocation(
-                    self,
-                    hir_fn_expr,
-                    args,
-                    has_block,
-                    &expr.locs,
-                )
+                method_call::convert_lambda_invocation(self, hir_fn_expr, args, &expr.locs)
             }
 
             AstExpressionBody::LambdaExpr {

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -83,7 +83,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             AstExpressionBody::MethodCall(AstMethodCall {
                 receiver_expr,
                 method_name,
-                arg_exprs,
+                args,
                 type_args,
                 has_block,
                 ..
@@ -91,7 +91,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 self,
                 receiver_expr,
                 method_name,
-                arg_exprs,
+                args,
                 has_block,
                 type_args,
                 &expr.locs,
@@ -99,14 +99,14 @@ impl<'hir_maker> HirMaker<'hir_maker> {
 
             AstExpressionBody::LambdaInvocation {
                 fn_expr,
-                arg_exprs,
+                args,
                 has_block,
             } => {
                 let hir_fn_expr = self.convert_expr(fn_expr)?;
                 method_call::convert_lambda_invocation(
                     self,
                     hir_fn_expr,
-                    arg_exprs,
+                    args,
                     has_block,
                     &expr.locs,
                 )

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -611,10 +611,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         if let Ok(found) = result {
             method_call::build_simple(self, found, self_expr)
         } else {
-            Err(error::program_error(&format!(
-                "variable or method `{}' was not found",
-                name
-            )))
+            Err(error::unknown_barename(name, locs))
         }
     }
 

--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -5,7 +5,7 @@ use crate::hir_maker::HirMaker;
 use crate::type_inference::method_call_inf;
 use crate::type_system::type_checking;
 use anyhow::{Context, Result};
-use shiika_ast::{AstCallArg, AstExpression, LocationSpan};
+use shiika_ast::{AstCallArgs, AstExpression, LocationSpan};
 use shiika_core::{names::MethodFirstname, ty, ty::TermTy};
 use skc_hir::*;
 
@@ -13,7 +13,7 @@ pub fn convert_method_call(
     mk: &mut HirMaker,
     receiver_expr: &Option<Box<AstExpression>>,
     method_name: &MethodFirstname,
-    args: &[AstCallArg],
+    args: &AstCallArgs,
     has_block: &bool,
     type_args: &[AstExpression],
     locs: &LocationSpan,
@@ -78,7 +78,7 @@ pub fn convert_method_call(
 pub fn convert_lambda_invocation(
     mk: &mut HirMaker,
     fn_expr: HirExpression,
-    args: &[AstCallArg],
+    args: &AstCallArgs,
     has_block: &bool,
     locs: &LocationSpan,
 ) -> Result<HirExpression> {
@@ -118,7 +118,7 @@ fn convert_method_args(
     mk: &mut HirMaker,
     inf: Option<method_call_inf::MethodCallInf1>,
     block_taker: &BlockTaker,
-    args: &[AstCallArg],
+    args: &AstCallArgs,
     has_block: &bool,
 ) -> Result<(Vec<HirExpression>, Option<method_call_inf::MethodCallInf3>)> {
     let n = args.len();

--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -14,7 +14,6 @@ pub fn convert_method_call(
     receiver_expr: &Option<Box<AstExpression>>,
     method_name: &MethodFirstname,
     args: &AstCallArgs,
-    has_block: &bool,
     type_args: &[AstExpression],
     locs: &LocationSpan,
 ) -> Result<HirExpression> {
@@ -22,7 +21,7 @@ pub fn convert_method_call(
     if receiver_expr.is_none() {
         if let Some(lvar) = mk._lookup_var(&method_name.0, locs.clone())? {
             if lvar.ty.fn_x_info().is_some() {
-                return convert_lambda_invocation(mk, lvar.ref_expr(), args, has_block, locs);
+                return convert_lambda_invocation(mk, lvar.ref_expr(), args, locs);
             }
         }
     }

--- a/lib/skc_ast2hir/src/error.rs
+++ b/lib/skc_ast2hir/src/error.rs
@@ -82,3 +82,11 @@ pub fn assign_to_undeclared_ivar(name: &str, locs: &LocationSpan) -> anyhow::Err
     });
     program_error(report)
 }
+
+pub fn unknown_barename(name: &str, locs: &LocationSpan) -> anyhow::Error {
+    let msg = format!("variable or method `{}' was not found", name);
+    let report = skc_error::build_report(msg.clone(), locs, |r, locs_span| {
+        r.with_label(Label::new(locs_span).with_message(msg))
+    });
+    program_error(report)
+}

--- a/lib/skc_ast2hir/src/error.rs
+++ b/lib/skc_ast2hir/src/error.rs
@@ -1,5 +1,6 @@
 use shiika_ast::LocationSpan;
 use skc_error::Label;
+use skc_hir::MethodSignature;
 
 #[derive(thiserror::Error, Debug)]
 #[allow(clippy::enum_variant_names)]
@@ -85,6 +86,37 @@ pub fn assign_to_undeclared_ivar(name: &str, locs: &LocationSpan) -> anyhow::Err
 
 pub fn unknown_barename(name: &str, locs: &LocationSpan) -> anyhow::Error {
     let msg = format!("variable or method `{}' was not found", name);
+    let report = skc_error::build_report(msg.clone(), locs, |r, locs_span| {
+        r.with_label(Label::new(locs_span).with_message(msg))
+    });
+    program_error(report)
+}
+
+pub fn unspecified_arg(
+    param_name: &str,
+    sig: &MethodSignature,
+    locs: &LocationSpan,
+) -> anyhow::Error {
+    let msg = format!("missing argument `{}' of method `{}'", param_name, sig);
+    let report = skc_error::build_report(msg.clone(), locs, |r, locs_span| {
+        r.with_label(Label::new(locs_span).with_message(msg))
+    });
+    program_error(report)
+}
+
+pub fn extranous_arg(name: &str, sig: &MethodSignature, locs: &LocationSpan) -> anyhow::Error {
+    let msg = format!("extranous argument `{}' of method `{}'", name, sig);
+    let report = skc_error::build_report(msg.clone(), locs, |r, locs_span| {
+        r.with_label(Label::new(locs_span).with_message(msg))
+    });
+    program_error(report)
+}
+
+pub fn named_arg_for_lambda(name: &str, locs: &LocationSpan) -> anyhow::Error {
+    let msg = format!(
+        "you cannot pass named argument (`{}') to a lambda (may be fixed in the future though.)",
+        name
+    );
     let report = skc_error::build_report(msg.clone(), locs, |r, locs_span| {
         r.with_label(Label::new(locs_span).with_message(msg))
     });

--- a/tests/sk/method_call.sk
+++ b/tests/sk/method_call.sk
@@ -15,3 +15,4 @@ class KwArgTest
 end
 KwArgTest.new.test
 
+puts "ok"

--- a/tests/sk/method_call.sk
+++ b/tests/sk/method_call.sk
@@ -1,5 +1,5 @@
 class KwArgTest
-  def foo(a: Int, b: String, c: Fn0<Void>) -> String
+  def foo(a: Int, b: String, c: Fn0<String>) -> String
     "#{a}#{b}#{c()}"
   end
 

--- a/tests/sk/method_call.sk
+++ b/tests/sk/method_call.sk
@@ -1,0 +1,17 @@
+class KwArgTest
+  def foo(a: Int, b: String, c: Fn0<Void>) -> String
+    "#{a}#{b}#{c()}"
+  end
+
+  def test
+    unless foo(0,    " "){ "~" } == "0 ~";             puts "fail 0 ~"; end
+    unless foo(1,    " ", fn(){ "~" }) == "1 ~";       puts "fail 1 ~"; end
+    unless foo(2,    b: " "){ "~" } == "2 ~";          puts "fail 2 ~"; end
+    unless foo(a: 3, b: " "){ "~" } == "3 ~";          puts "fail 3 ~"; end
+    unless foo(b: " ", a: 4){ "~" } == "4 ~";          puts "fail 4 ~"; end
+    unless foo(a: 5, b: " ", c: fn(){ "~" }) == "5 ~"; puts "fail 5 ~"; end
+    unless (foo 6, " " do "~" end) == "6 ~";           puts "fail 6 ~"; end
+  end
+end
+KwArgTest.new.test
+


### PR DESCRIPTION
This PR allows specifying method argument by name. For example:

```
foo(1, 2, c: 3, d: 4)
```

Unlike Ruby, there is no difference on the definition side. In other words, any argument is considered a keyword argument.