### PR TITLE
Upgrade llvm to llvm-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up the Linux env
         run: |
           set -eux
-          sudo apt install -y llvm-12 clang-12 libgc-dev
+          sudo apt install -y llvm-15 clang-15 libgc-dev
         if: matrix.os == 'ubuntu-latest'
 
       - name: Output versions
@@ -38,15 +38,15 @@ jobs:
           set -eux
           rustc --version
           cargo --version
-          clang-12 --version
+          clang-15 --version
 
       - name: Build and test
         run: |
           set -eux
           cd lib/skc_rustlib; cargo build; cd ../../
-          env -- LLC=llc-12 CLANG=clang-12 cargo run -- build-corelib
-          env -- LLC=llc-12 CLANG=clang-12 cargo test
-          env -- LLC=llc-12 CLANG=clang-12 bash release_test.sh
+          env -- LLC=llc-15 CLANG=clang-15 cargo run -- build-corelib
+          env -- LLC=llc-15 CLANG=clang-15 cargo test
+          env -- LLC=llc-15 CLANG=clang-15 bash release_test.sh
 
   # Run cargo fmt --all -- --check
   format:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,15 +634,15 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "llvm-sys"
-version = "130.1.2"
+version = "140.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20142c91fc4bde4036edbaf0d112f79667831d612efbaabe862ab9748fdd67c"
+checksum = "69b285f8682531b9b394dd9891977a2a28c47006e491bda944e1ca62ebab2664"
 dependencies = [
  "cc",
  "lazy_static",
  "libc",
  "regex",
- "semver 0.11.0",
+ "semver",
 ]
 
 [[package]]
@@ -1021,7 +1021,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver",
 ]
 
 [[package]]
@@ -1038,27 +1038,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,9 +634,9 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "llvm-sys"
-version = "120.3.0"
+version = "130.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44721270d140699646701a91b0e982b7ca858da96d8886629cc79f13c191c6d"
+checksum = "c20142c91fc4bde4036edbaf0d112f79667831d612efbaabe862ab9748fdd67c"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,8 +573,8 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.1.0"
-source = "git+https://github.com/TheDan64/inkwell?rev=845270c99ee6268385b79b2e178a872ab4b1b1a8#845270c99ee6268385b79b2e178a872ab4b1b1a8"
+version = "0.2.0"
+source = "git+https://github.com/TheDan64/inkwell?rev=4030f76#4030f764f1c889f36429ac02ef32e04fcfa8ce33"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -586,12 +586,12 @@ dependencies = [
 
 [[package]]
 name = "inkwell_internals"
-version = "0.5.0"
-source = "git+https://github.com/TheDan64/inkwell?rev=845270c99ee6268385b79b2e178a872ab4b1b1a8#845270c99ee6268385b79b2e178a872ab4b1b1a8"
+version = "0.8.0"
+source = "git+https://github.com/TheDan64/inkwell?rev=4030f76#4030f764f1c889f36429ac02ef32e04fcfa8ce33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -634,9 +634,9 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "llvm-sys"
-version = "140.1.2"
+version = "150.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b285f8682531b9b394dd9891977a2a28c47006e491bda944e1ca62ebab2664"
+checksum = "417dbaef2fece3b186fe15704e010849279de5f7eea1caa8845558130867bdd2"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ skc_codegen = { path = "lib/skc_codegen/" }
 
 ariadne = "0.1.5"
 anyhow = "1.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm14-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm15-0"], rev = "4030f76" }
 clap = { version = "3.1.18", features = ["derive"] }
 either = "1.5.3"
 env_logger = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ skc_codegen = { path = "lib/skc_codegen/" }
 
 ariadne = "0.1.5"
 anyhow = "1.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm13-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm14-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
 clap = { version = "3.1.18", features = ["derive"] }
 either = "1.5.3"
 env_logger = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ skc_codegen = { path = "lib/skc_codegen/" }
 
 ariadne = "0.1.5"
 anyhow = "1.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm12-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm13-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
 clap = { version = "3.1.18", features = ["derive"] }
 either = "1.5.3"
 env_logger = "0.8.2"

--- a/lib/skc_ast2hir/src/accessors.rs
+++ b/lib/skc_ast2hir/src/accessors.rs
@@ -77,6 +77,7 @@ fn create_setter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
         SkMethodBody::Setter {
             idx: ivar.idx,
             name: ivar.name.clone(),
+            ty: clsname.to_ty(),
         },
     )
 }

--- a/lib/skc_ast2hir/src/accessors.rs
+++ b/lib/skc_ast2hir/src/accessors.rs
@@ -55,6 +55,7 @@ fn create_getter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
             idx: ivar.idx,
             name: ivar.name.clone(),
             ty: ivar.ty.clone(),
+            self_ty: clsname.to_ty(),
         },
     )
 }
@@ -78,6 +79,7 @@ fn create_setter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
             idx: ivar.idx,
             name: ivar.name.clone(),
             ty: clsname.to_ty(),
+            self_ty: clsname.to_ty(),
         },
     )
 }

--- a/lib/skc_ast2hir/src/accessors.rs
+++ b/lib/skc_ast2hir/src/accessors.rs
@@ -54,6 +54,7 @@ fn create_getter(clsname: &ClassFullname, ivar: &SkIVar) -> SkMethod {
         SkMethodBody::Getter {
             idx: ivar.idx,
             name: ivar.name.clone(),
+            ty: ivar.ty.clone(),
         },
     )
 }

--- a/lib/skc_codegen/Cargo.toml
+++ b/lib/skc_codegen/Cargo.toml
@@ -14,6 +14,6 @@ skc_mir = { path = "../skc_mir" }
 anyhow = "1.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm12-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm13-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
 either = "1.5.3"
 log = "0.4.11"

--- a/lib/skc_codegen/Cargo.toml
+++ b/lib/skc_codegen/Cargo.toml
@@ -14,6 +14,6 @@ skc_mir = { path = "../skc_mir" }
 anyhow = "1.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm13-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm14-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
 either = "1.5.3"
 log = "0.4.11"

--- a/lib/skc_codegen/Cargo.toml
+++ b/lib/skc_codegen/Cargo.toml
@@ -14,6 +14,6 @@ skc_mir = { path = "../skc_mir" }
 anyhow = "1.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm14-0"], rev = "845270c99ee6268385b79b2e178a872ab4b1b1a8" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm15-0"], rev = "4030f76" }
 either = "1.5.3"
 log = "0.4.11"

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -135,7 +135,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let receiver = self.gen_const_ref(&toplevel_const("String"));
+        let receiver = self.gen_const_ref(&toplevel_const("String"), &ty::meta("String"));
         let str_i8ptr = function.get_nth_param(0).unwrap();
         let bytesize = function.get_nth_param(1).unwrap().into_int_value();
         let args = vec![self.box_i8ptr(str_i8ptr), self.box_int(&bytesize)];

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -57,7 +57,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i1_val = function.get_params()[0];
         let sk_bool = self.allocate_sk_obj(&class_fullname("Bool"), "sk_bool");
-        sk_bool.ivar_store_raw(self, "@llvm_bool", 0, i1_val);
+        self.build_ivar_store_raw(sk_bool.clone(), "@llvm_bool", 0, i1_val);
         self.build_return(&sk_bool);
 
         // unbox_bool
@@ -76,7 +76,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i64_val = function.get_params()[0];
         let sk_int = self.allocate_sk_obj(&class_fullname("Int"), "sk_int");
-        sk_int.ivar_store_raw(self, "@llvm_int", 0, i64_val);
+        self.build_ivar_store_raw(sk_int.clone(), "@llvm_int", 0, i64_val);
         self.build_return(&sk_int);
 
         // unbox_int
@@ -98,7 +98,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let f64_val = function.get_params()[0];
         let sk_float = self.allocate_sk_obj(&class_fullname("Float"), "sk_float");
-        sk_float.ivar_store_raw(self, "@llvm_float", 0, f64_val);
+        self.build_ivar_store_raw(sk_float.clone(), "@llvm_float", 0, f64_val);
         self.build_return(&sk_float);
 
         // unbox_float
@@ -120,7 +120,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i8ptr = function.get_params()[0];
         let sk_ptr = self.allocate_sk_obj(&class_fullname("Shiika::Internal::Ptr"), "sk_ptr");
-        sk_ptr.ivar_store_raw(self, "@llvm_i8ptr", 0, i8ptr);
+        self.build_ivar_store_raw(sk_ptr.clone(), "@llvm_i8ptr", 0, i8ptr);
         self.build_return(&sk_ptr);
 
         // unbox_i8ptr

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -57,7 +57,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i1_val = function.get_params()[0];
         let sk_bool = self.allocate_sk_obj(&class_fullname("Bool"), "sk_bool");
-        sk_bool.ivar_store_raw(self, "@llvm_bool", i1_val);
+        sk_bool.ivar_store_raw(self, "@llvm_bool", 0, i1_val);
         self.build_return(&sk_bool);
 
         // unbox_bool
@@ -66,7 +66,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let sk_bool = SkObj::new(ty::raw("Bool"), function.get_params()[0]);
-        let i1_val = self.build_ivar_load_raw(sk_bool, "@llvm_bool");
+        let i1_val = self.build_ivar_load_raw(sk_bool, self.i1_type.into(), 0, "@llvm_bool");
         self.builder.build_return(Some(&i1_val));
 
         // box_int
