### PR TITLE
Add typarams to .new

### DIFF
--- a/builtin/maybe.sk
+++ b/builtin/maybe.sk
@@ -1,5 +1,3 @@
-# TODO: Rename to `maybe.sk` after `require` is implemented
-
 enum Maybe<V>
   case Some(value: V)
   case None

--- a/lib/skc_ast2hir/src/class_dict/found_method.rs
+++ b/lib/skc_ast2hir/src/class_dict/found_method.rs
@@ -50,4 +50,12 @@ impl FoundMethod {
             ..self.clone()
         }
     }
+
+    /// Returns if this is of the form `Foo.new<Bar>`
+    pub fn is_generic_new(&self, receiver_ty: &TermTy) -> bool {
+        self.sig.fullname.first_name.0 == "new"
+            && receiver_ty.is_metaclass()
+            && !receiver_ty.has_type_args()
+            && !self.sig.typarams.is_empty()
+    }
 }

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -81,6 +81,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
                 &metaclass_fullname,
                 self._initializer_params(&inner_namespace, &typarams, &superclass, defs)?,
                 &ty::return_type_of_new(&fullname.clone().into(), &typarams),
+                typarams.clone(),
             ))
         };
 
@@ -751,7 +752,12 @@ fn enum_case_new_sig(
         ty::spe(&fullname.0, tyargs)
     };
     (
-        signature::signature_of_new(&fullname.meta_name(), params.clone(), &ret_ty),
+        signature::signature_of_new(
+            &fullname.meta_name(),
+            params.clone(),
+            &ret_ty,
+            typarams.to_vec(),
+        ),
         signature::signature_of_initialize(fullname, params),
     )
 }

