### PR TITLE
fix compilation error on nested closure

### DIFF
--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -555,6 +555,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                         ret.push(HirLambdaCapture {
                             ty: cap.ty,
                             upcast_needed: cap.upcast_needed,
+                            readonly: cap.readonly,
                             detail: HirLambdaCaptureDetail::CaptureLVar { name },
                         });
                     }
@@ -562,6 +563,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                         ret.push(HirLambdaCapture {
                             ty: cap.ty,
                             upcast_needed: cap.upcast_needed,
+                            readonly: cap.readonly,
                             detail: HirLambdaCaptureDetail::CaptureArg { idx },
                         });
                     }
@@ -570,6 +572,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 // The variable is in outer scope
                 let ty = cap.ty.clone();
                 let upcast_needed = cap.upcast_needed;
+                let readonly = cap.readonly;
                 let cidx = self
                     .ctx_stack
                     .lambda_ctx_mut()
@@ -578,6 +581,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                 ret.push(HirLambdaCapture {
                     ty,
                     upcast_needed,
+                    readonly,
                     detail: HirLambdaCaptureDetail::CaptureFwd { cidx },
                 });
             }
@@ -667,13 +671,16 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                         is_lambda_scope: scope.is_lambda_scope,
                         ty: lvar.ty.clone(),
                         upcast_needed: false,
+                        readonly: lvar.readonly,
                         detail: LambdaCaptureDetail::CapLVar {
                             name: name.to_string(),
                         },
                     };
                     let lvar_info = LVarInfo {
                         ty: lvar.ty.clone(),
-                        detail: LVarDetail::OuterScope_ { readonly: false },
+                        detail: LVarDetail::OuterScope_ {
+                            readonly: lvar.readonly,
+                        },
                         locs,
                     };
                     result = (Some(lvar_info), Some(cap));
@@ -709,6 +716,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
                         is_lambda_scope: scope.is_lambda_scope,
                         ty: param.ty.clone(),
                         upcast_needed: false,
+                        readonly: true,
                         detail,
                     };
                     let lvar_info = LVarInfo {

--- a/lib/skc_ast2hir/src/hir_maker_context.rs
+++ b/lib/skc_ast2hir/src/hir_maker_context.rs
@@ -168,6 +168,8 @@ pub struct LambdaCapture {
     pub is_lambda_scope: bool,
     pub ty: TermTy,
     pub upcast_needed: bool,
+    /// True if the captured variable is readonly
+    pub readonly: bool,
     pub detail: LambdaCaptureDetail,
 }
 

--- a/lib/skc_hir/src/lib.rs
+++ b/lib/skc_hir/src/lib.rs
@@ -299,6 +299,8 @@ pub enum HirExpressionBase {
 pub struct HirLambdaCapture {
     pub ty: TermTy,
     pub upcast_needed: bool,
+    /// True if the captured variable is readonly
+    pub readonly: bool,
     pub detail: HirLambdaCaptureDetail,
 }
 
@@ -309,7 +311,6 @@ pub enum HirLambdaCaptureDetail {
     /// Method/Function argument
     CaptureArg { idx: usize },
     /// Variable in the current `captures`
-    /// `ty` is needed for bitcast
     CaptureFwd { cidx: usize },
 }
 

--- a/tests/sk/lambda.sk
+++ b/tests/sk/lambda.sk
@@ -37,4 +37,17 @@ f1 = fn(x: Int) { a = 1 }
 f1(0)
 unless a == 1; puts "ng 5"; end
 
+class UpdateFromNestedClosure
+  def self.run
+    var a = 0
+    [1].each do |i|
+      [1].each do |j|
+        a = 1
+      end
+    end
+    unless a == 1; puts "ng UpdateFromNestedClosure"; end
+  end
+end
+UpdateFromNestedClosure.run
+
 puts "ok"


### PR DESCRIPTION
This PR fixes compiler to generate right code for nested closure like this.

```sk
class UpdateFromNestedClosure
  def self.run
    var a = 0
    [1].each do |i|
      [1].each do |j|
        a = 1
      end
    end
    unless a == 1; puts "ng UpdateFromNestedClosure"; end
  end
end
UpdateFromNestedClosure.run
```