### PR TITLE
treat '\r' as space in lexer

### DIFF
--- a/lib/shiika_parser/src/lexer.rs
+++ b/lib/shiika_parser/src/lexer.rs
@@ -738,7 +738,7 @@ impl<'a> Lexer<'a> {
             return CharType::Eof;
         }
         match cc.unwrap() {
-            ' ' | '\t' => CharType::Space,
+            ' ' | '\t' | '\r' => CharType::Space,
             '\n' | ';' => CharType::Separator,
             '#' => CharType::Comment,
             '"' => CharType::Str,


### PR DESCRIPTION
I don't know if it's ok, but seems treat '\r' as space is the easist way to fix this.

close: #460