@@ -76,7 +76,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i64_val = function.get_params()[0];
         let sk_int = self.allocate_sk_obj(&class_fullname("Int"), "sk_int");
-        sk_int.ivar_store_raw(self, "@llvm_int", i64_val);
+        sk_int.ivar_store_raw(self, "@llvm_int", 0, i64_val);
         self.build_return(&sk_int);
 
         // unbox_int
@@ -88,7 +88,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             ty::raw("Int"),
             function.get_params()[0].into_pointer_value(),
         );
-        let i64_val = self.build_ivar_load_raw(sk_int, "@llvm_int");
+        let i64_val = self.build_ivar_load_raw(sk_int, self.i64_type.into(), 0, "@llvm_int");
         self.builder.build_return(Some(&i64_val));
 
         // box_float
@@ -98,7 +98,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let f64_val = function.get_params()[0];
         let sk_float = self.allocate_sk_obj(&class_fullname("Float"), "sk_float");
-        sk_float.ivar_store_raw(self, "@llvm_float", f64_val);
+        sk_float.ivar_store_raw(self, "@llvm_float", 0, f64_val);
         self.build_return(&sk_float);
 
         // unbox_float
@@ -110,7 +110,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             ty::raw("Float"),
             function.get_params()[0].into_pointer_value(),
         );
-        let f64_val = self.build_ivar_load_raw(sk_float, "@llvm_float");
+        let f64_val = self.build_ivar_load_raw(sk_float, self.f64_type.into(), 0, "@llvm_float");
         self.builder.build_return(Some(&f64_val));
 
         // box_i8ptr
@@ -120,7 +120,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i8ptr = function.get_params()[0];
         let sk_ptr = self.allocate_sk_obj(&class_fullname("Shiika::Internal::Ptr"), "sk_ptr");
-        sk_ptr.ivar_store_raw(self, "@llvm_i8ptr", i8ptr);
+        sk_ptr.ivar_store_raw(self, "@llvm_i8ptr", 0, i8ptr);
         self.build_return(&sk_ptr);
 
         // unbox_i8ptr
@@ -132,7 +132,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             ty::raw("Shiika::Internal::Ptr"),
             function.get_params()[0].into_pointer_value(),
         );
-        let i8ptr = self.build_ivar_load_raw(sk_ptr, "@llvm_i8ptr");
+        let i8ptr = self.build_ivar_load_raw(sk_ptr, self.i8ptr_type.into(), 0, "@llvm_i8ptr");
         self.builder.build_return(Some(&i8ptr));
 
         // gen_literal_string

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -66,7 +66,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let sk_bool = SkObj(function.get_params()[0]);
-        let i1_val = self.build_ivar_load(sk_bool, 0, "@llvm_bool");
+        let i1_val = self.build_ivar_load(&ty::raw("Bool"), sk_bool, 0, "@llvm_bool");
         self.build_return(&i1_val);
 
         // box_int
@@ -85,7 +85,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let sk_int = SkObj(function.get_params()[0]);
-        let i64_val = self.build_ivar_load(sk_int, 0, "@llvm_int");
+        let i64_val = self.build_ivar_load(&ty::raw("Bool"), sk_int, 0, "@llvm_int");
         self.build_return(&i64_val);
 
         // box_float
@@ -104,7 +104,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let sk_float = SkObj(function.get_params()[0]);
-        let f64_val = self.build_ivar_load(sk_float, 0, "@llvm_float");
+        let f64_val = self.build_ivar_load(&ty::raw("Float"), sk_float, 0, "@llvm_float");
         self.build_return(&f64_val);
 
         // box_i8ptr
@@ -123,7 +123,8 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let sk_ptr = SkObj(function.get_params()[0]);
-        let i8ptr = self.build_ivar_load(sk_ptr, 0, "@llvm_i8ptr");
+        let i8ptr =
+            self.build_ivar_load(&ty::raw("Shiika::Internal::Ptr"), sk_ptr, 0, "@llvm_i8ptr");
         self.build_return(&i8ptr);
 
         // gen_literal_string

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -57,7 +57,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i1_val = SkObj(function.get_params()[0]);
         let sk_bool = self.allocate_sk_obj(&class_fullname("Bool"), "sk_bool");
-        self.build_ivar_store(&sk_bool, 0, i1_val, "@llvm_bool");
+        self.build_ivar_store(&ty::raw("Bool"), &sk_bool, 0, i1_val, "@llvm_bool");
         self.build_return(&sk_bool);
 
         // unbox_bool
@@ -76,7 +76,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i64_val = SkObj(function.get_params()[0]);
         let sk_int = self.allocate_sk_obj(&class_fullname("Int"), "sk_int");
-        self.build_ivar_store(&sk_int, 0, i64_val, "@llvm_int");
+        self.build_ivar_store(&ty::raw("Int"), &sk_int, 0, i64_val, "@llvm_int");
         self.build_return(&sk_int);
 
         // unbox_int
@@ -95,7 +95,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let f64_val = SkObj(function.get_params()[0]);
         let sk_float = self.allocate_sk_obj(&class_fullname("Float"), "sk_float");
-        self.build_ivar_store(&sk_float, 0, f64_val, "@llvm_float");
+        self.build_ivar_store(&ty::raw("Float"), &sk_float, 0, f64_val, "@llvm_float");
         self.build_return(&sk_float);
 
         // unbox_float
@@ -114,7 +114,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i8ptr = function.get_params()[0];
         let sk_ptr = self.allocate_sk_obj(&class_fullname("Shiika::Internal::Ptr"), "sk_ptr");
-        self.build_ivar_store_raw(&sk_ptr, 0, i8ptr, "@llvm_i8ptr");
+        self.build_ivar_store_raw(
+            &ty::raw("Shiika::Internal::Ptr"),
+            &sk_ptr,
+            0,
+            i8ptr,
+            "@llvm_i8ptr",
+        );
         self.build_return(&sk_ptr);
 
         // unbox_i8ptr

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -55,9 +55,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let i1_val = SkObj(function.get_params()[0]);
+        let i1_val = function.get_params()[0];
         let sk_bool = self.allocate_sk_obj(&class_fullname("Bool"), "sk_bool");
-        self.build_ivar_store(&ty::raw("Bool"), &sk_bool, 0, i1_val, "@llvm_bool");
+        sk_bool.ivar_store_raw(self, "@llvm_bool", i1_val);
         self.build_return(&sk_bool);
 
         // unbox_bool
@@ -65,18 +65,18 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_bool = SkObj(function.get_params()[0]);
-        let i1_val = self.build_ivar_load(&ty::raw("Bool"), sk_bool, 0, "@llvm_bool");
-        self.build_return(&i1_val);
+        let sk_bool = SkObj::new(ty::raw("Bool"), function.get_params()[0]);
+        let i1_val = self.build_ivar_load_raw(sk_bool, "@llvm_bool");
+        self.builder.build_return(Some(&i1_val));
 
         // box_int
         let function = self.module.get_function("box_int").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let i64_val = SkObj(function.get_params()[0]);
+        let i64_val = function.get_params()[0];
         let sk_int = self.allocate_sk_obj(&class_fullname("Int"), "sk_int");
-        self.build_ivar_store(&ty::raw("Int"), &sk_int, 0, i64_val, "@llvm_int");
+        sk_int.ivar_store_raw(self, "@llvm_int", i64_val);
         self.build_return(&sk_int);
 
         // unbox_int
@@ -84,18 +84,21 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_int = SkObj(function.get_params()[0]);
-        let i64_val = self.build_ivar_load(&ty::raw("Bool"), sk_int, 0, "@llvm_int");
-        self.build_return(&i64_val);
+        let sk_int = SkObj::new(
+            ty::raw("Int"),
+            function.get_params()[0].into_pointer_value(),
+        );
+        let i64_val = self.build_ivar_load_raw(sk_int, "@llvm_int");
+        self.builder.build_return(Some(&i64_val));
 
         // box_float
         let function = self.module.get_function("box_float").unwrap();
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let f64_val = SkObj(function.get_params()[0]);
+        let f64_val = function.get_params()[0];
         let sk_float = self.allocate_sk_obj(&class_fullname("Float"), "sk_float");
-        self.build_ivar_store(&ty::raw("Float"), &sk_float, 0, f64_val, "@llvm_float");
+        sk_float.ivar_store_raw(self, "@llvm_float", f64_val);
         self.build_return(&sk_float);
 
         // unbox_float
@@ -103,9 +106,12 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_float = SkObj(function.get_params()[0]);
-        let f64_val = self.build_ivar_load(&ty::raw("Float"), sk_float, 0, "@llvm_float");
-        self.build_return(&f64_val);
+        let sk_float = SkObj::new(
+            ty::raw("Float"),
+            function.get_params()[0].into_pointer_value(),
+        );
+        let f64_val = self.build_ivar_load_raw(sk_float, "@llvm_float");
+        self.builder.build_return(Some(&f64_val));
 
         // box_i8ptr
         let function = self.module.get_function("box_i8ptr").unwrap();
