### PR TITLE
Empty args compiler crash 

### DIFF
--- a/lib/skc_ast2hir/src/convert_exprs/method_call.rs
+++ b/lib/skc_ast2hir/src/convert_exprs/method_call.rs
@@ -47,7 +47,7 @@ pub fn convert_method_call(
     let found =
         mk.class_dict
             .lookup_method(&receiver_hir.ty, method_name, method_tyargs.as_slice())?;
-    let arranged = arrange_named_args(&found.sig, args)?;
+    let arranged = arrange_named_args(&found.sig, args, locs)?;
     validate_method_tyargs(&found, type_args)?;
 
     let inf1 = if !found.sig.typarams.is_empty() && type_args.is_empty() {
@@ -78,11 +78,17 @@ pub fn convert_method_call(
 pub fn arrange_named_args<'a>(
     sig: &'a MethodSignature,
     args: &'a AstCallArgs,
+    method_span: &'a LocationSpan,
 ) -> Result<Vec<ArrangedArg<'a>>> {
     let n_params = sig.params.len();
     let n_unnamed = args.unnamed.len();
     let mut named = args.named.iter().collect::<Vec<_>>();
     let mut v = vec![];
+    let locs = args.locs();
+    let error_locs = match &locs {
+        Some(loc) => loc,
+        None => method_span,
+    };
     for (i, param) in sig.params.iter().enumerate() {
         if i < n_unnamed {
             v.push(ArrangedArg::Expr(args.unnamed.get(i).unwrap()));
@@ -103,14 +109,10 @@ pub fn arrange_named_args<'a>(
             v.push(ArrangedArg::Default(&param.ty));
             continue;
         }
-        return Err(error::unspecified_arg(
-            &param.name,
-            sig,
-            &args.locs().unwrap(),
-        ));
+        return Err(error::unspecified_arg(&param.name, sig, error_locs));
     }
     if let Some((name, _)) = named.first() {
-        return Err(error::extranous_arg(name, sig, &args.locs().unwrap()));
+        return Err(error::extranous_arg(name, sig, error_locs));
     }
     Ok(v)
 }


### PR DESCRIPTION
#505 

- Fix the unwrap none when a method/function is called with 0 argument but expect more