### PR TITLE
Forward exit_status in lambda in lambda

### DIFF
--- a/tests/sk/loops_and_jumps.sk
+++ b/tests/sk/loops_and_jumps.sk
@@ -98,4 +98,17 @@ unless A.w_arg_end == 1; puts "ng w_arg_end" end
 #unless A.return_from_block == 99; puts "ng return_from_block" end
 unless A.return_from_fn == 1; puts "ng return_from_fn" end
 
+# #484 break from lambda in lambda
+class Issue484
+  def self.run
+    let a = Array<String>.new
+    "he\nllo".each_char do |b|
+      break if b == "\n"
+      a.push(b)
+    end
+    unless a == ["h", "e"]; puts "ng Issue484"; end
+  end
+end
+Issue484.run
+
 puts "ok"


### PR DESCRIPTION
This PR fixes #484.

```
"he\nllo".each_char do |b|
  p b
  break if b == "\n"
end
```

1. This code calls `#each_char` with a lambda (say, lambda1).
2. `#each_char` calls `Integer#times` with a lambda (say, lambda2).
3. lambda2 invokes lambda1.
4. lambda1 ends with `break`.
5. lambda2 also should end with `break`.