@@ -114,13 +120,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let i8ptr = function.get_params()[0];
         let sk_ptr = self.allocate_sk_obj(&class_fullname("Shiika::Internal::Ptr"), "sk_ptr");
-        self.build_ivar_store_raw(
-            &ty::raw("Shiika::Internal::Ptr"),
-            &sk_ptr,
-            0,
-            i8ptr,
-            "@llvm_i8ptr",
-        );
+        sk_ptr.ivar_store_raw(self, "@llvm_i8ptr", i8ptr);
         self.build_return(&sk_ptr);
 
         // unbox_i8ptr
@@ -128,10 +128,12 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let basic_block = self.context.append_basic_block(function, "");
         self.builder.position_at_end(basic_block);
 
-        let sk_ptr = SkObj(function.get_params()[0]);
-        let i8ptr =
-            self.build_ivar_load(&ty::raw("Shiika::Internal::Ptr"), sk_ptr, 0, "@llvm_i8ptr");
-        self.build_return(&i8ptr);
+        let sk_ptr = SkObj::new(
+            ty::raw("Shiika::Internal::Ptr"),
+            function.get_params()[0].into_pointer_value(),
+        );
+        let i8ptr = self.build_ivar_load_raw(sk_ptr, "@llvm_i8ptr");
+        self.builder.build_return(Some(&i8ptr));
 
         // gen_literal_string
         self.impl_gen_literal_string();
@@ -150,6 +152,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             &method_fullname(metaclass_fullname("String").into(), "new"),
             receiver,
             &args,
+            ty::raw("String"),
             "sk_str",
         );
         self.build_return(&sk_str);
@@ -157,7 +160,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Convert LLVM bool(i1) into Shiika Bool
     pub fn box_bool(&self, b: inkwell::values::IntValue<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func(&llvm_func_name("box_bool"), &[b.into()], "sk_bool"))
+        SkObj::new(
+            ty::raw("Bool"),
+            self.call_llvm_func(&llvm_func_name("box_bool"), &[b.into()], "sk_bool")
+                .into_pointer_value(),
+        )
     }
 
     /// Convert Shiika Bool into LLVM bool(i1)
@@ -172,11 +179,15 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Convert LLVM int into Shiika Int
     pub fn box_int(&self, i: &inkwell::values::IntValue<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func(
-            &llvm_func_name("box_int"),
-            &[i.as_basic_value_enum().into()],
-            "sk_int",
-        ))
+        SkObj::new(
+            ty::raw("Int"),
+            self.call_llvm_func(
+                &llvm_func_name("box_int"),
+                &[i.as_basic_value_enum().into()],
+                "sk_int",
+            )
+            .into_pointer_value(),
+        )
     }
 
     /// Convert Shiika Int into LLVM int
@@ -191,11 +202,15 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Convert LLVM float into Shiika Float
     pub fn box_float(&self, fl: &inkwell::values::FloatValue<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func(
-            &llvm_func_name("box_float"),
-            &[fl.as_basic_value_enum().into()],
-            "sk_float",
-        ))
+        SkObj::new(
+            ty::raw("Float"),
+            self.call_llvm_func(
+                &llvm_func_name("box_float"),
+                &[fl.as_basic_value_enum().into()],
+                "sk_float",
+            )
+            .into_pointer_value(),
+        )
     }
 
     /// Convert Shiika Float into LLVM float
@@ -210,7 +225,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Convert LLVM i8* into Shiika::Internal::Ptr
     pub fn box_i8ptr(&self, p: inkwell::values::BasicValueEnum<'run>) -> SkObj<'run> {
-        SkObj(self.call_llvm_func(&llvm_func_name("box_i8ptr"), &[p.into()], "sk_ptr"))
+        SkObj::new(
+            ty::raw("Shiika::Internal::Ptr"),
+            self.call_llvm_func(&llvm_func_name("box_i8ptr"), &[p.into()], "sk_ptr")
+                .into_pointer_value(),
+        )
     }
 
     /// Convert Shiika::Internal::Ptr into LLVM i8*

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -788,11 +788,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     fn indirect_method_function_call(
         &self,
         function: PointerValue<'run>,
-        func_type: FunctionType,
+        func_type: FunctionType<'ictx>,
         receiver_value: SkObj<'run>,
         arg_values: &[SkObj<'run>],
     ) -> SkObj<'run> {
-        let args = arg_values.to_vec();
+        let mut args = arg_values.to_vec();
         args.insert(0, receiver_value);
         self.indirect_function_call(function, func_type, args)
     }
@@ -801,7 +801,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     fn indirect_function_call(
         &self,
         function: PointerValue<'run>,
-        func_type: FunctionType,
+        func_type: FunctionType<'ictx>,
         arg_values: Vec<SkObj<'run>>,
     ) -> SkObj<'run> {
         let llvm_args = arg_values.iter().map(|x| x.0.into()).collect::<Vec<_>>();
@@ -937,7 +937,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         // eg. Fn1.new(fnptr, the_self, captures)
         let cls_name = format!("Fn{}", params.len());
-        let meta = self.gen_const_ref(&toplevel_const(&cls_name), &ty::meta(cls_name));
+        let meta = self.gen_const_ref(&toplevel_const(&cls_name), &ty::meta(&cls_name));
         let fnptr = self
             .get_llvm_func(&func_name)
             .as_global_value()

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -823,12 +823,14 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ty: &TermTy,
         name: &str,
     ) -> SkObj<'run> {
-        let llvm_ty = self.llvm_struct_type(ty).as_basic_type_enum();
         let ptr = ctx
             .lvars
             .get(name)
             .unwrap_or_else(|| panic!("[BUG] lvar `{}' not found in ctx.lvars", name));
-        SkObj::new(ty.clone(), self.builder.build_load(llvm_ty, *ptr, name))
+        SkObj::new(
+            ty.clone(),
+            self.builder.build_load(self.llvm_type(ty), *ptr, name),
+        )
     }
 
     fn gen_ivar_ref(

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -11,7 +11,6 @@ use shiika_core::{names::*, ty, ty::*};
 use skc_hir::pattern_match;
 use skc_hir::HirExpressionBase::*;
 use skc_hir::*;
-use std::convert::TryFrom;
 use std::rc::Rc;
 
 /// Index of @func of FnX
@@ -566,11 +565,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             func_type,
         );
 
-        let result = self.gen_llvm_function_call(
-            CallableValue::try_from(func).unwrap(),
-            receiver_value,
-            arg_values,
-        );
+        let result = self.gen_llvm_function_call(func, receiver_value, arg_values);
         if ret_ty.is_never_type() {
             self.builder.build_unreachable();
             Ok(None)
@@ -663,11 +658,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .build_bitcast(func_ptr, func_type, "as")
             .into_pointer_value();
 
-        let result = self.gen_llvm_function_call(
-            CallableValue::try_from(func).unwrap(),
-            receiver_value,
-            arg_values,
-        );
+        let result = self.gen_llvm_function_call(func, receiver_value, arg_values);
         if ret_ty.is_never_type() {
             self.builder.build_unreachable();
             Ok(None)

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -1018,7 +1018,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             self.the_main.clone().unwrap()
         } else if matches!(ctx.function_origin, FunctionOrigin::Lambda { .. }) {
             let fn_x = self.get_nth_param(ty::raw("Fn"), &ctx.function, 0);
-            self.build_ivar_load(fn_x, "@obj")
+            self.build_ivar_load(fn_x, "@the_self")
         } else {
             self.get_nth_param(ty.clone(), &ctx.function, 0)
         };

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -156,7 +156,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 self.gen_lambda_capture_ref(ctx, idx, !readonly, &expr.ty),
             )),
             HirLambdaCaptureWrite { cidx, rhs } => self.gen_lambda_capture_write(ctx, cidx, rhs),
-            HirBitCast { expr: target } => self.gen_bitcast(ctx, target, &expr.ty),
+            HirBitCast { expr: target } => self.gen_bitcast(ctx, target),
             HirClassLiteral {
                 fullname,
                 str_literal_idx,
@@ -1167,18 +1167,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &'run self,
         ctx: &mut CodeGenContext<'hir, 'run>,
         expr: &'hir HirExpression,
-        ty: &TermTy,
     ) -> Result<Option<SkObj<'run>>> {
-        if let Some(obj) = self.gen_expr(ctx, expr)? {
-            if expr.ty.equals_to(ty) {
-                // No bitcast needed
-                Ok(Some(obj))
-            } else {
-                Ok(Some(self.bitcast(obj, ty, "as")))
-            }
-        } else {
-            Ok(None)
-        }
+        // Just compile the expr (nothing to do more in the runtime)
+        self.gen_expr(ctx, expr)
     }
 
     /// Create a class object

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -592,7 +592,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     ) -> inkwell::values::PointerValue<'run> {
         let vtable = self.get_vtable_of_obj(receiver_value);
         let (idx, size) = self.__lookup_vtable(receiver_ty, method_name);
-        let func_raw = self.build_vtable_ref(vtable, *idx, size);
+        let func_raw = vtable.get_func(self, *idx, size);
         self.builder
             .build_bitcast(func_raw, func_type.ptr_type(Default::default()), "func")
             .into_pointer_value()

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -841,7 +841,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.call_method_func(
             &method_fullname_raw("Class", "_type_argument"),
             self.bitcast(cls_obj.as_sk_obj(), &ty::raw("Class"), "as"),
-            vec![self.gen_decimal_literal(idx as i64)],
+            &vec![self.gen_decimal_literal(idx as i64)],
             "tyarg",
         )
     }
