### PR TITLE
Remove bitcast after allocate_llvm_obj

### DIFF
--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -56,7 +56,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let i1_val = function.get_params()[0];
-        let sk_bool = self.allocate_sk_obj(&class_fullname("Bool"), "sk_bool");
+        let sk_bool = self.allocate_sk_obj(&class_fullname("Bool"));
         self.build_ivar_store_raw(sk_bool.clone(), "@llvm_bool", 0, i1_val);
         self.build_return(&sk_bool);
 
@@ -75,7 +75,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let i64_val = function.get_params()[0];
-        let sk_int = self.allocate_sk_obj(&class_fullname("Int"), "sk_int");
+        let sk_int = self.allocate_sk_obj(&class_fullname("Int"));
         self.build_ivar_store_raw(sk_int.clone(), "@llvm_int", 0, i64_val);
         self.build_return(&sk_int);
 
@@ -97,7 +97,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let f64_val = function.get_params()[0];
-        let sk_float = self.allocate_sk_obj(&class_fullname("Float"), "sk_float");
+        let sk_float = self.allocate_sk_obj(&class_fullname("Float"));
         self.build_ivar_store_raw(sk_float.clone(), "@llvm_float", 0, f64_val);
         self.build_return(&sk_float);
 
@@ -119,7 +119,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.position_at_end(basic_block);
 
         let i8ptr = function.get_params()[0];
-        let sk_ptr = self.allocate_sk_obj(&class_fullname("Shiika::Internal::Ptr"), "sk_ptr");
+        let sk_ptr = self.allocate_sk_obj(&class_fullname("Shiika::Internal::Ptr"));
         self.build_ivar_store_raw(sk_ptr.clone(), "@llvm_i8ptr", 0, i8ptr);
         self.build_return(&sk_ptr);
 

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -1255,7 +1255,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     fn gen_the_metaclass(&'run self, str_literal_idx: &usize) -> SkObj<'run> {
         // We need a trick here to achieve `Metaclass.class == Metaclass`.
         let null = SkClassObj::nullptr(self);
-        let cls_obj = self._allocate_sk_obj(&class_fullname("Metaclass"), "the_metaclass", null);
+        let cls_obj = self._allocate_sk_obj(&class_fullname("Metaclass"), null);
         self.build_ivar_store(
             cls_obj.clone(),
             skc_corelib::class::IVAR_NAME_IDX,

--- a/lib/skc_codegen/src/lib.rs
+++ b/lib/skc_codegen/src/lib.rs
@@ -338,7 +338,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         let create_main_block = self.context.append_basic_block(function, "CreateMain");
         self.builder.build_unconditional_branch(create_main_block);
         self.builder.position_at_end(create_main_block);
-        self.the_main = Some(self.allocate_sk_obj(&class_fullname("Object"), "main"));
+        self.the_main = Some(self.allocate_sk_obj(&class_fullname("Object")));
 
         // UserMain:
         let user_main_block = self.context.append_basic_block(function, "UserMain");
@@ -806,9 +806,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             let obj_ty = self.llvm_type(ty);
             if *captured {
                 // Allocate memory on heap in case it lives longer than the method call.
-                let ptrptr = self
-                    .allocate_llvm_obj(&obj_ty, "ptrptr")
-                    .into_pointer_value();
+                let ptrptr = self.allocate_llvm_obj(&obj_ty).into_pointer_value();
                 lvar_ptrs.insert(name.to_string(), ptrptr);
             } else {
                 let ptr = self.builder.build_alloca(obj_ty, name);
@@ -898,7 +896,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
     ) {
         // Allocate memory and set .class (which is the receiver of .new)
         let class_obj = SkClassObj(llvm_func_args[0].into_pointer_value());
-        let obj = self._allocate_sk_obj(class_fullname, "addr", class_obj);
+        let obj = self._allocate_sk_obj(class_fullname, class_obj);
 
         // Call initialize
         let addr = if init_cls_name == class_fullname {


### PR DESCRIPTION
This PR removes unneeded bitcast in allocate_llvm_obj. The argument `reg_name` is also removed by tihs change.