### PR TITLE
Remove argument `ty` from gen.llvm_type

### DIFF
--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -8,41 +8,24 @@ use shiika_core::{names::*, ty};
 impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Generate llvm funcs about boxing
     pub fn gen_boxing_funcs(&self) {
-        let fn_type = self
-            .llvm_type(&ty::raw("Bool"))
-            .fn_type(&[self.i1_type.into()], false);
+        let fn_type = self.llvm_type().fn_type(&[self.i1_type.into()], false);
         self.module.add_function("box_bool", fn_type, None);
-        let fn_type = self
-            .i1_type
-            .fn_type(&[self.llvm_type(&ty::raw("Bool")).into()], false);
+        let fn_type = self.i1_type.fn_type(&[self.llvm_type().into()], false);
         self.module.add_function("unbox_bool", fn_type, None);
-        let fn_type = self
-            .llvm_type(&ty::raw("Int"))
-            .fn_type(&[self.i64_type.into()], false);
+        let fn_type = self.llvm_type().fn_type(&[self.i64_type.into()], false);
         self.module.add_function("box_int", fn_type, None);
-        let fn_type = self
-            .i64_type
-            .fn_type(&[self.llvm_type(&ty::raw("Int")).into()], false);
+        let fn_type = self.i64_type.fn_type(&[self.llvm_type().into()], false);
         self.module.add_function("unbox_int", fn_type, None);
-        let fn_type = self
-            .llvm_type(&ty::raw("Float"))
-            .fn_type(&[self.f64_type.into()], false);
+        let fn_type = self.llvm_type().fn_type(&[self.f64_type.into()], false);
         self.module.add_function("box_float", fn_type, None);
-        let fn_type = self
-            .f64_type
-            .fn_type(&[self.llvm_type(&ty::raw("Float")).into()], false);
+        let fn_type = self.f64_type.fn_type(&[self.llvm_type().into()], false);
         self.module.add_function("unbox_float", fn_type, None);
-        let fn_type = self
-            .llvm_type(&ty::raw("Shiika::Internal::Ptr"))
-            .fn_type(&[self.ptr_type.into()], false);
+        let fn_type = self.llvm_type().fn_type(&[self.ptr_type.into()], false);
         self.module.add_function("box_i8ptr", fn_type, None);
-        let fn_type = self.ptr_type.fn_type(
-            &[self.llvm_type(&ty::raw("Shiika::Internal::Ptr")).into()],
-            false,
-        );
+        let fn_type = self.ptr_type.fn_type(&[self.llvm_type().into()], false);
         self.module.add_function("unbox_i8ptr", fn_type, None);
         let fn_type = self
-            .llvm_type(&ty::raw("String"))
+            .llvm_type()
             .fn_type(&[self.ptr_type.into(), self.i64_type.into()], false);
         self.module
             .add_function("gen_literal_string", fn_type, None);

--- a/lib/skc_codegen/src/boxing.rs
+++ b/lib/skc_codegen/src/boxing.rs
@@ -34,16 +34,16 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.module.add_function("unbox_float", fn_type, None);
         let fn_type = self
             .llvm_type(&ty::raw("Shiika::Internal::Ptr"))
-            .fn_type(&[self.i8ptr_type.into()], false);
+            .fn_type(&[self.ptr_type.into()], false);
         self.module.add_function("box_i8ptr", fn_type, None);
-        let fn_type = self.i8ptr_type.fn_type(
+        let fn_type = self.ptr_type.fn_type(
             &[self.llvm_type(&ty::raw("Shiika::Internal::Ptr")).into()],
             false,
         );
         self.module.add_function("unbox_i8ptr", fn_type, None);
         let fn_type = self
             .llvm_type(&ty::raw("String"))
-            .fn_type(&[self.i8ptr_type.into(), self.i64_type.into()], false);
+            .fn_type(&[self.ptr_type.into(), self.i64_type.into()], false);
         self.module
             .add_function("gen_literal_string", fn_type, None);
     }
@@ -132,7 +132,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             ty::raw("Shiika::Internal::Ptr"),
             function.get_params()[0].into_pointer_value(),
         );
-        let i8ptr = self.build_ivar_load_raw(sk_ptr, self.i8ptr_type.into(), 0, "@llvm_i8ptr");
+        let i8ptr = self.build_ivar_load_raw(sk_ptr, self.ptr_type.into(), 0, "@llvm_i8ptr");
         self.builder.build_return(Some(&i8ptr));
 
         // gen_literal_string

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -945,7 +945,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .get_llvm_func(&func_name)
             .as_global_value()
             .as_basic_value_enum();