@@ -908,7 +908,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.call_method_func(
             &method_fullname(metaclass_fullname(cls_name).into(), "new"),
             meta,
-            arg_values,
+            &arg_values,
             "lambda",
         )
     }
@@ -1135,7 +1135,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             let metacls_obj = self.call_method_func(
                 &method_fullname_raw("Metaclass", "_new"),
                 receiver,
-                vec![
+                &vec![
                     self.gen_string_literal(str_literal_idx),
                     self.bitcast(vtable, &ty::raw("Object"), "as"),
                     self.bitcast(wtable, &ty::raw("Object"), "as"),
@@ -1152,7 +1152,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             let cls = self.call_method_func(
                 &method_fullname(metaclass_fullname("Class").into(), "_new"),
                 receiver,
-                vec![
+                &vec![
                     self.gen_string_literal(str_literal_idx),
                     self.bitcast(vtable, &ty::raw("Object"), "as"),
                     self.bitcast(wtable, &ty::raw("Object"), "as"),

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -593,7 +593,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         func_type: inkwell::types::FunctionType<'ictx>,
     ) -> inkwell::values::PointerValue<'run> {
         let (idx, size) = self.__lookup_vtable(receiver_ty, method_name);
-        let vtable = VTableRef::from_sk_obj(self, receiver_value, size);
+        let vtable = VTableRef::of_sk_obj(self, receiver_value, size);
         let func_raw = vtable.get_func(self, *idx);
         self.builder
             .build_bitcast(func_raw, func_type.ptr_type(Default::default()), "func")

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -590,9 +590,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         receiver_value: SkObj<'run>,
         func_type: inkwell::types::FunctionType<'ictx>,
     ) -> inkwell::values::PointerValue<'run> {
-        let vtable = self.get_vtable_of_obj(receiver_value);
         let (idx, size) = self.__lookup_vtable(receiver_ty, method_name);
-        let func_raw = vtable.get_func(self, *idx, size);
+        let vtable = self.get_vtable_of_obj(receiver_value, size);
+        let func_raw = vtable.get_func(self, *idx);
         self.builder
             .build_bitcast(func_raw, func_type.ptr_type(Default::default()), "func")
             .into_pointer_value()

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -817,7 +817,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ty: &TermTy,
         name: &str,
     ) -> SkObj<'run> {
-        let llvm_ty = self.llvm_struct_type(ty);
+        let llvm_ty = self.llvm_struct_type(ty).as_basic_type_enum();
         let ptr = ctx
             .lvars
             .get(name)
@@ -886,7 +886,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     pub fn gen_const_ref(&self, fullname: &ConstFullname, ty: &TermTy) -> SkObj<'run> {
         let name = llvm_const_name(fullname);
-        let llvm_type = self.llvm_struct_type(ty);
+        let llvm_type = self.llvm_struct_type(ty).as_basic_type_enum();
         let ptr = self
             .module
             .get_global(&name)

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -458,7 +458,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 // Set @exit_status
                 let fn_x = self.get_nth_param(&ctx.function, 0);
                 let i = self.box_int(&self.i64_type.const_int(EXIT_BREAK, false));
-                self.build_ivar_store(&fn_x, FN_X_EXIT_STATUS_IDX, i, "@exit_status");
+                self.build_ivar_store(
+                    &ty::raw("Fn"),
+                    &fn_x,
+                    FN_X_EXIT_STATUS_IDX,
+                    i,
+                    "@exit_status",
+                );
 
                 // Jump to the end of the llvm func
                 self.builder
@@ -507,7 +513,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     ) -> Result<Option<SkObj<'run>>> {
         let object = self.gen_self_expression(ctx, self_ty);
         let value = self.gen_expr(ctx, rhs)?.unwrap();
-        self.build_ivar_store(&object, *idx, value.clone(), name);
+        self.build_ivar_store(self_ty, &object, *idx, value.clone(), name);
         Ok(Some(value))
     }
 
@@ -697,7 +703,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let n_args = arg_exprs.len();
 
         // Prepare arguments
-        let mut args = vec![lambda_obj];
+        let mut args = vec![lambda_obj.clone()];
         for e in arg_exprs {
             args.push(self.gen_expr(ctx, e)?.unwrap());
         }
@@ -760,7 +766,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 // Set @exit_status
                 let fn_x = self.get_nth_param(&ctx.function, 0);
                 let i = self.box_int(&self.i64_type.const_int(EXIT_BREAK, false));
-                self.build_ivar_store(&fn_x, FN_X_EXIT_STATUS_IDX, i, "@exit_status");
+                self.build_ivar_store(
+                    &ty::raw("Fn"),
+                    &fn_x,
+                    FN_X_EXIT_STATUS_IDX,
+                    i,
+                    "@exit_status",
+                );
             }
             self.builder
                 .build_unconditional_branch(*ctx.current_func_end);
@@ -1230,6 +1242,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             SkClassObj(null),
         );
         self.build_ivar_store(
+            &ty::raw("Class"),
             &cls_obj,
             skc_corelib::class::IVAR_NAME_IDX,
             self.gen_string_literal(str_literal_idx),

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -908,7 +908,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     pub fn gen_const_ref(&self, fullname: &ConstFullname, ty: &TermTy) -> SkObj<'run> {
         let name = llvm_const_name(fullname);
-        let llvm_type = self.llvm_struct_type(ty).as_basic_type_enum();
+        let llvm_type = self.llvm_type(ty);
         let ptr = self
             .module
             .get_global(&name)

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -2,6 +2,7 @@ use crate::code_gen_context::*;
 use crate::lambda::LambdaCapture;
 use crate::utils::*;
 use crate::values::*;
+use crate::vtable::VTableRef;
 use crate::wtable;
 use crate::CodeGen;
 use anyhow::Result;

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -7,7 +7,6 @@ use crate::CodeGen;
 use anyhow::Result;
 use inkwell::types::*;
 use inkwell::values::*;
-use inkwell::AddressSpace;
 use shiika_core::{names::*, ty, ty::*};
 use skc_hir::pattern_match;
 use skc_hir::HirExpressionBase::*;
@@ -597,7 +596,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let (idx, size) = self.__lookup_vtable(receiver_ty, method_name);
         let func_raw = self.build_vtable_ref(vtable, *idx, size);
         self.builder
-            .build_bitcast(func_raw, func_type.ptr_type(AddressSpace::Generic), "func")
+            .build_bitcast(func_raw, func_type.ptr_type(Default::default()), "func")
             .into_pointer_value()
     }
 
@@ -658,7 +657,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .into_pointer_value();
         let func_type = self
             .llvm_func_type(Some(&receiver_expr.ty), &arg_tys, ret_ty)
-            .ptr_type(AddressSpace::Generic);
+            .ptr_type(Default::default());
         let func = self
             .builder
             .build_bitcast(func_ptr, func_type, "as")
@@ -727,7 +726,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             arg_types.push(self.llvm_type(&e.ty).into());
         }
         let fntype = self.llvm_type(ret_ty).fn_type(&arg_types, false);
-        let fnptype = fntype.ptr_type(AddressSpace::Generic);
+        let fnptype = fntype.ptr_type(Default::default());
 
         // Cast `fnptr` to that type
         let fnptr =
@@ -1212,7 +1211,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .llvm_struct_types
             .get(&init_cls_name.to_type_fullname())
             .expect("ances_type not found")
-            .ptr_type(inkwell::AddressSpace::Generic);
+            .ptr_type(Default::default());
         let addr = SkObj(self.builder.build_bitcast(
             receiver.clone().0,
             ances_type,

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -1219,7 +1219,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ));
         let args = vec![addr.0.into()];
         let initialize = self.get_llvm_func(&method_func_name(initialize_name));
