### PR TITLE
define Math as a module instead of class

### DIFF
--- a/builtin/math.sk
+++ b/builtin/math.sk
@@ -1,3 +1,2 @@
-# TODO: change this to `module Math` (#416)
-class Math
+module Math
 end

--- a/lib/skc_ast2hir/src/class_dict/indexing.rs
+++ b/lib/skc_ast2hir/src/class_dict/indexing.rs
@@ -228,9 +228,15 @@ impl<'hir_maker> ClassDict<'hir_maker> {
         let metaclass_fullname = fullname.meta_name();
 
         match self.sk_types.0.get_mut(&fullname.to_type_fullname()) {
-            Some(_) => {
+            Some(sk_type) => {
                 // This module is predefined in skc_corelib.
-                // Inject methods
+                // Inject instance methods
+                let method_sigs = &mut sk_type.base_mut().method_sigs;
+                method_sigs.append(instance_methods);
+                if let Some(sigs) = self.rust_methods.remove(&fullname.to_type_fullname()) {
+                    method_sigs.append_vec(sigs);
+                }
+                // Inject class methods
                 let metaclass = self
                     .sk_types
                     .0
@@ -242,7 +248,7 @@ impl<'hir_maker> ClassDict<'hir_maker> {
                         )
                     });
                 let meta_method_sigs = &mut metaclass.base_mut().method_sigs;
-                meta_method_sigs.append(instance_methods);
+                meta_method_sigs.append(class_methods);
                 if let Some(sigs) = self
                     .rust_methods
                     .remove(&metaclass_fullname.to_type_fullname())


### PR DESCRIPTION
close #416

Current codes runs well, but I don't know if I missed some fields in the todo entry.

And then add other fields in `math.sk`, `build-corelib` will panic:

```
thread 'main' panicked at lib/skc_ast2hir/src/hir_maker.rs:457:17:
[BUG] signature not found (Math/a)
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: skc_ast2hir::hir_maker::HirMaker::convert_method_def_::{{closure}}
             at ./lib/skc_ast2hir/src/hir_maker.rs:457:17
   3: core::option::Option<T>::unwrap_or_else
             at /private/tmp/rust-20231125-5709-3eoq7y/rustc-1.74.0-src/library/core/src/option.rs:979:21
   4: skc_ast2hir::hir_maker::HirMaker::convert_method_def_
             at ./lib/skc_ast2hir/src/hir_maker.rs:453:25
   5: skc_ast2hir::hir_maker::HirMaker::convert_method_def
             at ./lib/skc_ast2hir/src/hir_maker.rs:440:35
   6: skc_ast2hir::hir_maker::HirMaker::process_defs
             at ./lib/skc_ast2hir/src/hir_maker.rs:184:38
   7: skc_ast2hir::hir_maker::HirMaker::process_module_def
             at ./lib/skc_ast2hir/src/hir_maker.rs:319:9
   8: skc_ast2hir::hir_maker::HirMaker::process_defs
             at ./lib/skc_ast2hir/src/hir_maker.rs:236:21
   9: skc_ast2hir::hir_maker::HirMaker::convert_toplevel_items
             at ./lib/skc_ast2hir/src/hir_maker.rs:157:9
  10: skc_ast2hir::make_corelib_hir
             at ./lib/skc_ast2hir/src/lib.rs:58:36
  11: shiika::runner::build_corelib
             at ./src/runner.rs:54:15
  12: shiika::main
             at ./src/main.rs:18:13
  13: core::ops::function::FnOnce::call_once
             at /private/tmp/rust-20231125-5709-3eoq7y/rustc-1.74.0-src/library/core/src/ops/function.rs:250:5
```

It looks like the runtime also find `Math/a` from the class type (not the meta type). Maybe there should be more works to do?