### PR TITLE
Remove HirExpressions

### DIFF
--- a/lib/skc_ast2hir/src/type_system/type_checking.rs
+++ b/lib/skc_ast2hir/src/type_system/type_checking.rs
@@ -17,7 +17,7 @@ macro_rules! type_error {
 pub fn check_return_value(
     class_dict: &ClassDict,
     sig: &MethodSignature,
-    body_exprs: &HirExpressions,
+    body_exprs: &HirExpression,
 ) -> Result<()> {
     let ty = &body_exprs.ty;
     if sig.ret_ty.is_void_type() {

--- a/lib/skc_hir/src/pattern_match.rs
+++ b/lib/skc_hir/src/pattern_match.rs
@@ -1,4 +1,4 @@
-use crate::{HirExpression, HirExpressions, HirLVars};
+use crate::{HirExpression, HirLVars};
 
 #[derive(Debug, Clone)]
 pub enum Component {
@@ -11,7 +11,7 @@ pub enum Component {
 #[derive(Debug, Clone)]
 pub struct MatchClause {
     pub components: Vec<Component>,
-    pub body_hir: HirExpressions,
+    pub body_hir: HirExpression,
     /// Local variables declared in this clause
     pub lvars: HirLVars,
 }

--- a/lib/skc_hir/src/sk_method.rs
+++ b/lib/skc_hir/src/sk_method.rs
@@ -1,5 +1,5 @@
 use crate::signature::MethodSignature;
-use crate::{HirExpressions, HirLVars};
+use crate::{HirExpression, HirLVars};
 use shiika_core::names::*;
 use shiika_core::ty::TermTy;
 use std::collections::HashMap;
@@ -16,7 +16,7 @@ pub type SkMethods = HashMap<TypeFullname, Vec<SkMethod>>;
 #[derive(Debug)]
 pub enum SkMethodBody {
     /// A method defined with Shiika expressions
-    Normal { exprs: HirExpressions },
+    Normal { exprs: HirExpression },
     /// A method defined in skc_rustlib
     RustLib,
     /// The method .new


### PR DESCRIPTION
This PR removes `HirExpressions` from HIR.

`HirExpressions` expresses serial execution of some exprs but it can be done by `HirParenthesizedExpr`. Codegen is now a bit simpler by removing `gen_exprs`.