-        self.builder.build_call(initialize, &args, "");
+        self.builder.build_direct_call(initialize, &args, "");
     }
 
     /// Create the metaclass object `Metaclass`

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -799,15 +799,15 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Generate IR for HirArgRef.
     fn gen_arg_ref(&'run self, ctx: &mut CodeGenContext<'hir, 'run>, idx: &usize) -> SkObj<'run> {
-        let ty = &ctx.function_params.unwrap()[*idx].ty;
         match ctx.function_origin {
-            FunctionOrigin::Method => {
+            FunctionOrigin::Method { params } => {
                 SkObj::new(
-                    ty.clone(),
+                    params[*idx].ty.clone(),
                     ctx.function.get_nth_param((*idx as u32) + 1).unwrap(),
                 ) // +1 for the first %self
             }
-            FunctionOrigin::Lambda { .. } => {
+            FunctionOrigin::Lambda { params, .. } => {
+                let ty = &params[*idx].ty;
                 // +1 for the first %self
                 let obj = self.get_nth_param(ty.clone(), &ctx.function, *idx + 1);
                 // Bitcast is needed because lambda params are always `%Object*`

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -26,7 +26,7 @@ impl<'run> LambdaCapture<'run> {
     }
 
     pub fn struct_ptr_type<'ictx>(gen: &CodeGen, name: &str) -> inkwell::types::PointerType<'ictx> {
-        Self::get_struct_type(gen, name).ptr_type(inkwell::AddressSpace::Generic)
+        Self::get_struct_type(gen, name).ptr_type(Default::default())
     }
 
     fn new(
@@ -439,7 +439,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             // PERF: not needed to be by-ref when the variable is declared with
             // `var` but not reassigned from closure.
             self.llvm_type(&cap.ty)
-                .ptr_type(inkwell::AddressSpace::Generic)
+                .ptr_type(Default::default())
                 .as_basic_type_enum()
         }
     }

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -134,7 +134,7 @@ impl<'run> LambdaCapture<'run> {
                     "load",
                 )
                 .into_pointer_value();
-            let pointee_ty = gen.llvm_struct_type(ty).as_basic_type_enum();
+            let pointee_ty = gen.llvm_type(ty).as_basic_type_enum();
             gen.builder.build_load(pointee_ty, addr, "deref")
         } else {
             gen.build_llvm_struct_ref(

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -138,13 +138,16 @@ impl<'run> LambdaCapture<'run> {
         ty: &TermTy,
         deref: bool,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        let value_ty = gen.llvm_type(ty);
-        let t = if deref {
-            value_ty.ptr_type(Default::default()).as_basic_type_enum()
+        if deref {
+            gen.build_llvm_struct_ref_raw(
+                gen.i8ptr_type.as_basic_type_enum(),
+                self.to_struct_ptr(),
+                idx,
+                "load",
+            )
         } else {
-            value_ty
-        };
-        gen.build_llvm_struct_ref(t, self.to_struct_ptr(), idx, "load")
+            gen.build_llvm_struct_ref(*gen.llvm_struct_type(ty), self.to_struct_ptr(), idx, "load")
+        }
     }
 
     /// Given there is a pointer stored at `idx`, update its value.

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -140,18 +140,8 @@ impl<'run> LambdaCapture<'run> {
 
     /// Given there is a pointer stored at `idx`, update its value.
     pub fn reassign(&self, gen: &CodeGen<'_, 'run, '_>, idx: usize, value: SkObj) {
-        // eg. `%Int**`
-        let ptr_ty = self
-            .struct_type(gen)
-            .get_field_type_at_index(idx as u32)
-            .unwrap()
-            .into_pointer_type();
-        // eg. `%Int*`
-        let ty = ptr_ty.get_element_type().into_pointer_type();
-        let upcast = gen.builder.build_bitcast(value.0, ty, "upcast");
-
         let ptr = self.load(gen, idx).into_pointer_value();
-        gen.builder.build_store(ptr, upcast);
+        gen.builder.build_store(ptr, value.0);
     }
 }
 

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -109,6 +109,26 @@ impl<'run> LambdaCapture<'run> {
         }
     }
 
+    /// Get the (possibly indirectly) stored value.
+    pub fn get_value(
+        &self,
+        gen: &CodeGen<'_, 'run, '_>,
+        idx: usize,
+        ty: &TermTy,
+        deref: bool,
+    ) -> SkObj<'run> {
+        let x = self.load(gen, idx);
+        if deref {
+            let pointee_ty = gen.llvm_struct_type(ty).as_basic_type_enum();
+            SkObj(
+                gen.builder
+                    .build_load(pointee_ty, x.into_pointer_value(), "deref"),
+            )
+        } else {
+            SkObj(x)
+        }
+    }
+
     /// Load the value at the given index
     pub fn load(
         &self,

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -79,6 +79,7 @@ impl<'run> LambdaCapture<'run> {
         debug_assert!(self.store_type_matches(gen, idx, value));
 
         gen.build_llvm_struct_set(
+            self.struct_type(gen).as_basic_type_enum(),
             self.to_struct_ptr(),
             idx,
             value,

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -751,7 +751,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                     *arity,
                     *const_is_obj,
                 ),
-                SkMethodBody::Getter { idx, name } => {
+                SkMethodBody::Getter { idx, name, ty } => {
                     let this = self.get_nth_param(&function, 0);
                     let val = self.build_ivar_load(this, *idx, name);
                     self.build_return(&val);

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -4,6 +4,7 @@ mod gen_exprs;
 mod lambda;
 mod utils;
 pub mod values;
+mod vtable;
 mod wtable;
 use crate::code_gen_context::*;
 use crate::utils::*;

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -756,10 +756,10 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                     let val = self.build_ivar_load(ty, this, *idx, name);
                     self.build_return(&val);
                 }
-                SkMethodBody::Setter { idx, name } => {
+                SkMethodBody::Setter { idx, name, ty } => {
                     let this = self.get_nth_param(&function, 0);
                     let val = self.get_nth_param(&function, 1);
-                    self.build_ivar_store(&this, *idx, val, name);
+                    self.build_ivar_store(ty, &this, *idx, val, name);
                     let val = self.get_nth_param(&function, 1);
                     self.build_return(&val);
                 }

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -283,7 +283,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 self.module
                     .add_function(&format!("{}_init_constants", s), fn_type, None);
                 let func = self.get_llvm_func(&llvm_func_name(format!("{}_init_constants", s)));
-                self.builder.build_call(func, &[], "");
+                self.builder.build_direct_call(func, &[], "");
             }
         }
 
@@ -296,7 +296,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             // These builtin classes must be created first
             for name in &basic_classes {
                 let func = self.get_llvm_func(&llvm_func_name(const_initialize_func_name(name)));
-                self.builder.build_call(func, &[], "");
+                self.builder.build_direct_call(func, &[], "");
             }
         }
         for expr in const_inits {
@@ -305,7 +305,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                     if !basic_classes.iter().any(|s| s.0 == fullname.0) {
                         let func = self
                             .get_llvm_func(&llvm_func_name(const_initialize_func_name(fullname)));
-                        self.builder.build_call(func, &[], "");
+                        self.builder.build_direct_call(func, &[], "");
                     }
                 }
                 _ => panic!("gen_init_constants: Not a HirConstAssign"),
@@ -362,13 +362,13 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
         // Call GC_init
         let func = self.get_llvm_func(&llvm_func_name("GC_init"));
-        self.builder.build_call(func, &[], "");
+        self.builder.build_direct_call(func, &[], "");
 
         // Call init_constants, user_main
         let func = self.get_llvm_func(&llvm_func_name("main_init_constants"));
-        self.builder.build_call(func, &[], "");
+        self.builder.build_direct_call(func, &[], "");
         let func = self.get_llvm_func(&llvm_func_name("user_main"));
-        self.builder.build_call(func, &[], "");
+        self.builder.build_direct_call(func, &[], "");
 
         // ret i32 0
         self.builder
@@ -918,7 +918,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             })
             .collect::<Vec<_>>();
         let initialize = self.get_llvm_func(&method_func_name(initialize_name));
-        self.builder.build_call(initialize, &args, "");
+        self.builder.build_direct_call(initialize, &args, "");
 
         self.build_return(&obj);
     }

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -12,7 +12,6 @@ use anyhow::{anyhow, Result};
 use either::*;
 use inkwell::types::*;
 use inkwell::values::*;
-use inkwell::AddressSpace;
 use shiika_core::{names::*, ty, ty::*};
 use skc_hir::pattern_match::MatchClause;
 use skc_hir::*;
@@ -92,7 +91,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             builder,
             i1_type: context.bool_type(),
             i8_type: context.i8_type(),
-            i8ptr_type: context.i8_type().ptr_type(AddressSpace::Generic),
+            i8ptr_type: context.i8_type().ptr_type(Default::default()),
             i32_type: context.i32_type(),
             i64_type: context.i64_type(),
             f64_type: context.f64_type(),
@@ -903,7 +902,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 .llvm_struct_types
                 .get(&init_cls_name.to_type_fullname())
                 .expect("ances_type not found")
-                .ptr_type(inkwell::AddressSpace::Generic);
+                .ptr_type(Default::default());
             SkObj(
                 self.builder
                     .build_bitcast(obj.clone().0, ances_type, "obj_as_super"),

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -753,7 +753,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 ),
                 SkMethodBody::Getter { idx, name, ty } => {
                     let this = self.get_nth_param(&function, 0);
-                    let val = self.build_ivar_load(this, *idx, name);
+                    let val = self.build_ivar_load(ty, this, *idx, name);
                     self.build_return(&val);
                 }
                 SkMethodBody::Setter { idx, name } => {

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -173,14 +173,16 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     }
 
     /// Load a class object
-    pub fn load_class_object(&self, class_fullname: &ClassFullname) -> SkClassObj<'run> {
+    /// NOTE: this does not work with `const_is_obj` classes (i.e. Void, None, etc.)
+    fn load_class_object(&self, class_fullname: &ClassFullname) -> SkClassObj<'run> {
         let class_const_name = llvm_const_name(&class_fullname.to_const_fullname());
         let class_obj_addr = self
             .module
             .get_global(&class_const_name)
             .unwrap_or_else(|| panic!("global `{}' not found", class_const_name))
             .as_pointer_value();
-        SkClassObj(self.builder.build_load(class_obj_addr, "class_obj"))
+        let t = self.llvm_type(&ty::raw("Class"));
+        SkClassObj(self.builder.build_load(t, class_obj_addr, "class_obj"))
     }
 
     pub fn _allocate_sk_obj(

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -27,7 +27,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     /// Build IR to return ::Void
     pub fn build_return_void(&self) {
-        let v = self.gen_const_ref(&toplevel_const("Void"));
+        let v = self.gen_const_ref(&toplevel_const("Void"), &ty::raw("Void"));
         self.build_return(&v);
     }
 

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -6,6 +6,8 @@ use inkwell::values::BasicValue;
 use shiika_core::{names::*, ty, ty::*};
 use shiika_ffi::{mangle_const, mangle_method};
 
+/// Number of elements before ivars
+const OBJ_HEADER_SIZE: usize = 2;
 /// 0th: reference to the vtable
 pub const OBJ_VTABLE_IDX: usize = 0;
 /// 1st: reference to the class object
@@ -52,7 +54,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             &self.llvm_struct_type(&obj.ty()),
             obj.0.clone(),
             item_ty,
-            idx,
+            OBJ_HEADER_SIZE + idx,
             name,
         )
     }
