### PR TITLE
Remove omittable type arguments

### DIFF
--- a/builtin/array.sk
+++ b/builtin/array.sk
@@ -95,7 +95,7 @@ class Array<T> : Enumerable<T>
     if self.empty?
       None
     else
-      Some<T>.new(self[0])
+      Some.new(self[0])
     end
   end
 
@@ -136,7 +136,7 @@ class Array<T> : Enumerable<T>
     if empty?
       None
     else
-      Some<T>.new(self[length - 1])
+      Some.new(self[length - 1])
     end
   end
 
@@ -262,6 +262,6 @@ class Array<T> : Enumerable<T>
         a.push(self[i])
       end
     end
-    Pair<Array<T>, Array<T>>.new(a, b)
+    Pair.new(a, b)
   end
 end

--- a/builtin/dict.sk
+++ b/builtin/dict.sk
@@ -19,7 +19,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
         end
       end
       unless done
-        @pairs.push(Pair<KK, VV>.new(key, value))
+        @pairs.push(Pair.new(key, value))
       end
     end
 
@@ -28,7 +28,7 @@ class Dict<K, V> : Enumerable<Pair<K, V>>
       var ret = None
       @pairs.each do |pair|
         if pair.fst == key
-          ret = Some<VV>.new(pair.snd)
+          ret = Some.new(pair.snd)
         end
       end
       ret

--- a/builtin/enumerable.sk
+++ b/builtin/enumerable.sk
@@ -8,7 +8,7 @@ module Enumerable<E>
     match [a.length, b.length].min
     when Maybe::Some(n)
       0.upto(n-1) do |i|
-        ret.push(Pair<A, B>.new(a[i], b[i]))
+        ret.push(Pair.new(a[i], b[i]))
       end
     end
     ret
@@ -37,7 +37,7 @@ module Enumerable<E>
 
   # Like `map` but `f` should return an array and the result is flattened.
   def flat_map<R>(f: Fn1<E, Array<R>>) -> Array<R>
-    self.map<Array<R>>(f).fold<Array<R>>(Array<R>.new){|sum: Array<R>, item: Array<R>|
+    self.map<Array<R>>(f).fold(Array<R>.new){|sum: Array<R>, item: Array<R>|
       sum.append(item)
       sum
     }

--- a/builtin/file.sk
+++ b/builtin/file.sk
@@ -10,7 +10,7 @@ class File : Readable
     when Ok(file)
       let v = f(file)
       #file.close
-      Ok<V>.new(v)
+      Ok.new(v)
     when Fail(e)
       Fail<V>.new(e)
     end

--- a/builtin/maybe.sk
+++ b/builtin/maybe.sk
@@ -6,7 +6,7 @@ enum Maybe<V>
   def map<U>(f: Fn1<V, U>) -> Maybe<U>
     match self
     when Some(v)
-      Some<U>.new(f(v))
+      Some.new(f(v))
     else
       None
     end

--- a/builtin/readable.sk
+++ b/builtin/readable.sk
@@ -47,7 +47,7 @@ module Readable
         return Fail<Array<String>>.new(e)
       end
     end
-    Ok<Array<String>>.new(a)
+    Ok.new(a)
   end
 
   def read -> Result<String>
@@ -65,6 +65,6 @@ module Readable
         return Fail<String>.new(e)
       end
     end
-    Ok<String>.new(acc._unsafe_to_s)
+    Ok.new(acc._unsafe_to_s)
   end
 end


### PR DESCRIPTION
This PR removes omittable type arguments from builtin/*.sk.

The only exception is `Enumerable#flat_map`; I got a compile error when I removed the type arguments. I'll fix it by another PR.