### PR TITLE
refactor: Change TermTy::fullname to be TypeFullname

### DIFF
--- a/lib/shiika_core/src/names/type_name.rs
+++ b/lib/shiika_core/src/names/type_name.rs
@@ -28,7 +28,11 @@ impl TypeFullname {
 
     /// Returns a ClassFullname of the same name. Should only be called when
     /// `self` is a class (i.e. is not a module.)
-    pub fn to_class_fullname(self) -> ClassFullname {
+    pub fn to_class_fullname(&self) -> ClassFullname {
+        class_fullname(&self.0)
+    }
+
+    pub fn as_class_fullname(self) -> ClassFullname {
         class_fullname(self.0)
     }
 

--- a/lib/shiika_core/src/ty.rs
+++ b/lib/shiika_core/src/ty.rs
@@ -17,7 +17,7 @@ pub fn new(base_name_: impl Into<String>, type_args: Vec<TermTy>, is_meta: bool)
     debug_assert!(!base_name.is_empty());
     debug_assert!(!base_name.starts_with("Meta:"));
     debug_assert!(!base_name.contains('<'));
-    let fullname = ClassFullname::new(
+    let fullname = TypeFullname::new(
         format!("{}{}", &base_name, &tyargs_str(&type_args)),
         is_meta,
     );

--- a/lib/shiika_core/src/ty/term_ty.rs
+++ b/lib/shiika_core/src/ty/term_ty.rs
@@ -283,7 +283,7 @@ impl TermTy {
             TyRaw(LitTy {
                 base_name, is_meta, ..
             }) => ClassFullname::new(base_name, *is_meta),
-            _ => self.fullname.clone().to_class_fullname(),
+            _ => self.fullname.to_class_fullname(),
         }
     }
 

--- a/lib/shiika_core/src/ty/term_ty.rs
+++ b/lib/shiika_core/src/ty/term_ty.rs
@@ -7,10 +7,10 @@ use nom::IResult;
 use serde::{de, ser};
 use std::fmt;
 
-/// Types for a term (types of Shiika values)
+/// Types for a term (a Shiika value).
 #[derive(PartialEq, Eq, Clone)]
 pub struct TermTy {
-    pub fullname: ClassFullname, // TODO: should be TypeFullname
+    pub fullname: TypeFullname,
     pub body: TyBody,
 }
 
@@ -283,7 +283,7 @@ impl TermTy {
             TyRaw(LitTy {
                 base_name, is_meta, ..
             }) => ClassFullname::new(base_name, *is_meta),
-            _ => self.fullname.clone(),
+            _ => self.fullname.clone().to_class_fullname(),
         }
     }
 

--- a/lib/shiika_core/src/ty/typaram_ref.rs
+++ b/lib/shiika_core/src/ty/typaram_ref.rs
@@ -1,4 +1,4 @@
-use crate::names::class_fullname;
+use crate::names::type_fullname;
 use crate::ty::lit_ty::LitTy;
 use crate::ty::term_ty::{TermTy, TyBody};
 use nom::{bytes::complete::tag, IResult};
@@ -45,8 +45,8 @@ impl TyParamRef {
 
     pub fn into_term_ty(self) -> TermTy {
         TermTy {
-            // TODO: self.name (eg. "T") is not a class name. Should remove fullname from TermTy?
-            fullname: class_fullname(&self.name),
+            // TODO: self.name (eg. "T") is not a class/module name. Should remove fullname from TermTy?
+            fullname: type_fullname(&self.name),
             body: TyBody::TyPara(self),
         }
     }

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -455,7 +455,10 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         let expr = self.convert_expr(rhs)?;
         let base_ty = self.ctx_stack.self_ty().erasure_ty();
 
-        if let Some(ivar) = self.class_dict.find_ivar(&base_ty.fullname, name) {
+        if let Some(ivar) = self
+            .class_dict
+            .find_ivar(&base_ty.fullname.to_class_fullname(), name)
+        {
             if ivar.readonly {
                 return Err(error::program_error(&format!(
                     "instance variable `{}' is readonly",
@@ -803,7 +806,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
         let base_ty = self.ctx_stack.self_ty().erasure_ty();
         let found = self
             .class_dict
-            .find_ivar(&base_ty.fullname, name)
+            .find_ivar(&base_ty.fullname.to_class_fullname(), name)
             .or_else(|| {
                 self.ctx_stack
                     .method_ctx()
@@ -892,7 +895,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
 
         let sk_type = self
             .class_dict
-            .get_type(&base_expr.ty.instance_ty().fullname.to_type_fullname());
+            .get_type(&base_expr.ty.instance_ty().fullname);
         type_checking::check_class_specialization(&sk_type, &arg_exprs, &locs)?;
 
         let meta_spe_ty = base_expr.ty.specialized_ty(type_args);

--- a/lib/skc_ast2hir/src/hir_maker.rs
+++ b/lib/skc_ast2hir/src/hir_maker.rs
@@ -382,7 +382,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             Default::default(),
         )?;
         let new_body = SkMethodBody::New {
-            classname: class_name.fullname.clone(),
+            classname: class_name.fullname.to_class_fullname(),
             initialize_name,
             init_cls_name,
             arity: found.sig.params.len(),

--- a/lib/skc_ast2hir/src/pattern_match.rs
+++ b/lib/skc_ast2hir/src/pattern_match.rs
@@ -220,7 +220,10 @@ fn get_base_ty(mk: &mut HirMaker, names: &[String]) -> Result<Erasure> {
     if expr.ty.is_metaclass() || expr.ty.is_typaram_ref() {
         return Ok(expr.ty.instance_ty().erasure());
     }
-    if let Some(cls) = mk.class_dict.lookup_class(&expr.ty.fullname) {
+    if let Some(cls) = mk
+        .class_dict
+        .lookup_class(&expr.ty.fullname.to_class_fullname())
+    {
         if cls.const_is_obj {
             return Ok(expr.ty.erasure()); // eg. Void, None, etc.
         }


### PR DESCRIPTION
This PR changes the type of `TermTy::fullname` to `TypeFullname`.