--- a/lib/skc_ast2hir/src/class_dict/query.rs
+++ b/lib/skc_ast2hir/src/class_dict/query.rs
@@ -6,7 +6,7 @@ use shiika_core::{names::*, ty, ty::*};
 use skc_hir::*;
 
 impl<'hir_maker> ClassDict<'hir_maker> {
-    /// Find a method in a class or module. Does not lookup into superclass.
+    /// Find a method in a class or module. Unlike `lookup_method`, does not lookup into superclass.
     pub fn find_method(
         &self,
         fullname: &TypeFullname,

--- a/lib/skc_ast2hir/src/convert_exprs.rs
+++ b/lib/skc_ast2hir/src/convert_exprs.rs
@@ -647,7 +647,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
             .class_dict
             .lookup_method(&self_expr.ty, &method_firstname(name), &[]);
         if let Ok(found) = result {
-            method_call::build_simple(self, found, self_expr)
+            method_call::build_simple(self, found, self_expr, locs)
         } else {
             Err(error::unknown_barename(name, locs))
         }
@@ -978,7 +978,7 @@ impl<'hir_maker> HirMaker<'hir_maker> {
     }
 
     /// Expand `[123]` into `tmp=Array<X>.new; tmp.push(123)`
-    fn create_array_instance_(
+    pub fn create_array_instance_(
         &mut self,
         item_exprs: Vec<HirExpression>,
         item_ty: TermTy,

--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -6,7 +6,8 @@ use crate::type_inference::method_call_inf;
 use crate::type_system::type_checking;
 use anyhow::{Context, Result};
 use shiika_ast::{AstCallArgs, AstExpression, LocationSpan};
-use shiika_core::{names::MethodFirstname, ty, ty::TermTy};
+use shiika_core::names::{method_fullname, MethodFirstname};
+use shiika_core::{ty, ty::TermTy};
 use skc_hir::*;
 
 pub enum ArrangedArg<'ast> {
@@ -71,7 +72,8 @@ pub fn convert_method_call(
         args.has_block(),
     )
     .context(msg)?;
-    build(mk, found, receiver_hir, arg_hirs, inf3)
+
+    build(mk, found, receiver_hir, arg_hirs, inf3, method_tyargs, locs)
 }
 
 /// Arrange named and unnamed arguments into a Vec which corresponds to `sig.params`.
@@ -213,9 +215,10 @@ fn convert_method_args(
 
 /// For method calls without any arguments.
 pub fn build_simple(
-    mk: &HirMaker,
+    mk: &mut HirMaker,
     found: FoundMethod,
     receiver_hir: HirExpression,
+    locs: &LocationSpan,
 ) -> Result<HirExpression> {
     build(
         mk,
@@ -223,18 +226,23 @@ pub fn build_simple(
         receiver_hir,
         Default::default(),
         Default::default(),
+        Default::default(),
+        locs,
     )
 }
 
 /// Check the arguments and create HirMethodCall or HirModuleMethodCall
 pub fn build(
-    mk: &HirMaker,
+    mk: &mut HirMaker,
     found: FoundMethod,
     receiver_hir: HirExpression,
     mut arg_hirs: Vec<HirExpression>,
     inf: Option<method_call_inf::MethodCallInf3>,
+    method_tyargs: Vec<TermTy>,
+    locs: &LocationSpan,
 ) -> Result<HirExpression> {
     check_argument_types(mk, &found.sig, &receiver_hir, &mut arg_hirs, &inf)?;
+    let receiver_ty = receiver_hir.ty.clone();
     let specialized = receiver_hir.ty.is_specialized();
     let first_arg_ty = arg_hirs.get(0).map(|x| x.ty.clone());
 
@@ -249,11 +257,19 @@ pub fn build(
         arg_hirs
     };
 
+    if found.is_generic_new(&receiver_ty) {
+        return Ok(call_specialized_new(
+            mk,
+            &receiver_ty,
+            args,
+            method_tyargs,
+            locs,
+        ));
+    }
+
     let hir = build_hir(&found, &owner, receiver, args, &inf);
     if found.sig.fullname.full_name == "Object#unsafe_cast" {
         Ok(Hir::bit_cast(first_arg_ty.unwrap().instance_ty(), hir))
-    } else if specialized {
-        Ok(hir) //Hir::bit_cast(found.sig.ret_ty.erasure().to_term_ty(), hir))
     } else {
         Ok(hir)
     }
@@ -320,4 +336,24 @@ fn build_hir(
             arg_hirs,
         ),
     }
+}
+
+/// Build HIR for `Foo<Bar>.new(x)`
+fn call_specialized_new(
+    mk: &mut HirMaker,
+    // `TermTy(Meta:Foo)`
+    receiver_ty: &TermTy,
+    // Args for .new
+    arg_hirs: Vec<HirExpression>,
+    tyargs: Vec<TermTy>,
+    locs: &LocationSpan,
+) -> HirExpression {
+    let meta_spe_ty = receiver_ty.specialized_ty(tyargs);
+    let spe_cls = mk.get_class_object(&meta_spe_ty, locs);
+    Hir::method_call(
+        meta_spe_ty.instance_ty(),
+        spe_cls,
+        method_fullname(receiver_ty.erasure().to_type_fullname(), "new"),
+        arg_hirs,
+    )
 }

--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -14,6 +14,7 @@ pub enum ArrangedArg<'ast> {
     Default(&'ast TermTy),
 }
 
+/// Entry point of Converting `AstMethodCall` into `HirMethodCall`.
 pub fn convert_method_call(
     mk: &mut HirMaker,
     receiver_expr: &Option<Box<AstExpression>>,
@@ -179,6 +180,8 @@ fn resolve_method_tyarg(mk: &mut HirMaker, arg: &AstExpression) -> Result<TermTy
 fn convert_method_args(
     mk: &mut HirMaker,
     inf: Option<method_call_inf::MethodCallInf1>,
+    // The method or lambda to be called.
+    // (TODO: this name is odd when has_block=false...)
     block_taker: &BlockTaker,
     arg_exprs: &[ArrangedArg],
     has_block: bool,

--- a/lib/skc_ast2hir/src/type_inference/method_call_inf.rs
+++ b/lib/skc_ast2hir/src/type_inference/method_call_inf.rs
@@ -5,8 +5,10 @@ use shiika_core::ty::{TermTy, TyParamKind};
 use skc_hir::MethodSignature;
 
 /// Phase 1
+/// Initial state.
 #[derive(Debug)]
 pub struct MethodCallInf1 {
+    /// True if the last method argument is a block.
     has_block: bool,
     pub method_arg_tys: Vec<TmpTy>,
     pub method_ret_ty: TmpTy,
@@ -134,6 +136,7 @@ impl MethodCallInf3 {
 
 /// Infer types of block parameters.
 pub fn infer_block_param(
+    // Destructively extracts information from inf.
     mut inf: MethodCallInf1,
     pre_block_arg_tys: &[&TermTy],
 ) -> Result<MethodCallInf2> {

--- a/lib/skc_ast2hir/src/type_inference/tmp_ty.rs
+++ b/lib/skc_ast2hir/src/type_inference/tmp_ty.rs
@@ -9,6 +9,8 @@ pub enum TmpTy {
     /// This type is unknown and should be inferred from other parts of the program.
     Unknown(Id),
     /// Mostly the same as `ty::LitTy` but may contain `Unknown` as a type argument.
+    /// (In other words, a `ty::LitTy` or `ty::TermTy` is guaranteed to
+    /// be Unknown-free.)
     Literal {
         base_name: String,
         type_args: Vec<TmpTy>,

--- a/lib/skc_hir/src/signature.rs
+++ b/lib/skc_hir/src/signature.rs
@@ -205,12 +205,13 @@ pub fn signature_of_new(
     metaclass_fullname: &ClassFullname,
     initialize_params: Vec<MethodParam>,
     instance_ty: &TermTy,
+    typarams: Vec<ty::TyParam>,
 ) -> MethodSignature {
     MethodSignature {
         fullname: method_fullname(metaclass_fullname.clone().into(), "new"),
         ret_ty: instance_ty.clone(),
         params: initialize_params,
-        typarams: vec![],
+        typarams,
     }
 }
 

--- a/lib/skc_hir/src/sk_method.rs
+++ b/lib/skc_hir/src/sk_method.rs
@@ -33,6 +33,7 @@ pub enum SkMethodBody {
 }
 
 impl SkMethod {
+    /// Create a SkMethod which does not use lvar at all.
     pub fn simple(signature: MethodSignature, body: SkMethodBody) -> SkMethod {
         SkMethod {
             signature,


### PR DESCRIPTION
For the first step of #483, this PR adds type parameters to the signature of `.new`.

- `Array.new` takes type parameter so `Array.new<Int>` is legal now
- This yields the same result as `Array<Int>.new`
- Iplementation
  - At the end of convert_method_call, if the called method is `Array.new<Int>`, generate HIR for `Array<Int>.new` instead
  - In the llvm layer they are the same function (`@Meta_Array_new`) but the first argument should be `Array<Int>` because it is set to the .class of the new instance.