@@ -74,7 +76,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         idx: usize,
         value: inkwell::values::BasicValueEnum<'run>,
     ) {
-        self.build_llvm_struct_set(&obj.struct_ty(self), obj.0.clone(), idx, value, name);
+        self.build_llvm_struct_set(
+            &obj.struct_ty(self),
+            obj.0.clone(),
+            OBJ_HEADER_SIZE + idx,
+            value,
+            name,
+        );
     }
 
     /// Get the class object of an object as `*Class`

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -32,21 +32,22 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     pub fn build_ivar_load(&'run self, obj: SkObj<'run>, name: &str) -> SkObj<'run> {
         let sk_class = self.sk_types.get_class(&obj.classname());
         let sk_ivar = sk_class.ivars.get(name).unwrap();
-        SkObj::new(sk_ivar.ty.clone(), self.build_ivar_load_raw(obj, name))
+        let value = self.build_ivar_load_raw(obj, self.llvm_type(&sk_ivar.ty), sk_ivar.idx, name);
+        SkObj::new(sk_ivar.ty.clone(), value)
     }
 
     pub fn build_ivar_load_raw(
         &'run self,
         obj: SkObj<'run>,
+        item_ty: inkwell::types::BasicTypeEnum<'run>,
+        idx: usize,
         name: &str,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        let sk_class = self.sk_types.get_class(&obj.classname());
-        let sk_ivar = sk_class.ivars.get(name).unwrap();
-        self.build_llvm_struct_ref(
+        self.build_llvm_struct_ref_raw(
             &self.llvm_struct_type(&obj.ty()),
             obj.0.clone(),
-            &sk_ivar.ty,
-            sk_ivar.idx,
+            item_ty,
+            idx,
             name,
         )
     }

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -2,7 +2,6 @@ use crate::values::*;
 use crate::CodeGen;
 use inkwell::types::*;
 use inkwell::values::BasicValue;
-use inkwell::AddressSpace;
 use shiika_core::{names::*, ty, ty::*};
 use shiika_ffi::{mangle_const, mangle_method};
 
@@ -106,7 +105,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .builder
             .build_bitcast(
                 vtable_ref.0,
-                ary_type.ptr_type(AddressSpace::Generic),
+                ary_type.ptr_type(Default::default()),
                 "vtable_ptr",
             )
             .into_pointer_value();
@@ -224,7 +223,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         reg_name: &str,
     ) -> inkwell::values::BasicValueEnum<'run> {
         let mem = self.allocate_mem(t);
-        let ptr_type = t.ptr_type(AddressSpace::Generic);
+        let ptr_type = t.ptr_type(Default::default());
         self.builder.build_bitcast(mem.0, ptr_type, reg_name)
     }
 
@@ -318,8 +317,8 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         // eg. `%Int*`
         let t2 = val.as_basic_value_enum().get_type();
         // eg. `%Int**`
-        let t1ptr = t1.ptr_type(AddressSpace::Generic).as_any_type_enum();
-        let t2ptr = t2.ptr_type(AddressSpace::Generic).as_any_type_enum();
+        let t1ptr = t1.ptr_type(Default::default()).as_any_type_enum();
+        let t2ptr = t2.ptr_type(Default::default()).as_any_type_enum();
         if t1.as_any_type_enum() == t2ptr || t2.as_any_type_enum() == t1ptr {
             println!("[BUG] Found wrong bitcast from t2 to t1, where");
             dbg!(&t2);
@@ -356,7 +355,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     fn llvm_type_of_lit_ty(&self, lit_ty: &LitTy) -> inkwell::types::BasicTypeEnum<'ictx> {
         self.llvm_struct_type(&lit_ty.erasure().into())
-            .ptr_type(AddressSpace::Generic)
+            .ptr_type(Default::default())
             .as_basic_type_enum()
     }
 

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -238,7 +238,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let func = self.get_llvm_func(&llvm_func_name("shiika_malloc"));
         I8Ptr(
             self.builder
-                .build_call(func, &[size.as_basic_value_enum().into()], "mem")
+                .build_direct_call(func, &[size.as_basic_value_enum().into()], "mem")
                 .try_as_basic_value()
                 .left()
                 .unwrap()
@@ -271,7 +271,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .get_function(&func_name.0)
             .unwrap_or_else(|| panic!("[BUG] llvm function {:?} not found", func_name));
         self.builder
-            .build_call(f, args, reg_name)
+            .build_direct_call(f, args, reg_name)
             .try_as_basic_value()
             .left()
             .unwrap()
@@ -288,7 +288,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .module
             .get_function(&func_name.0)
             .unwrap_or_else(|| panic!("[BUG] llvm function {:?} not found", func_name));
-        self.builder.build_call(f, args, reg_name);
+        self.builder.build_direct_call(f, args, reg_name);
     }
 
     /// Get nth parameter of llvm func as SkObj

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -93,31 +93,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         )
     }
 
-    /// Lookup llvm func from vtable of an object
-    pub fn build_vtable_ref(
-        &self,
-        vtable_ref: VTableRef<'run>,
-        idx: usize,
-        size: usize,
-    ) -> inkwell::values::BasicValueEnum<'run> {
-        let ary_type = self.i8ptr_type.array_type(size as u32);
-        let vtable_ptr = self
-            .builder
-            .build_bitcast(
-                vtable_ref.0,
-                ary_type.ptr_type(Default::default()),
-                "vtable_ptr",
-            )
-            .into_pointer_value();
-        let vtable = self
-            .builder
-            .build_load(vtable_ptr, "vtable")
-            .into_array_value();
-        self.builder
-            .build_extract_value(vtable, idx as u32, "func_raw")
-            .unwrap()
-    }
-
     /// Load value of the nth element of the llvm struct of a Shiika object
     fn build_object_struct_ref(
         &self,

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -121,13 +121,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         idx: usize,
         name: &str,
     ) -> inkwell::values::BasicValueEnum<'run> {
-        self.build_llvm_struct_ref_raw(
-            struct_ty,
-            struct_ptr,
-            self.llvm_struct_type(item_ty).as_basic_type_enum(),
-            idx,
-            name,
-        )
+        self.build_llvm_struct_ref_raw(struct_ty, struct_ptr, self.llvm_type(item_ty), idx, name)
     }
 
     /// Get a value in an llvm struct

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -1,4 +1,5 @@
 use crate::values::*;
+use crate::vtable::OpaqueVTableRef;
 use crate::CodeGen;
 use inkwell::types::*;
 use inkwell::values::BasicValue;

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -31,7 +31,9 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     pub fn build_ivar_load(&'run self, obj: SkObj<'run>, name: &str) -> SkObj<'run> {
         let sk_class = self.sk_types.get_class(&obj.classname());
-        let sk_ivar = sk_class.ivars.get(name).unwrap();
+        let sk_ivar = sk_class.ivars.get(name).unwrap_or_else(|| {
+            panic!("[BUG] ivar `{}' not found in class {}", name, &obj.ty());
+        });
         let value = self.build_ivar_load_raw(obj, self.llvm_type(&sk_ivar.ty), sk_ivar.idx, name);
         SkObj::new(sk_ivar.ty.clone(), value)
     }

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -112,9 +112,14 @@ impl<'run> VTableRef<'run> {
     }
 
     fn llvm_type(gen: &CodeGen<'_, 'run, '_>, len: usize) -> inkwell::types::PointerType<'run> {
-        gen.i8ptr_type
-            .array_type(len as u32)
-            .ptr_type(Default::default())
+        Self::llvm_pointee_type(gen, len).ptr_type(Default::default())
+    }
+
+    fn llvm_pointee_type(
+        gen: &CodeGen<'_, 'run, '_>,
+        len: usize,
+    ) -> inkwell::types::ArrayType<'run> {
+        gen.i8ptr_type.array_type(len as u32)
     }
 
     /// Returns the vtable of a Shiika object.
