### PR TITLE
fix command name

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 
 #[derive(clap::Parser, Debug)]
-#[clap(name = "subcommand", author, version, about)]
+#[clap(name = "shiika", author, version, about)]
 pub struct Arguments {
     #[clap(subcommand)]
     pub command: Command,


### PR DESCRIPTION
## Before

```
$ cargo run
subcommand 0.9.1
...
```

## After

```
$ cargo run
shiika 0.9.1
...
```