### PR TITLE
Simplify JSON representation of MethodSignature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,7 @@ dependencies = [
  "anyhow",
  "either",
  "log",
+ "nom",
  "serde",
  "serde_json",
  "shiika_ast",

--- a/lib/shiika_core/src/names/method_name.rs
+++ b/lib/shiika_core/src/names/method_name.rs
@@ -67,6 +67,15 @@ impl std::fmt::Display for MethodFullname {
 }
 
 impl MethodFullname {
+    pub fn from_str(v: &str) -> Option<MethodFullname> {
+        let parts = v.split("#").collect::<Vec<_>>();
+        if parts.len() == 2 {
+            Some(method_fullname_raw(parts[0], parts[1]))
+        } else {
+            None
+        }
+    }
+
     /// Returns true if this method isn't an instance method
     pub fn is_class_method(&self) -> bool {
         self.full_name.starts_with("Meta:")
@@ -97,14 +106,12 @@ impl<'de> de::Visitor<'de> for MethodFullnameVisitor {
     where
         E: serde::de::Error,
     {
-        let parts = v.split("#").collect::<Vec<_>>();
-        if parts.len() == 2 {
-            Ok(method_fullname_raw(parts[0], parts[1]))
-        } else {
-            Err(serde::de::Error::invalid_value(
+        match MethodFullname::from_str(v) {
+            Some(n) => Ok(n),
+            None => Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(v),
                 &"something like `Foo#bar'",
-            ))
+            )),
         }
     }
 }

--- a/lib/shiika_core/src/ty/term_ty.rs
+++ b/lib/shiika_core/src/ty/term_ty.rs
@@ -1,8 +1,8 @@
 use crate::names::*;
 use crate::ty;
 use crate::ty::erasure::Erasure;
-use crate::ty::lit_ty::{parse_lit_ty, LitTy};
-use crate::ty::typaram_ref::{parse_typaram_ref, TyParamKind, TyParamRef};
+use crate::ty::lit_ty::LitTy;
+use crate::ty::typaram_ref::{TyParamKind, TyParamRef};
 use nom::IResult;
 use serde::{de, ser};
 use std::fmt;
@@ -311,10 +311,10 @@ impl TermTy {
 
     /// nom parser for TermTy
     pub fn deserialize(s: &str) -> IResult<&str, TermTy> {
-        if let Ok((s, t)) = parse_typaram_ref(s) {
+        if let Ok((s, t)) = TyParamRef::deserialize(s) {
             Ok((s, t.to_term_ty()))
         } else {
-            let (s, t) = parse_lit_ty(s)?;
+            let (s, t) = LitTy::deserialize(s)?;
             Ok((s, t.to_term_ty()))
         }
     }

--- a/lib/shiika_core/src/ty/term_ty.rs
+++ b/lib/shiika_core/src/ty/term_ty.rs
@@ -301,22 +301,22 @@ impl TermTy {
         }
     }
 
-    /// Returns a serialized string which can be parsed by `parse_term_ty`
+    /// Returns a serialized string which can be parsed by `deserialize`
     pub fn serialize(&self) -> String {
         match &self.body {
             TyRaw(x) => x.serialize(),
             TyPara(x) => x.serialize(),
         }
     }
-}
 
-/// nom parser for TermTy
-pub fn parse_term_ty(s: &str) -> IResult<&str, TermTy> {
-    if let Ok((s, t)) = parse_typaram_ref(s) {
-        Ok((s, t.to_term_ty()))
-    } else {
-        let (s, t) = parse_lit_ty(s)?;
-        Ok((s, t.to_term_ty()))
+    /// nom parser for TermTy
+    pub fn deserialize(s: &str) -> IResult<&str, TermTy> {
+        if let Ok((s, t)) = parse_typaram_ref(s) {
+            Ok((s, t.to_term_ty()))
+        } else {
+            let (s, t) = parse_lit_ty(s)?;
+            Ok((s, t.to_term_ty()))
+        }
     }
 }
 
@@ -344,7 +344,7 @@ impl<'de> de::Visitor<'de> for TermTyVisitor {
     where
         E: serde::de::Error,
     {
-        match parse_term_ty(v) {
+        match TermTy::deserialize(v) {
             Ok((s, ty)) => {
                 if s.is_empty() {
                     Ok(ty)

--- a/lib/skc_hir/Cargo.toml
+++ b/lib/skc_hir/Cargo.toml
@@ -9,5 +9,6 @@ shiika_ast = { path = "../shiika_ast" }
 anyhow = "1.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0"
+nom = "7.1.3"
 either = "1.5.3"
 log = "0.4.11"

--- a/lib/skc_mir/src/library.rs
+++ b/lib/skc_mir/src/library.rs
@@ -4,7 +4,7 @@ use shiika_core::{names::ConstFullname, ty::TermTy};
 use skc_hir::SkTypes;
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct LibraryExports {
     pub sk_types: SkTypes,
     pub vtables: VTables,

--- a/lib/skc_mir/src/vtable.rs
+++ b/lib/skc_mir/src/vtable.rs
@@ -3,7 +3,7 @@ use shiika_core::names::*;
 use skc_hir::SkClass;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct VTable {
     /// List of methods, ordered by index
     fullnames: Vec<MethodFullname>,

--- a/lib/skc_mir/src/vtables.rs
+++ b/lib/skc_mir/src/vtables.rs
@@ -6,7 +6,7 @@ use skc_hir::SkTypes;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct VTables {
     // REFACTOR: how about just use `type`
     vtables: HashMap<ClassFullname, VTable>,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -70,6 +70,7 @@ pub fn build_corelib() -> Result<(), Error> {
     let mut f = fs::File::create(from_shiika_root("builtin/exports.json")).unwrap();
     f.write_all(json.as_bytes()).unwrap();
     log::debug!("created .json");
+    debug_assert!(exports == load_builtin_exports()?);
     Ok(())
 }
 


### PR DESCRIPTION
This PR reduces size of exports.json by customizing how MethodSignature is serialized.