@@ -142,7 +147,11 @@ impl<'run> VTableRef<'run> {
 
     fn get_vtable(&self, gen: &CodeGen<'_, 'run, '_>) -> inkwell::values::ArrayValue<'run> {
         gen.builder
-            .build_load(Self::llvm_type(gen, self.len), self.ptr.clone(), "vtable")
+            .build_load(
+                Self::llvm_pointee_type(gen, self.len),
+                self.ptr.clone(),
+                "vtable",
+            )
             .into_array_value()
     }
 }

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -1,6 +1,4 @@
-use crate::utils::OBJ_VTABLE_IDX;
 use crate::CodeGen;
-use inkwell::types::BasicType;
 use inkwell::values::BasicValue;
 use shiika_core::{names::ClassFullname, ty, ty::TermTy};
 
@@ -73,91 +71,6 @@ impl<'run> SkClassObj<'run> {
     /// A class object is a Shiika object.
     pub fn as_sk_obj(self) -> SkObj<'run> {
         SkObj::new(ty::raw("Class"), self.0)
-    }
-}
-
-/// Reference to vtable (eg. `shiika_vtable_Int`)
-#[derive(Debug)]
-pub struct VTableRef<'run> {
-    pub ptr: inkwell::values::PointerValue<'run>,
-    len: usize,
-}
-
-impl<'run> VTableRef<'run> {
-    pub fn new(ptr: inkwell::values::PointerValue<'run>, len: usize) -> VTableRef<'run> {
-        VTableRef { ptr, len }
-    }
-
-    fn llvm_type(gen: &CodeGen<'_, 'run, '_>, len: usize) -> inkwell::types::PointerType<'run> {
-        Self::llvm_pointee_type(gen, len).ptr_type(Default::default())
-    }
-
-    fn llvm_pointee_type(
-        gen: &CodeGen<'_, 'run, '_>,
-        len: usize,
-    ) -> inkwell::types::ArrayType<'run> {
-        gen.i8ptr_type.array_type(len as u32)
-    }
-
-    /// Returns the vtable of a Shiika object.
-    pub fn from_sk_obj(
-        gen: &CodeGen<'_, 'run, '_>,
-        object: SkObj<'run>,
-        len: usize,
-    ) -> VTableRef<'run> {
-        let item_ty = Self::llvm_type(gen, len).as_basic_type_enum();
-        let ptr = gen
-            .build_object_struct_ref_raw(object, item_ty, OBJ_VTABLE_IDX, "vtable")
-            .into_pointer_value();
-        VTableRef::new(ptr, len)
-    }
-
-    pub fn get_func(
-        &self,
-        gen: &CodeGen<'_, 'run, '_>,
-        idx: usize,
-    ) -> inkwell::values::BasicValueEnum<'run> {
-        gen.builder
-            .build_extract_value(self.get_vtable(gen), idx as u32, "func_raw")
-            .unwrap()
-    }
-
-    fn get_vtable(&self, gen: &CodeGen<'_, 'run, '_>) -> inkwell::values::ArrayValue<'run> {
-        gen.builder
-            .build_load(
-                Self::llvm_pointee_type(gen, self.len),
-                self.ptr.clone(),
-                "vtable",
-            )
-            .into_array_value()
-    }
-}
-
-/// Reference to vtable where its length is unknown.
-#[derive(Debug)]
-pub struct OpaqueVTableRef<'run> {
-    pub ptr: inkwell::values::PointerValue<'run>,
-}
-
-impl<'run> OpaqueVTableRef<'run> {
-    pub fn new(ptr: inkwell::values::PointerValue<'run>) -> OpaqueVTableRef<'run> {
-        OpaqueVTableRef { ptr }
-    }
-
-    /// Normally vtables are not Shiika object. This is used internally
-    pub fn as_object_ptr(self, gen: &CodeGen<'_, 'run, '_>) -> SkObj<'run> {
-        let ty = ty::raw("Object");
-        SkObj::new(
-            ty.clone(),
-            gen.builder
-                .build_bitcast(self.ptr.as_basic_value_enum(), gen.llvm_type(&ty), "as"),
-        )
-    }
-}
-
-impl<'run> From<VTableRef<'run>> for OpaqueVTableRef<'run> {
-    fn from(x: VTableRef<'run>) -> Self {
-        OpaqueVTableRef::new(x.ptr)
     }
 }
 

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -100,7 +100,7 @@ impl<'run> OpaqueVTableRef<'run> {
 }
 
 impl<'run> From<VTableRef<'run>> for OpaqueVTableRef<'run> {
-    fn from(x: VTableRef) -> Self {
+    fn from(x: VTableRef<'run>) -> Self {
         OpaqueVTableRef::new(x.ptr)
     }
 }

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -49,26 +49,6 @@ impl<'run> SkObj<'run> {
             .build_bitcast(self.0, code_gen.i8ptr_type, "ptr")
     }
 
-    pub fn ivar_store(&self, gen: &CodeGen<'_, 'run, '_>, name: &str, value: SkObj<'run>) {
-        let sk_class = gen
-            .sk_types
-            .get_class(&self.1.erasure().to_class_fullname());
-        let sk_ivar = sk_class.ivars.get(name).unwrap_or_else(|| {
-            panic!("[BUG] ivar `{}' not found in class {}", name, &self.1);
-        });
-        self.ivar_store_raw(gen, name, sk_ivar.idx, value.0.as_basic_value_enum());
-    }
-
-    pub fn ivar_store_raw(
-        &self,
-        gen: &CodeGen<'_, 'run, '_>,
-        name: &str,
-        idx: usize,
-        value: inkwell::values::BasicValueEnum<'run>,
-    ) {
-        gen.build_llvm_struct_set(&self.struct_ty(gen), self.0.clone(), idx, value, name);
-    }
-
     pub fn struct_ty(&self, gen: &'run CodeGen<'_, 'run, '_>) -> inkwell::types::StructType<'run> {
         gen.llvm_struct_type(&self.1).clone()
     }

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -41,6 +41,23 @@ impl<'run> VTableRef<'run> {
     pub fn as_sk_obj(self) -> SkObj<'run> {
         SkObj(self.0)
     }
+
+    pub fn get_func(
+        &self,
+        gen: &CodeGen<'_, 'run, '_>,
+        idx: usize,
+        size: usize,
+    ) -> inkwell::values::BasicValueEnum<'run> {
+        let ary_type = gen.i8ptr_type.array_type(size as u32);
+        let vtable_type = ary_type.ptr_type(Default::default());
+        let vtable = gen
+            .builder
+            .build_load(vtable_type, &self.0, "vtable")
+            .into_array_value();
+        gen.builder
+            .build_extract_value(vtable, idx as u32, "func_raw")
+            .unwrap()
+    }
 }
 
 /// i8* (REFACTOR: rename to VoidPtr)

