### PR TITLE
Fix: Warning: calls to std::mem::drop 

### DIFF
--- a/lib/skc_rustlib/src/builtin/file.rs
+++ b/lib/skc_rustlib/src/builtin/file.rs
@@ -62,7 +62,7 @@ impl SkFile {
 
 extern "C" fn file_finalizer(obj: *mut c_void, _data: *mut c_void) {
     let shiika_file = obj as *mut ShiikaFile;
-    std::mem::drop(SkFile(shiika_file).file_mut());
+    SkFile(shiika_file).file_mut();
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
What I did:
Fix warning `calls to std::mem::drop `


Why the problem occurred:
The std::mem::drop function is used to drop (dispose of) a value, taking ownership of that value as its argument.
In this case, a reference (&mut File) was passed to the function.
Since std::mem::drop targets values with ownership and not references, using it on a reference does nothing.
Therefore, this call to drop was unnecessary and the cause of the warning.