### PR TITLE
breaking change: Remove unused type parameters from enum case

### DIFF
--- a/builtin/error.sk
+++ b/builtin/error.sk
@@ -5,6 +5,6 @@ class Error
   # def backtrace
 
   def to_s -> String
-    "#<Error: #{@msg}>"
+    "#<Error \{@msg}>"
   end
 end

--- a/builtin/file.sk
+++ b/builtin/file.sk
@@ -12,7 +12,7 @@ class File : Readable
       #file.close
       Ok.new(v)
     when Fail(e)
-      Fail<V>.new(e)
+      Fail.new(e)
     end
   end
   

--- a/builtin/readable.sk
+++ b/builtin/readable.sk
@@ -24,7 +24,7 @@ module Readable
           end
         end
       when Fail(e)
-        return Fail<Maybe<String>>.new(e)
+        return Fail.new(e)
       end
       break if done
     end
@@ -44,7 +44,7 @@ module Readable
       when Ok(None)
         break
       when Fail(e)
-        return Fail<Array<String>>.new(e)
+        return Fail.new(e)
       end
     end
     Ok.new(a)
@@ -62,7 +62,7 @@ module Readable
           consume(s.bytesize)
         end
       when Fail(e)
-        return Fail<String>.new(e)
+        return Fail.new(e)
       end
     end
     Ok.new(acc._unsafe_to_s)

--- a/builtin/result.sk
+++ b/builtin/result.sk
@@ -2,8 +2,8 @@ enum Result<V>
   case Ok(value: V)
   case Fail(err: Error)
 
-  def self.fail<V>(msg: String) -> Fail<V>
-    Fail<V>.new(Error.new(msg))
+  def self.fail(msg: String) -> Fail
+    Fail.new(Error.new(msg))
   end
 
   def fail? -> Bool

--- a/lib/shiika_ast/src/lib.rs
+++ b/lib/shiika_ast/src/lib.rs
@@ -101,6 +101,13 @@ pub struct EnumCase {
     pub params: Vec<Param>,
 }
 