-        let fnptr_i8 = self.builder.build_bitcast(fnptr, self.i8ptr_type, "");
+        let fnptr_i8 = self.builder.build_bitcast(fnptr, self.ptr_type, "");
         let sk_ptr = self.box_i8ptr(fnptr_i8);
         let the_self = self.gen_self_expression(ctx, &ty::raw("Object"));
         let captured = self._gen_lambda_captures(ctx, name, captures);
@@ -1039,9 +1039,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .get_global(&format!("str_{}", idx))
             .unwrap_or_else(|| panic!("[BUG] global for str_{} not created", idx))
             .as_pointer_value();
-        let i8ptr = self
-            .builder
-            .build_bitcast(byte_ary, self.i8ptr_type, "i8ptr");
+        let i8ptr = self.builder.build_bitcast(byte_ary, self.ptr_type, "i8ptr");
         let bytesize = self
             .i64_type
             .const_int(self.str_literals[*idx].len() as u64, false);

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -1103,7 +1103,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         let captures = self._gen_get_lambda_captures(ctx);
         let value = self.gen_expr(ctx, rhs)?.unwrap();
-        captures.reassign(self, *idx_in_captures, value.clone(), &rhs.ty);
+        captures.reassign(self, *idx_in_captures, value.clone());
 
         let block = self.context.append_basic_block(
             ctx.function,

--- a/lib/skc_codegen/src/gen_exprs.rs
+++ b/lib/skc_codegen/src/gen_exprs.rs
@@ -192,9 +192,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         // AndEnd:
         self.builder.position_at_end(merge_block);
 
-        let phi_node = self
-            .builder
-            .build_phi(self.llvm_type(&ty::raw("Bool")), "AndResult");
+        let phi_node = self.builder.build_phi(self.llvm_type(), "AndResult");
         phi_node.add_incoming(&[
             (&left_value.0, begin_block_end),
             (&right_value.0, more_block_end),
@@ -225,9 +223,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         // OrEnd:
         self.builder.position_at_end(merge_block);
 
-        let phi_node = self
-            .builder
-            .build_phi(self.llvm_type(&ty::raw("Bool")), "OrResult");
+        let phi_node = self.builder.build_phi(self.llvm_type(), "OrResult");
         phi_node.add_incoming(&[
             (&left_value.0, begin_block_end),
             (&right_value.0, else_block_end),
@@ -278,7 +274,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             (None, else_value) => Ok(else_value),
             (then_value, None) => Ok(then_value),
             (Some(then_val), Some(else_val)) => {
-                let phi_node = self.builder.build_phi(self.llvm_type(ty), "ifResult");
+                let phi_node = self.builder.build_phi(self.llvm_type(), "ifResult");
                 phi_node
                     .add_incoming(&[(&then_val.0, then_block_end), (&else_val.0, else_block_end)]);
                 Ok(Some(SkObj::new(ty.clone(), phi_node.as_basic_value())))
@@ -336,9 +332,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         } else {
             // MatchEnd:
             self.builder.position_at_end(merge_block);
-            let phi_node = self
-                .builder
-                .build_phi(self.llvm_type(result_ty), "matchResult");
+            let phi_node = self.builder.build_phi(self.llvm_type(), "matchResult");
             phi_node.add_incoming(
                 incoming_values
                     .iter()
@@ -699,12 +693,12 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
         // Create the type of lambda_xx()
         let fn_x_ty = ty::raw(&format!("Fn{}", n_args));
-        let fn_x_type = self.llvm_type(&fn_x_ty);
+        let fn_x_type = self.llvm_type();
         let mut arg_types = vec![fn_x_type.into()];
         for e in arg_exprs {
-            arg_types.push(self.llvm_type(&e.ty).into());
+            arg_types.push(self.llvm_type().into());
         }
-        let fntype = self.llvm_type(ret_ty).fn_type(&arg_types, false);
+        let fntype = self.llvm_type().fn_type(&arg_types, false);
         let fnptype = fntype.ptr_type(Default::default());
 
         // Cast `fnptr` to that type
@@ -849,7 +843,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             .unwrap_or_else(|| panic!("[BUG] lvar `{}' not found in ctx.lvars", name));
         SkObj::new(
             ty.clone(),
-            self.builder.build_load(self.llvm_type(ty), *ptr, name),
+            self.builder.build_load(self.llvm_type(), *ptr, name),
         )
     }
 
@@ -910,7 +904,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
 
     pub fn gen_const_ref(&'run self, fullname: &ConstFullname, ty: &TermTy) -> SkObj<'run> {
         let name = llvm_const_name(fullname);
-        let llvm_type = self.llvm_type(ty);
+        let llvm_type = self.llvm_type();
         let ptr = self
             .module
             .get_global(&name)

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -134,7 +134,7 @@ impl<'run> LambdaCapture<'run> {
                     "load",
                 )
                 .into_pointer_value();
-            let pointee_ty = gen.llvm_type(ty).as_basic_type_enum();
+            let pointee_ty = gen.llvm_type().as_basic_type_enum();
             gen.builder.build_load(pointee_ty, addr, "deref")
         } else {
             gen.build_llvm_struct_ref(
@@ -453,12 +453,12 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
     fn capture_ty(&self, cap: &HirLambdaCapture) -> inkwell::types::BasicTypeEnum {
         if cap.readonly {
-            self.llvm_type(&cap.ty)
+            self.llvm_type()
         } else {
             // The (local) variable is captured by reference.
             // PERF: not needed to be by-ref when the variable is declared with
             // `var` but not reassigned from closure.
-            self.llvm_type(&cap.ty)
+            self.llvm_type()
                 .ptr_type(Default::default())
                 .as_basic_type_enum()
         }

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -137,27 +137,15 @@ impl<'run> LambdaCapture<'run> {
             let pointee_ty = gen.llvm_type().as_basic_type_enum();
             gen.builder.build_load(pointee_ty, addr, "deref")
         } else {
-            gen.build_llvm_struct_ref(
-                &self.struct_type(gen),
-                self.to_struct_ptr(),
-                ty,
-                idx,
-                "load",
-            )
+            gen.build_llvm_struct_ref(&self.struct_type(gen), self.to_struct_ptr(), idx, "load")
         };
         SkObj::new(ty.clone(), v)
     }
 
     /// Given there is a pointer stored at `idx`, update its value.
-    pub fn reassign(&self, gen: &CodeGen<'_, 'run, '_>, idx: usize, value: SkObj, ty: &TermTy) {
+    pub fn reassign(&self, gen: &CodeGen<'_, 'run, '_>, idx: usize, value: SkObj) {
         let ptr = gen
-            .build_llvm_struct_ref(
-                &self.struct_type(gen),
-                self.to_struct_ptr(),
-                ty,
-                idx,
-                "load",
-            )
+            .build_llvm_struct_ref(&self.struct_type(gen), self.to_struct_ptr(), idx, "load")
             .into_pointer_value();
         gen.builder.build_store(ptr, value.0);
     }

--- a/lib/skc_codegen/src/lambda.rs
+++ b/lib/skc_codegen/src/lambda.rs
@@ -129,7 +129,7 @@ impl<'run> LambdaCapture<'run> {
                 .build_llvm_struct_ref_raw(
                     &self.struct_type(gen),
                     self.to_struct_ptr(),
-                    gen.i8ptr_type.clone().as_basic_type_enum(),
+                    gen.ptr_type.clone().as_basic_type_enum(),
                     idx,
                     "load",
                 )

--- a/lib/skc_codegen/src/utils.rs
+++ b/lib/skc_codegen/src/utils.rs
@@ -88,7 +88,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     /// Get the class object of an object as `*Class`
     pub fn get_class_of_obj(&self, object: SkObj<'run>) -> SkClassObj<'run> {
         SkClassObj(
-            self.build_object_struct_ref(object, &ty::raw("Class"), OBJ_CLASS_IDX, "class")
+            self.build_object_struct_ref(object, OBJ_CLASS_IDX, "class")
                 .into_pointer_value(),
         )
     }
@@ -125,12 +125,11 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     pub fn build_object_struct_ref(
         &self,
         object: SkObj<'run>,
-        item_ty: &TermTy,
         idx: usize,
         name: &str,
     ) -> inkwell::values::BasicValueEnum<'run> {
         let struct_ty = self.llvm_struct_type(object.ty());
-        self.build_llvm_struct_ref(&struct_ty, object.0, item_ty, idx, name)
+        self.build_llvm_struct_ref(&struct_ty, object.0, idx, name)
     }
 
     /// Load a raw llvm value in a Shiika object
@@ -151,7 +150,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         &self,
         struct_ty: &inkwell::types::StructType<'run>,
         struct_ptr: inkwell::values::PointerValue<'run>,
-        item_ty: &TermTy,
         idx: usize,
         name: &str,
     ) -> inkwell::values::BasicValueEnum<'run> {
@@ -177,7 +175,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             )
             .unwrap_or_else(|_| {
                 panic!(
-                    "build_llvm_struct_ref: elem not found (idx: {}, name: {}, struct_ptr: {:?})",
+                    "build_llvm_struct_ref_raw: elem not found (idx: {}, name: {}, struct_ptr: {:?})",
                     &idx, &name, &struct_ptr
                 )
             });

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -59,7 +59,6 @@ pub struct SkClassObj<'run>(pub inkwell::values::PointerValue<'run>);
 impl<'run> SkClassObj<'run> {
     /// Returns a null pointer cast to `%Object*`.
     pub fn nullptr(gen: &CodeGen<'_, 'run, '_>) -> SkClassObj<'run> {
-        let ty = ty::raw("Class");
         let null = gen.ptr_type.const_null().as_basic_value_enum();
         SkClassObj(
             gen.builder

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -17,7 +17,7 @@ impl<'run> SkObj<'run> {
     /// Returns a null pointer cast to `%Object*`.
     pub fn nullptr(gen: &CodeGen<'_, 'run, '_>) -> SkObj<'run> {
         let ty = ty::raw("Object");
-        let null = gen.i8ptr_type.const_null().as_basic_value_enum();
+        let null = gen.ptr_type.const_null().as_basic_value_enum();
         SkObj::new(
             ty.clone(),
             gen.builder.build_bitcast(null, gen.llvm_type(&ty), "as"),
@@ -44,7 +44,7 @@ impl<'run> SkObj<'run> {
     ) -> inkwell::values::BasicValueEnum<'run> {
         code_gen
             .builder
-            .build_bitcast(self.0, code_gen.i8ptr_type, "ptr")
+            .build_bitcast(self.0, code_gen.ptr_type, "ptr")
     }
 
     pub fn struct_ty(&self, gen: &'run CodeGen<'_, 'run, '_>) -> inkwell::types::StructType<'run> {
@@ -60,7 +60,7 @@ impl<'run> SkClassObj<'run> {
     /// Returns a null pointer cast to `%Object*`.
     pub fn nullptr(gen: &CodeGen<'_, 'run, '_>) -> SkClassObj<'run> {
         let ty = ty::raw("Class");
-        let null = gen.i8ptr_type.const_null().as_basic_value_enum();
+        let null = gen.ptr_type.const_null().as_basic_value_enum();
         SkClassObj(
             gen.builder
                 .build_bitcast(null, gen.llvm_type(&ty), "as")
@@ -86,7 +86,7 @@ impl<'run> I8Ptr<'run> {
     ) -> I8Ptr<'run> {
         I8Ptr(
             gen.builder
-                .build_bitcast(p, gen.i8ptr_type, "cast")
+                .build_bitcast(p, gen.ptr_type, "cast")
                 .into_pointer_value(),
         )
     }

--- a/lib/skc_codegen/src/values.rs
+++ b/lib/skc_codegen/src/values.rs
@@ -20,7 +20,7 @@ impl<'run> SkObj<'run> {
         let null = gen.ptr_type.const_null().as_basic_value_enum();
         SkObj::new(
             ty.clone(),
-            gen.builder.build_bitcast(null, gen.llvm_type(&ty), "as"),
+            gen.builder.build_bitcast(null, gen.llvm_type(), "as"),
         )
     }
 
@@ -63,7 +63,7 @@ impl<'run> SkClassObj<'run> {
         let null = gen.ptr_type.const_null().as_basic_value_enum();
         SkClassObj(
             gen.builder
-                .build_bitcast(null, gen.llvm_type(&ty), "as")
+                .build_bitcast(null, gen.llvm_type(), "as")
                 .into_pointer_value(),
         )
     }

--- a/lib/skc_codegen/src/vtable.rs
+++ b/lib/skc_codegen/src/vtable.rs
@@ -17,10 +17,6 @@ impl<'run> VTableRef<'run> {
         VTableRef { ptr, len }
     }
 
-    fn llvm_type(gen: &CodeGen<'_, 'run, '_>, len: usize) -> inkwell::types::PointerType<'run> {
-        Self::llvm_pointee_type(gen, len).ptr_type(Default::default())
-    }
-
     fn llvm_pointee_type(
         gen: &CodeGen<'_, 'run, '_>,
         len: usize,
@@ -34,7 +30,7 @@ impl<'run> VTableRef<'run> {
         object: SkObj<'run>,
         len: usize,
     ) -> VTableRef<'run> {
-        let item_ty = Self::llvm_type(gen, len).as_basic_type_enum();
+        let item_ty = gen.ptr_type.as_basic_type_enum();
         let ptr = gen
             .build_object_struct_ref_raw(object, item_ty, OBJ_VTABLE_IDX, "vtable")
             .into_pointer_value();

--- a/lib/skc_codegen/src/vtable.rs
+++ b/lib/skc_codegen/src/vtable.rs
@@ -25,7 +25,7 @@ impl<'run> VTableRef<'run> {
         gen: &CodeGen<'_, 'run, '_>,
         len: usize,
     ) -> inkwell::types::ArrayType<'run> {
-        gen.i8ptr_type.array_type(len as u32)
+        gen.ptr_type.array_type(len as u32)
     }
 
     /// Returns the vtable of a Shiika object.

--- a/lib/skc_codegen/src/vtable.rs
+++ b/lib/skc_codegen/src/vtable.rs
@@ -75,7 +75,7 @@ impl<'run> OpaqueVTableRef<'run> {
         SkObj::new(
             ty.clone(),
             gen.builder
-                .build_bitcast(self.ptr.as_basic_value_enum(), gen.llvm_type(&ty), "as"),
+                .build_bitcast(self.ptr.as_basic_value_enum(), gen.llvm_type(), "as"),
         )
     }
 }

--- a/lib/skc_codegen/src/wtable.rs
+++ b/lib/skc_codegen/src/wtable.rs
@@ -7,7 +7,7 @@ use skc_hir::SkClass;
 /// Define llvm constants like `@shiika_wtable_Array_Enumerable`
 pub fn gen_wtable_constants(code_gen: &CodeGen, sk_class: &SkClass) {
     for (mod_name, method_names) in &sk_class.wtable.0 {
-        let ary_type = code_gen.i8ptr_type.array_type(method_names.len() as u32);
+        let ary_type = code_gen.ptr_type.array_type(method_names.len() as u32);
         let cname = llvm_wtable_const_name(&sk_class.fullname(), mod_name);
         let global = code_gen.module.add_global(ary_type, None, &cname);
         global.set_constant(true);
@@ -20,11 +20,11 @@ pub fn gen_wtable_constants(code_gen: &CodeGen, sk_class: &SkClass) {
                     .as_pointer_value();
                 code_gen
                     .builder
-                    .build_bitcast(func, code_gen.i8ptr_type, "")
+                    .build_bitcast(func, code_gen.ptr_type, "")
                     .into_pointer_value()
             })
             .collect::<Vec<_>>();
-        global.set_initializer(&code_gen.i8ptr_type.const_array(&func_ptrs));
+        global.set_initializer(&code_gen.ptr_type.const_array(&func_ptrs));
     }
 }
 
@@ -72,7 +72,7 @@ fn load_wtable_const<'a>(
         });
     code_gen
         .builder
-        .build_bitcast(ptr, code_gen.i8ptr_type, "ary")
+        .build_bitcast(ptr, code_gen.ptr_type, "ary")
 }
 
 /// Name of llvm constant of a wtable

--- a/lib/skc_codegen/src/wtable.rs
+++ b/lib/skc_codegen/src/wtable.rs
@@ -26,7 +26,7 @@ pub fn gen_wtable_constants(code_gen: &CodeGen, sk_class: &SkClass) {
 
 /// Define `@insert_XX_wtables()` for the class
 pub fn gen_insert_wtable(code_gen: &CodeGen, sk_class: &SkClass) {
-    let fargs = &[code_gen.llvm_type(&ty::raw("Class")).into()];
+    let fargs = &[code_gen.llvm_type().into()];
     let ftype = code_gen.void_type.fn_type(fargs, false);
     let fname = insert_wtable_func_name(&sk_class.fullname());
     let function = code_gen.module.add_function(&fname, ftype, None);

--- a/lib/skc_codegen/src/wtable.rs
+++ b/lib/skc_codegen/src/wtable.rs
@@ -14,14 +14,10 @@ pub fn gen_wtable_constants(code_gen: &CodeGen, sk_class: &SkClass) {
         let func_ptrs = method_names
             .iter()
             .map(|name| {
-                let func = code_gen
+                code_gen
                     .get_llvm_func(&method_func_name(name))
                     .as_global_value()
-                    .as_pointer_value();
-                code_gen
-                    .builder
-                    .build_bitcast(func, code_gen.ptr_type, "")
-                    .into_pointer_value()
+                    .as_pointer_value()
             })
             .collect::<Vec<_>>();
         global.set_initializer(&code_gen.ptr_type.const_array(&func_ptrs));


### PR DESCRIPTION
This PR simplify codegen by removing arguments unnecessary after LLVM 15.