--- a/lib/skc_codegen/src/vtable.rs
+++ b/lib/skc_codegen/src/vtable.rs
@@ -1,0 +1,91 @@
+use crate::utils::OBJ_VTABLE_IDX;
+use crate::values::SkObj;
+use crate::CodeGen;
+use inkwell::types::BasicType;
+use inkwell::values::BasicValue;
+use shiika_core::ty;
+
+/// Reference to vtable (eg. `shiika_vtable_Int`)
+#[derive(Debug)]
+pub struct VTableRef<'run> {
+    pub ptr: inkwell::values::PointerValue<'run>,
+    len: usize,
+}
+
+impl<'run> VTableRef<'run> {
+    pub fn new(ptr: inkwell::values::PointerValue<'run>, len: usize) -> VTableRef<'run> {
+        VTableRef { ptr, len }
+    }
+
+    fn llvm_type(gen: &CodeGen<'_, 'run, '_>, len: usize) -> inkwell::types::PointerType<'run> {
+        Self::llvm_pointee_type(gen, len).ptr_type(Default::default())
+    }
+
+    fn llvm_pointee_type(
+        gen: &CodeGen<'_, 'run, '_>,
+        len: usize,
+    ) -> inkwell::types::ArrayType<'run> {
+        gen.i8ptr_type.array_type(len as u32)
+    }
+
+    /// Returns the vtable of a Shiika object.
+    pub fn from_sk_obj(
+        gen: &CodeGen<'_, 'run, '_>,
+        object: SkObj<'run>,
+        len: usize,
+    ) -> VTableRef<'run> {
+        let item_ty = Self::llvm_type(gen, len).as_basic_type_enum();
+        let ptr = gen
+            .build_object_struct_ref_raw(object, item_ty, OBJ_VTABLE_IDX, "vtable")
+            .into_pointer_value();
+        VTableRef::new(ptr, len)
+    }
+
+    pub fn get_func(
+        &self,
+        gen: &CodeGen<'_, 'run, '_>,
+        idx: usize,
+    ) -> inkwell::values::BasicValueEnum<'run> {
+        gen.builder
+            .build_extract_value(self.get_vtable(gen), idx as u32, "func_raw")
+            .unwrap()
+    }
+
+    fn get_vtable(&self, gen: &CodeGen<'_, 'run, '_>) -> inkwell::values::ArrayValue<'run> {
+        gen.builder
+            .build_load(
+                Self::llvm_pointee_type(gen, self.len),
+                self.ptr.clone(),
+                "vtable",
+            )
+            .into_array_value()
+    }
+}
+
+/// Reference to vtable where its length is unknown.
+#[derive(Debug)]
+pub struct OpaqueVTableRef<'run> {
+    pub ptr: inkwell::values::PointerValue<'run>,
+}
+
+impl<'run> OpaqueVTableRef<'run> {
+    pub fn new(ptr: inkwell::values::PointerValue<'run>) -> OpaqueVTableRef<'run> {
+        OpaqueVTableRef { ptr }
+    }
+
+    /// Normally vtables are not Shiika object. This is used internally
+    pub fn as_object_ptr(self, gen: &CodeGen<'_, 'run, '_>) -> SkObj<'run> {
+        let ty = ty::raw("Object");
+        SkObj::new(
+            ty.clone(),
+            gen.builder
+                .build_bitcast(self.ptr.as_basic_value_enum(), gen.llvm_type(&ty), "as"),
+        )
+    }
+}
+
+impl<'run> From<VTableRef<'run>> for OpaqueVTableRef<'run> {
+    fn from(x: VTableRef<'run>) -> Self {
+        OpaqueVTableRef::new(x.ptr)
+    }
+}

--- a/lib/skc_codegen/src/vtable.rs
+++ b/lib/skc_codegen/src/vtable.rs
@@ -29,7 +29,7 @@ impl<'run> VTableRef<'run> {
     }
 
     /// Returns the vtable of a Shiika object.
-    pub fn from_sk_obj(
+    pub fn of_sk_obj(
         gen: &CodeGen<'_, 'run, '_>,
         object: SkObj<'run>,
         len: usize,

--- a/lib/skc_codegen/src/wtable.rs
+++ b/lib/skc_codegen/src/wtable.rs
@@ -43,7 +43,7 @@ pub fn gen_insert_wtable(code_gen: &CodeGen, sk_class: &SkClass) {
             code_gen,
             &llvm_wtable_const_name(&sk_class.fullname(), mod_name),
         );
-        let cls = code_gen.get_nth_param(&function, 0);
+        let cls = code_gen.get_nth_param(ty::raw("Class"), &function, 0);
         let len = sk_class.wtable.get_len(mod_name);
         let args = &[
             cls.into_i8ptr(code_gen).into(),

--- a/lib/skc_corelib/src/fn_x.rs
+++ b/lib/skc_corelib/src/fn_x.rs
@@ -3,6 +3,11 @@ use shiika_core::ty;
 use skc_hir::{SkIVar, Supertype};
 use std::collections::HashMap;
 
+pub const IVAR_FUNC_IDX: usize = 0;
+pub const IVAR_THE_SELF_IDX: usize = 1;
+pub const IVAR_CAPTURES_IDX: usize = 2;
+pub const IVAR_EXIT_STATUS_IDX: usize = 3;
+
 macro_rules! fn_item {
     ($i:expr) => {{
         let mut typarams = (1..=$i).map(|i| format!("S{}", i)).collect::<Vec<_>>();

--- a/lib/skc_corelib/src/lib.rs
+++ b/lib/skc_corelib/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod class;
-mod fn_x;
+pub mod fn_x;
 pub mod rustlib_methods;
 use shiika_core::names::*;
 use shiika_core::ty::{self, Erasure};

--- a/lib/skc_corelib/src/shiika_internal_ptr.rs
+++ b/lib/skc_corelib/src/shiika_internal_ptr.rs
@@ -22,7 +22,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             |code_gen, function| {
                 let i8ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
                 let obj_ptr_type = code_gen.llvm_type(&ty::raw("Object")).into_pointer_type();
-                let obj_ptrptr_type = obj_ptr_type.ptr_type(inkwell::AddressSpace::Generic);
+                let obj_ptrptr_type = obj_ptr_type.ptr_type(Default::default());
                 let obj_ptr = code_gen
                     .builder
                     .build_bitcast(i8ptr.0, obj_ptrptr_type, "")
@@ -39,7 +39,7 @@ pub fn create_methods() -> Vec<SkMethod> {
             |code_gen, function| {
                 let i8ptr = code_gen.unbox_i8ptr(code_gen.get_nth_param(function, 0));
                 let obj_ptr_type = code_gen.llvm_type(&ty::raw("Object")).into_pointer_type();
-                let obj_ptrptr_type = obj_ptr_type.ptr_type(inkwell::AddressSpace::Generic);
+                let obj_ptrptr_type = obj_ptr_type.ptr_type(Default::default());
                 let obj_ptr = code_gen
                     .builder
                     .build_bitcast(i8ptr.0, obj_ptrptr_type, "")

--- a/lib/skc_hir/src/sk_method.rs
+++ b/lib/skc_hir/src/sk_method.rs
@@ -1,6 +1,7 @@
 use crate::signature::MethodSignature;
 use crate::{HirExpressions, HirLVars};
 use shiika_core::names::*;
+use shiika_core::ty::TermTy;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -27,7 +28,11 @@ pub enum SkMethodBody {
         const_is_obj: bool,
     },
     /// A method that just return the value of `idx`th ivar
-    Getter { idx: usize, name: String },
+    Getter {
+        idx: usize,
+        name: String,
+        ty: TermTy,
+    },
     /// A method that just update the value of `idx`th ivar
     Setter { idx: usize, name: String },
 }

--- a/lib/skc_hir/src/sk_method.rs
+++ b/lib/skc_hir/src/sk_method.rs
@@ -34,7 +34,11 @@ pub enum SkMethodBody {
         ty: TermTy,
     },
     /// A method that just update the value of `idx`th ivar
-    Setter { idx: usize, name: String },
+    Setter {
+        idx: usize,
+        name: String,
+        ty: TermTy,
+    },
 }
 
 impl SkMethod {

--- a/lib/skc_hir/src/sk_method.rs
+++ b/lib/skc_hir/src/sk_method.rs
@@ -32,12 +32,14 @@ pub enum SkMethodBody {
         idx: usize,
         name: String,
         ty: TermTy,
+        self_ty: TermTy,
     },
     /// A method that just update the value of `idx`th ivar
     Setter {
         idx: usize,
         name: String,
         ty: TermTy,
+        self_ty: TermTy,
     },
 }
 

--- a/lib/skc_hir/src/sk_type.rs
+++ b/lib/skc_hir/src/sk_type.rs
@@ -34,7 +34,10 @@ impl SkTypes {
     }
 
     pub fn get_class<'hir>(&'hir self, name: &ClassFullname) -> &'hir SkClass {
-        let sk_type = self.0.get(&name.to_type_fullname()).unwrap();
+        let sk_type = self
+            .0
+            .get(&name.to_type_fullname())
+            .unwrap_or_else(|| panic!("[BUG] class {} not found", name));
         if let SkType::Class(class) = sk_type {
             class
         } else {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -94,7 +94,11 @@ fn run_<P: AsRef<Path>>(sk_path_: P, capture_out: bool) -> Result<(String, Strin
     let triple = targets::default_triple();
     let sk_path = sk_path_.as_ref();
     let bc_path = sk_path.with_extension("bc");
-    let exe_path = make_exe_path(sk_path)?;
+    let exe_path = if cfg!(target_os = "windows") {
+        sk_path.canonicalize()?.with_extension("exe")
+    } else {
+        sk_path.canonicalize()?.with_extension("out")
+    };
 
     let mut cmd = Command::new(env::var("CLANG").unwrap_or_else(|_| "clang".to_string()));
     add_args_from_env(&mut cmd, "CFLAGS");
@@ -141,8 +145,7 @@ fn run_<P: AsRef<Path>>(sk_path_: P, capture_out: bool) -> Result<(String, Strin
         cmd.arg("-lpthread");
     }
 
-    let result = cmd.status().context(format!("failed to run {:?}", cmd))?;
-    if !result.success() {
+    if !cmd.status()?.success() {
         return Err(anyhow!("clang failed"));
     }
 
@@ -161,24 +164,18 @@ fn run_<P: AsRef<Path>>(sk_path_: P, capture_out: bool) -> Result<(String, Strin
     }
 }
 
-/// Remove .bc and the executable (used by unit tests)
+/// Remove .bc and .out (used by unit tests)
 pub fn cleanup<P: AsRef<Path>>(sk_path_: P) -> Result<()> {
     let sk_path = sk_path_.as_ref();
     let bc_path = sk_path.with_extension("bc");
-    let exe_path = make_exe_path(sk_path)?;
+    let exe_path = if cfg!(target_os = "windows") {
+        sk_path.with_extension("exe")
+    } else {
+        sk_path.with_extension("out")
+    };
     let _ = fs::remove_file(bc_path);
     let _ = fs::remove_file(exe_path);
     Ok(())
-}
-
-fn make_exe_path<P: AsRef<Path>>(sk_path_: P) -> Result<PathBuf> {
-    let sk_path = sk_path_.as_ref();
-    let ext = if cfg!(target_os = "windows") {
-        "exe"
-    } else {
-        ""
-    };
-    Ok(sk_path.canonicalize()?.with_extension(ext))
 }
 
 fn add_args_from_env(cmd: &mut Command, key: &str) {


### PR DESCRIPTION
This PR upgrades LLVM to v15.

The biggest change is that llvm pointer types no more holds the pointee type. https://llvm.org/docs/OpaquePointers.html
As a consequence, `build_load` API needs the pointee type (i.e. the type of the value to load.)

Considering all Shiika values (formerly `%Object*` or `%Bool*`, etc) are now a `ptr` type, we could make codegen simpler but I'll try it later.