+impl EnumCase {
+    /// Returns true if the typaram name `name` appears in the type definition of any of `params`.
+    pub fn appears(&self, name: &str) -> bool {
+        self.params.iter().any(|param| param.typ.appears(name))
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct AstMethodSignature {
     pub name: MethodFirstname,

--- a/lib/shiika_ast/src/lib.rs
+++ b/lib/shiika_ast/src/lib.rs
@@ -146,6 +146,12 @@ pub struct UnresolvedTypeName {
     pub locs: LocationSpan,
 }
 
+impl UnresolvedTypeName {
+    pub fn appears(&self, name: &str) -> bool {
+        self.names.join("::") == name || self.args.iter().any(|arg| arg.appears(name))
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct AstExpression {
     pub body: AstExpressionBody,

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -708,7 +708,7 @@ fn enum_case_superclass(
         .iter()
         .enumerate()
         .map(|(i, t)| {
-            if case.params.iter().any(|param| param.typ.appears(&t.name)) {
+            if case.appears(&t.name) {
                 case_typarams.push(t.clone());
                 ty::typaram_ref(&t.name, TyParamKind::Class, i).into_term_ty()
             } else {

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -306,20 +306,15 @@ impl<'hir_maker> ClassDict<'hir_maker> {
     ) -> Result<()> {
         let ivar_list = self._enum_case_ivars(namespace, typarams, case)?;
         let fullname = case.name.add_namespace(&enum_fullname.0);
-        let superclass = enum_case_superclass(enum_fullname, typarams, case);
+        let (superclass, case_typarams) = enum_case_superclass(enum_fullname, typarams, case);
         let (new_sig, initialize_sig) = enum_case_new_sig(&ivar_list, typarams, &fullname);
 
         let mut instance_methods = enum_case_getters(&fullname, &ivar_list);
         instance_methods.insert(initialize_sig);
 
-        let case_typarams = if case.params.is_empty() {
-            Default::default()
-        } else {
-            typarams
-        };
         self.add_new_class(
             &fullname,
-            case_typarams,
+            &case_typarams,
             superclass,
             Default::default(),
             Some(new_sig),
@@ -707,23 +702,22 @@ fn enum_case_superclass(
     enum_fullname: &ClassFullname,
     typarams: &[ty::TyParam],
     case: &shiika_ast::EnumCase,
-) -> Supertype {
-    if case.params.is_empty() {
-        // eg. Maybe::None : Maybe<Never>
-        let tyargs = typarams
-            .iter()
-            .map(|_| ty::raw("Never"))
-            .collect::<Vec<_>>();
-        Supertype::from_ty(LitTy::new(enum_fullname.0.clone(), tyargs, false))
-    } else {
-        // eg. Maybe::Some<out V> : Maybe<V>
-        let tyargs = typarams
-            .iter()
-            .enumerate()
-            .map(|(i, t)| ty::typaram_ref(&t.name, TyParamKind::Class, i).into_term_ty())
-            .collect::<Vec<_>>();
-        Supertype::from_ty(LitTy::new(enum_fullname.0.clone(), tyargs, false))
-    }
+) -> (Supertype, Vec<ty::TyParam>) {
+    let mut case_typarams = vec![];
+    let tyargs = typarams
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            if case.params.iter().any(|param| param.typ.appears(&t.name)) {
+                case_typarams.push(t.clone());
+                ty::typaram_ref(&t.name, TyParamKind::Class, i).into_term_ty()
+            } else {
+                ty::raw("Never")
+            }
+        })
+        .collect::<Vec<_>>();
+    let supertype = Supertype::from_ty(LitTy::new(enum_fullname.0.clone(), tyargs, false));
+    (supertype, case_typarams)
 }
 
 /// Returns signature of `.new` and `#initialize` of an enum case

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -307,7 +307,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         let ivar_list = self._enum_case_ivars(namespace, typarams, case)?;
         let fullname = case.name.add_namespace(&enum_fullname.0);
         let (superclass, case_typarams) = enum_case_superclass(enum_fullname, typarams, case);
-        let (new_sig, initialize_sig) = enum_case_new_sig(&ivar_list, typarams, &fullname);
+        let (new_sig, initialize_sig) = enum_case_new_sig(&ivar_list, &case_typarams, &fullname);
 
         let mut instance_methods = enum_case_getters(&fullname, &ivar_list);
         instance_methods.insert(initialize_sig);

--- a/lib/skc_ast2hir/src/class_dict/type_index.rs
+++ b/lib/skc_ast2hir/src/class_dict/type_index.rs
@@ -94,8 +94,20 @@ fn index_enum(
     let inner_namespace = namespace.add(firstname.0.clone());
     for case in cases {
         let case_fullname = inner_namespace.type_fullname(&case.name.0);
-        insert_class_and_metaclass(cindex, case_fullname, typarams.clone());
+        let case_typarams = enum_case_typarams(case, &typarams);
+        insert_class_and_metaclass(cindex, case_fullname, case_typarams);
     }
+}
+
+fn enum_case_typarams(
+    case: &shiika_ast::EnumCase,
+    base_typarams: &[ty::TyParam],
+) -> Vec<ty::TyParam> {
+    base_typarams
+        .iter()
+        .filter(|t| case.appears(&t.name))
+        .map(|t| t.clone())
+        .collect::<Vec<_>>()
 }
 
 fn insert_class_and_metaclass(

--- a/tests/sk/enum.sk
+++ b/tests/sk/enum.sk
@@ -6,7 +6,7 @@ f(b)
 unless a.value == 1; puts "ng Some#value"; end
 
 let o = Ok<Int>.new(0)
-let e = Fail<Int>.new(Error.new("fail"))
+let e = Fail.new(Error.new("fail"))
 
 # Class method of enum
 enum EnumWithClassMethod


### PR DESCRIPTION
This PR removes unused type parameters from enum cases. For example, `Result::Fail<V>` is changed to just `Result::Fail` because `Fail` does not depend on `V`.

```
enum Result<V>
  case Ok(value: V)
  case Fail(err: Error)
```