### PR TITLE
new_runtime: Remove hir::Ty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,8 +1392,10 @@ dependencies = [
  "os_info",
  "peg",
  "shiika_ast",
+ "shiika_core",
  "shiika_ffi",
  "shiika_parser",
+ "skc_hir",
 ]
 
 [[package]]

--- a/lib/skc_async_experiment/Cargo.toml
+++ b/lib/skc_async_experiment/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 shiika_ast = { path = "../shiika_ast" }
 shiika_parser = { path = "../shiika_parser" }
 shiika_ffi = { path = "../shiika_ffi" }
+shiika_core = { path = "../shiika_core" }
+skc_hir = { path = "../skc_hir" }
+
 inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm16-0"], rev = "4030f76" }
 nom = "7.1.3"
 peg = "0.8.2"

--- a/lib/skc_async_experiment/src/hir.rs
+++ b/lib/skc_async_experiment/src/hir.rs
@@ -3,17 +3,17 @@ mod ty;
 pub mod typing;
 pub mod untyped;
 use crate::names::FunctionName;
-pub use expr::{Expr, Typed, TypedExpr};
+pub use expr::{Expr, TypedExpr};
 pub use ty::{FunTy, Ty};
 
 #[derive(Debug, Clone)]
-pub struct Program {
+pub struct Program<T> {
     pub externs: Vec<Extern>,
-    pub methods: Vec<Method>,
+    pub methods: Vec<Method<T>>,
 }
 
-impl Program {
-    pub fn new(externs: Vec<Extern>, methods: Vec<Method>) -> Self {
+impl<T> Program<T> {
+    pub fn new(externs: Vec<Extern>, methods: Vec<Method<T>>) -> Self {
         Self { externs, methods }
     }
 }
@@ -31,15 +31,15 @@ impl Extern {
 }
 
 #[derive(Debug, Clone)]
-pub struct Method {
+pub struct Method<T> {
     pub asyncness: Asyncness,
     pub name: FunctionName,
     pub params: Vec<Param>,
     pub ret_ty: Ty,
-    pub body_stmts: Typed<Expr>,
+    pub body_stmts: TypedExpr<T>,
 }
 
-impl Method {
+impl<T> Method<T> {
     pub fn fun_ty(&self) -> FunTy {
         FunTy {
             asyncness: self.asyncness.clone(),

--- a/lib/skc_async_experiment/src/hir.rs
+++ b/lib/skc_async_experiment/src/hir.rs
@@ -4,7 +4,8 @@ pub mod typing;
 pub mod untyped;
 use crate::names::FunctionName;
 pub use expr::{Expr, TypedExpr};
-pub use ty::{FunTy, Ty};
+use shiika_core::ty::TermTy;
+pub use ty::FunTy;
 
 #[derive(Debug, Clone)]
 pub struct Program<T> {
@@ -35,28 +36,28 @@ pub struct Method<T> {
     pub asyncness: Asyncness,
     pub name: FunctionName,
     pub params: Vec<Param>,
-    pub ret_ty: Ty,
+    pub ret_ty: TermTy,
     pub body_stmts: TypedExpr<T>,
 }
 
-impl<T> Method<T> {
+impl<T: Clone> Method<T> {
     pub fn fun_ty(&self) -> FunTy {
         FunTy {
             asyncness: self.asyncness.clone(),
             param_tys: self.params.iter().map(|x| x.ty.clone()).collect::<Vec<_>>(),
-            ret_ty: Box::new(self.ret_ty.clone()),
+            ret_ty: self.ret_ty.clone(),
         }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct Param {
-    pub ty: Ty,
+    pub ty: TermTy,
     pub name: String,
 }
 
 impl Param {
-    pub fn new(ty: Ty, name: impl Into<String>) -> Self {
+    pub fn new(ty: TermTy, name: impl Into<String>) -> Self {
         Self {
             ty,
             name: name.into(),

--- a/lib/skc_async_experiment/src/hir.rs
+++ b/lib/skc_async_experiment/src/hir.rs
@@ -9,12 +9,12 @@ pub use ty::{FunTy, Ty};
 #[derive(Debug, Clone)]
 pub struct Program {
     pub externs: Vec<Extern>,
-    pub funcs: Vec<Function>,
+    pub methods: Vec<Method>,
 }
 
 impl Program {
-    pub fn new(externs: Vec<Extern>, funcs: Vec<Function>) -> Self {
-        Self { externs, funcs }
+    pub fn new(externs: Vec<Extern>, methods: Vec<Method>) -> Self {
+        Self { externs, methods }
     }
 }
 
@@ -31,7 +31,7 @@ impl Extern {
 }
 
 #[derive(Debug, Clone)]
-pub struct Function {
+pub struct Method {
     pub asyncness: Asyncness,
     pub name: FunctionName,
     pub params: Vec<Param>,
@@ -39,7 +39,7 @@ pub struct Function {
     pub body_stmts: Typed<Expr>,
 }
 
-impl Function {
+impl Method {
     pub fn fun_ty(&self) -> FunTy {
         FunTy {
             asyncness: self.asyncness.clone(),

--- a/lib/skc_async_experiment/src/hir.rs
+++ b/lib/skc_async_experiment/src/hir.rs
@@ -4,25 +4,12 @@ pub mod typing;
 pub mod untyped;
 use crate::names::FunctionName;
 pub use expr::{Expr, Typed, TypedExpr};
-use std::fmt;
 pub use ty::{FunTy, Ty};
 
 #[derive(Debug, Clone)]
 pub struct Program {
     pub externs: Vec<Extern>,
     pub funcs: Vec<Function>,
-}
-
-impl fmt::Display for Program {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for e in &self.externs {
-            write!(f, "{}", e)?;
-        }
-        for func in &self.funcs {
-            write!(f, "{}", func)?;
-        }
-        write!(f, "")
-    }
 }
 
 impl Program {
@@ -35,16 +22,6 @@ impl Program {
 pub struct Extern {
     pub name: FunctionName,
     pub fun_ty: FunTy,
-}
-
-impl fmt::Display for Extern {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "extern({}) {} {};\n",
-            self.fun_ty.asyncness, self.name, self.fun_ty
-        )
-    }
 }
 
 impl Extern {
@@ -60,24 +37,6 @@ pub struct Function {
     pub params: Vec<Param>,
     pub ret_ty: Ty,
     pub body_stmts: Typed<Expr>,
-}
-
-impl fmt::Display for Function {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let para = self
-            .params
-            .iter()
-            .map(|p| p.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        write!(
-            f,
-            "fun {}{}({}) -> {} {{\n",
-            self.name, self.asyncness, para, self.ret_ty
-        )?;
-        write!(f, "{}\n", &self.body_stmts.0.pretty_print(1, true),)?;
-        write!(f, "}}\n")
-    }
 }
 
 impl Function {
@@ -105,29 +64,12 @@ impl Param {
     }
 }
 
-impl fmt::Display for Param {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}", self.ty, self.name)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Asyncness {
     Unknown,
     Sync,
     Async,
     Lowered,
-}
-
-impl fmt::Display for Asyncness {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Asyncness::Unknown => write!(f, "[?]"),
-            Asyncness::Sync => write!(f, "[+]"),
-            Asyncness::Async => write!(f, "[*]"),
-            Asyncness::Lowered => write!(f, ""), // "[.]"
-        }
-    }
 }
 
 impl From<bool> for Asyncness {

--- a/lib/skc_async_experiment/src/hir/expr.rs
+++ b/lib/skc_async_experiment/src/hir/expr.rs
@@ -124,71 +124,11 @@ impl Expr {
             _ => false,
         }
     }
-
-    pub fn pretty_print(&self, lv: usize, as_stmt: bool) -> String {
-        pretty_print(self, lv, as_stmt)
-    }
 }
 
 pub fn into_exprs(expr: TypedExpr) -> Vec<TypedExpr> {
     match expr.0 {
         Expr::Exprs(exprs) => exprs,
         _ => vec![expr],
-    }
-}
-
-fn pretty_print(node: &Expr, lv: usize, as_stmt: bool) -> String {
-    let sp = "  ".repeat(lv);
-    let mut indent = as_stmt;
-    let s = match node {
-        Expr::Number(n) => format!("{}", n),
-        Expr::PseudoVar(PseudoVar::True) => "true".to_string(),
-        Expr::PseudoVar(PseudoVar::False) => "false".to_string(),
-        Expr::PseudoVar(PseudoVar::Void) => "Void".to_string(),
-        Expr::LVarRef(name) => format!("{}", name),
-        Expr::ArgRef(idx, name) => format!("{}@{}", name, idx),
-        Expr::FuncRef(name) => format!("{}", name),
-        Expr::FunCall(func, args) => {
-            let Ty::Fun(fun_ty) = &func.1 else {
-                panic!("[BUG] not a function: {:?}", func);
-            };
-            format!("{}{}(", func.0.pretty_print(0, false), fun_ty.asyncness)
-                + args
-                    .iter()
-                    .map(|arg| arg.0.pretty_print(0, false))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-                    .as_str()
-                + ")"
-        }
-        Expr::If(cond, then, else_) => {
-            format!("if {}\n", cond.0.pretty_print(0, false))
-                + then.0.pretty_print(lv + 1, true).as_str()
-                + &format!("\n{}else\n", sp)
-                + else_.0.pretty_print(lv + 1, true).as_str()
-                + &format!("\n{}end", sp)
-        }
-        Expr::While(cond, body) => {
-            format!("while {}\n", cond.0.pretty_print(0, false))
-                + body.0.pretty_print(lv + 1, true).as_str()
-                + &format!("\n{}end", sp)
-        }
-        Expr::Spawn(e) => format!("spawn {}", pretty_print(&e.0, lv, false)),
-        Expr::Alloc(name) => format!("alloc {}", name),
-        Expr::Assign(name, e) => format!("{} = {}", name, pretty_print(&e.0, lv, false)),
-        Expr::Return(e) => format!("return {} # {}", pretty_print(&e.0, lv, false), e.1),
-        Expr::Exprs(exprs) => {
-            indent = false;
-            exprs
-                .iter()
-                .map(|expr| format!("{}  #-> {}", pretty_print(&expr.0, lv, true), &expr.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        } //_ => todo!("{:?}", self),
-    };
-    if indent {
-        format!("{}{}", sp, s)
-    } else {
-        s
     }
 }

--- a/lib/skc_async_experiment/src/hir/ty.rs
+++ b/lib/skc_async_experiment/src/hir/ty.rs
@@ -1,20 +1,10 @@
 use crate::hir::Asyncness;
-use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ty {
     Unknown, // Used before typecheck
     Raw(String),
     Fun(FunTy),
-}
-
-impl fmt::Display for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Ty::Fun(fun_ty) => write!(f, "{}", fun_ty),
-            _ => write!(f, "{:?}", self),
-        }
-    }
 }
 
 impl Ty {
@@ -55,29 +45,11 @@ impl Ty {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunTy {
     pub asyncness: Asyncness,
     pub param_tys: Vec<Ty>,
     pub ret_ty: Box<Ty>,
-}
-
-impl fmt::Display for FunTy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let para = self
-            .param_tys
-            .iter()
-            .map(|p| p.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-        write!(f, "({})->{}", para, &self.ret_ty)
-    }
-}
-
-impl fmt::Debug for FunTy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
-    }
 }
 
 impl From<FunTy> for Ty {

--- a/lib/skc_async_experiment/src/hir/ty.rs
+++ b/lib/skc_async_experiment/src/hir/ty.rs
@@ -1,100 +1,38 @@
 use crate::hir::Asyncness;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Ty {
-    Raw(String),
-    Fun(FunTy),
-}
-
-impl Ty {
-    pub fn raw(s: impl Into<String>) -> Self {
-        Ty::Raw(s.into())
-    }
-
-    pub fn as_fun_ty(&self) -> &FunTy {
-        match self {
-            Ty::Fun(f) => f,
-            _ => panic!("[BUG] not a function type: {:?}", self),
-        }
-    }
-
-    pub fn into_fun_ty(self) -> FunTy {
-        match self {
-            Ty::Fun(f) => f,
-            _ => panic!("[BUG] not a function type: {:?}", self),
-        }
-    }
-
-    /// Returns Some(true) if the type is a function type and it is async.
-    /// Returns Some(false) if the type is a function type and it is sync.
-    /// Returns None if the type is not a function type.
-    pub fn is_async_fun(&self) -> Option<bool> {
-        match self {
-            Ty::Fun(f) => Some(f.asyncness.is_async()),
-            _ => None,
-        }
-    }
-
-    /// Returns true if the two function types are the same except for asyncness.
-    pub fn same(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Ty::Fun(f1), Ty::Fun(f2)) => f1.same(f2),
-            _ => self == other,
-        }
-    }
-}
+use shiika_core::ty::{self, TermTy};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunTy {
     pub asyncness: Asyncness,
-    pub param_tys: Vec<Ty>,
-    pub ret_ty: Box<Ty>,
-}
-
-impl From<FunTy> for Ty {
-    fn from(x: FunTy) -> Self {
-        Ty::Fun(x)
-    }
-}
-
-impl From<Ty> for FunTy {
-    fn from(x: Ty) -> Self {
-        match x {
-            Ty::Fun(f) => f,
-            _ => panic!("[BUG] not a function type: {:?}", x),
-        }
-    }
+    pub param_tys: Vec<TermTy>,
+    pub ret_ty: TermTy,
 }
 
 impl FunTy {
-    fn new(asyncness: Asyncness, param_tys: Vec<Ty>, ret_ty: Ty) -> Self {
+    fn new(asyncness: Asyncness, param_tys: Vec<TermTy>, ret_ty: TermTy) -> Self {
         FunTy {
             asyncness,
             param_tys,
-            ret_ty: Box::new(ret_ty),
+            ret_ty,
         }
     }
 
-    pub fn sync(param_tys: Vec<Ty>, ret_ty: Ty) -> Self {
+    pub fn sync(param_tys: Vec<TermTy>, ret_ty: TermTy) -> Self {
         Self::new(Asyncness::Sync, param_tys, ret_ty)
     }
 
-    pub fn async_(param_tys: Vec<Ty>, ret_ty: Ty) -> Self {
+    pub fn async_(param_tys: Vec<TermTy>, ret_ty: TermTy) -> Self {
         Self::new(Asyncness::Async, param_tys, ret_ty)
     }
 
-    pub fn lowered(param_tys: Vec<Ty>, ret_ty: Ty) -> Self {
+    pub fn lowered(param_tys: Vec<TermTy>, ret_ty: TermTy) -> Self {
         Self::new(Asyncness::Lowered, param_tys, ret_ty)
     }
 
-    /// Returns true if the two function types are the same except for asyncness.
-    pub fn same(&self, other: &Self) -> bool {
-        self.ret_ty.same(&other.ret_ty)
-            && self.param_tys.len() == other.param_tys.len()
-            && self
-                .param_tys
-                .iter()
-                .zip(other.param_tys.iter())
-                .all(|(a, b)| a.same(b))
+    pub fn to_term_ty(self) -> TermTy {
+        let base_name = format!("Fn{}", self.param_tys.len());
+        let mut ts = self.param_tys;
+        ts.push(self.ret_ty);
+        ty::nonmeta(base_name, ts)
     }
 }

--- a/lib/skc_async_experiment/src/hir/ty.rs
+++ b/lib/skc_async_experiment/src/hir/ty.rs
@@ -2,7 +2,6 @@ use crate::hir::Asyncness;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ty {
-    Unknown, // Used before typecheck
     Raw(String),
     Fun(FunTy),
 }

--- a/lib/skc_async_experiment/src/hir/typing.rs
+++ b/lib/skc_async_experiment/src/hir/typing.rs
@@ -1,139 +1,164 @@
 use crate::hir;
-use crate::mir;
 use crate::names::FunctionName;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 
 struct Typing<'f> {
-    sigs: HashMap<FunctionName, hir::FunTy>,
-    current_func_name: Option<&'f FunctionName>,
-    current_func_params: Option<&'f [hir::Param]>,
-    current_func_ret_ty: Option<&'f hir::Ty>,
+    sigs: &'f HashMap<FunctionName, hir::FunTy>,
+    current_func_name: &'f FunctionName,
+    current_func_params: &'f [hir::Param],
+    current_func_ret_ty: &'f hir::Ty,
 }
 
 /// Create typed HIR from untyped HIR.
-pub fn run(hir: &mut hir::Program) -> Result<()> {
-    let mut c = Typing {
-        sigs: HashMap::new(),
-        current_func_name: None,
-        current_func_params: None,
-        current_func_ret_ty: None,
-    };
+pub fn run(hir: hir::Program<()>) -> Result<hir::Program<hir::Ty>> {
+    let mut sigs = HashMap::new();
     for e in &hir.externs {
-        c.sigs.insert(e.name.clone(), e.fun_ty.clone());
+        sigs.insert(e.name.clone(), e.fun_ty.clone());
     }
     for f in &hir.methods {
-        c.sigs.insert(f.name.clone(), f.fun_ty());
+        sigs.insert(f.name.clone(), f.fun_ty());
     }
 
-    for f in hir.methods.iter_mut() {
-        c.compile_func(f)?;
-    }
+    let methods = hir
+        .methods
+        .into_iter()
+        .map(|f| {
+            let mut c = Typing {
+                sigs: &sigs,
+                current_func_name: &f.name,
+                current_func_params: &f.params,
+                current_func_ret_ty: &f.ret_ty,
+            };
+            let new_body_stmts = c.compile_func(f.body_stmts)?;
+            Ok(hir::Method {
+                asyncness: f.asyncness,
+                name: f.name,
+                params: f.params,
+                ret_ty: f.ret_ty,
+                body_stmts: new_body_stmts,
+            })
+        })
+        .collect::<Result<_>>()?;
 
-    Ok(())
+    Ok(hir::Program {
+        externs: hir.externs,
+        methods,
+    })
 }
 
 impl<'f> Typing<'f> {
-    fn compile_func(&mut self, func: &'f mut hir::Method) -> Result<()> {
-        self.current_func_name = Some(&func.name);
-        self.current_func_params = Some(&func.params);
-        self.current_func_ret_ty = Some(&func.ret_ty);
+    fn compile_func(&mut self, body_stmts: hir::TypedExpr<()>) -> Result<hir::TypedExpr<hir::Ty>> {
         let mut lvars = HashMap::new();
-        self.compile_expr(&mut lvars, &mut func.body_stmts)?;
-        Ok(())
+        self.compile_expr(&mut lvars, body_stmts)
     }
 
     fn compile_expr(
         &mut self,
         lvars: &mut HashMap<String, hir::Ty>,
-        e: &mut hir::TypedExpr,
-    ) -> Result<()> {
-        match &mut e.0 {
-            hir::Expr::Number(_) => e.1 = hir::Ty::raw("Int"),
-            hir::Expr::PseudoVar(mir::PseudoVar::True) => e.1 = hir::Ty::raw("Bool"),
-            hir::Expr::PseudoVar(mir::PseudoVar::False) => e.1 = hir::Ty::raw("Bool"),
-            hir::Expr::PseudoVar(mir::PseudoVar::Void) => e.1 = hir::Ty::raw("Void"),
+        e: hir::TypedExpr<()>,
+    ) -> Result<hir::TypedExpr<hir::Ty>> {
+        let new_e = match e.0 {
+            hir::Expr::Number(n) => hir::Expr::number(n),
+            hir::Expr::PseudoVar(p) => hir::Expr::pseudo_var(p),
             hir::Expr::LVarRef(name) => {
-                if let Some(ty) = lvars.get(name) {
-                    e.1 = ty.clone();
+                if let Some(ty) = lvars.get(&name) {
+                    hir::Expr::lvar_ref(name, ty.clone())
                 } else {
                     return Err(anyhow!("[BUG] unknown variable `{name}'"));
                 }
             }
-            hir::Expr::ArgRef(i, _) => e.1 = self.current_func_params.unwrap()[*i].ty.clone(),
+            hir::Expr::ArgRef(i, s) => {
+                let ty = self.current_func_params[i].ty.clone();
+                hir::Expr::arg_ref(i, s, ty)
+            }
             hir::Expr::FuncRef(name) => {
-                if let Some(fun_ty) = self.sigs.get(name) {
-                    e.1 = hir::Ty::Fun(fun_ty.clone());
+                if let Some(fun_ty) = self.sigs.get(&name) {
+                    hir::Expr::func_ref(name, fun_ty.clone())
                 } else {
                     return Err(anyhow!("[BUG] unknown function `{name}'"));
                 }
             }
             hir::Expr::FunCall(fexpr, arg_exprs) => {
-                self.compile_expr(lvars, &mut *fexpr)?;
-                let hir::Ty::Fun(fun_ty) = &fexpr.1 else {
-                    return Err(anyhow!("not a function: {:?}", fexpr));
+                let new_fexpr = self.compile_expr(lvars, *fexpr)?;
+                let hir::Ty::Fun(fun_ty) = &new_fexpr.1 else {
+                    return Err(anyhow!("not a function"));
                 };
                 if fun_ty.param_tys.len() != arg_exprs.len() {
                     return Err(anyhow!(
-                        "funcall arity mismatch (expected {}, got {}): {:?}",
+                        "funcall arity mismatch (expected {}, got {})",
                         fun_ty.param_tys.len(),
                         arg_exprs.len(),
-                        e
                     ));
                 }
-                for e in arg_exprs {
-                    self.compile_expr(lvars, e)?;
-                }
-                e.1 = *fun_ty.ret_ty.clone();
+                let new_arg_exprs = arg_exprs
+                    .into_iter()
+                    .map(|e| self.compile_expr(lvars, e))
+                    .collect::<Result<_>>()?;
+                hir::Expr::fun_call(new_fexpr, new_arg_exprs)
             }
             hir::Expr::If(cond, then, els) => {
-                self.compile_expr(lvars, &mut *cond)?;
-                if cond.1 != hir::Ty::raw("Bool") {
-                    return Err(anyhow!("condition should be bool but got {:?}", cond.1));
+                let new_cond = self.compile_expr(lvars, *cond)?;
+                if new_cond.1 != hir::Ty::raw("Bool") {
+                    return Err(anyhow!("condition should be bool but got {:?}", new_cond.1));
                 }
-                self.compile_expr(lvars, then)?;
-                self.compile_expr(lvars, els)?;
-                let if_ty = hir::Expr::if_ty(&then.1, &els.1)?;
-                e.1 = if_ty.clone();
+                let new_then = self.compile_expr(lvars, *then)?;
+                let new_els = self.compile_expr(lvars, *els)?;
+                hir::Expr::if_(new_cond, new_then, new_els)
             }
             hir::Expr::While(cond, body) => {
-                self.compile_expr(lvars, cond)?;
-                self.compile_expr(lvars, body)?;
-                e.1 = hir::Ty::raw("Void");
+                let new_cond = self.compile_expr(lvars, *cond)?;
+                if new_cond.1 != hir::Ty::raw("Bool") {
+                    return Err(anyhow!("condition should be bool but got {:?}", new_cond.1));
+                }
+                let new_body = self.compile_expr(lvars, *body)?;
+                hir::Expr::while_(new_cond, new_body)
             }
             hir::Expr::Spawn(func) => {
-                self.compile_expr(lvars, func)?;
-                e.1 = hir::Ty::raw("Void");
+                let new_func = self.compile_expr(lvars, *func)?;
+                hir::Expr::spawn(new_func)
             }
             hir::Expr::Alloc(name) => {
                 // Milika vars are always Int now
                 lvars.insert(name.clone(), hir::Ty::raw("Int"));
-                e.1 = hir::Ty::raw("Void");
+                hir::Expr::alloc(name)
             }
-            hir::Expr::Assign(_, val) => {
-                self.compile_expr(lvars, val)?;
-                e.1 = hir::Ty::raw("Void");
+            hir::Expr::Assign(name, val) => {
+                let new_val = self.compile_expr(lvars, *val)?;
+                if let Some(ty) = lvars.get(&name) {
+                    if ty != &new_val.1 {
+                        return Err(anyhow!(
+                            "type mismatch: variable `{name}' should be {:?} but got {:?}",
+                            ty,
+                            new_val.1
+                        ));
+                    }
+                } else {
+                    panic!("unknown variable `{name}'");
+                }
+                hir::Expr::assign(name, new_val)
             }
             hir::Expr::Return(val) => {
-                self.compile_expr(lvars, val)?;
-                if !valid_return_type(self.current_func_ret_ty.unwrap(), &val.1) {
+                let new_val = self.compile_expr(lvars, *val)?;
+                if !valid_return_type(self.current_func_ret_ty, &new_val.1) {
                     return Err(anyhow!(
                         "return type mismatch: {} should return {:?} but got {:?}",
-                        self.current_func_name.unwrap(),
-                        self.current_func_ret_ty.unwrap(),
-                        val.1
+                        self.current_func_name,
+                        self.current_func_ret_ty,
+                        new_val.1
                     ));
                 }
-                e.1 = hir::Ty::raw("Never");
+                hir::Expr::return_(new_val)
             }
             hir::Expr::Exprs(exprs) => {
-                for e in exprs.iter_mut() {
-                    self.compile_expr(lvars, e)?;
-                }
-                e.1 = exprs.last().unwrap().1.clone();
-            } //_ => panic!("must not occur in hir::typing: {:?}", e.0),
+                let new_exprs = exprs
+                    .into_iter()
+                    .map(|e| self.compile_expr(lvars, e))
+                    .collect::<Result<_>>()?;
+                hir::Expr::exprs(new_exprs)
+            }
         };
-        Ok(())
+        Ok(new_e)
     }
 }
 

--- a/lib/skc_async_experiment/src/hir/typing.rs
+++ b/lib/skc_async_experiment/src/hir/typing.rs
@@ -22,11 +22,11 @@ pub fn run(hir: &mut hir::Program) -> Result<()> {
     for e in &hir.externs {
         c.sigs.insert(e.name.clone(), e.fun_ty.clone());
     }
-    for f in &hir.funcs {
+    for f in &hir.methods {
         c.sigs.insert(f.name.clone(), f.fun_ty());
     }
 
-    for f in hir.funcs.iter_mut() {
+    for f in hir.methods.iter_mut() {
         c.compile_func(f)?;
     }
 
@@ -34,7 +34,7 @@ pub fn run(hir: &mut hir::Program) -> Result<()> {
 }
 
 impl<'f> Typing<'f> {
-    fn compile_func(&mut self, func: &'f mut hir::Function) -> Result<()> {
+    fn compile_func(&mut self, func: &'f mut hir::Method) -> Result<()> {
         self.current_func_name = Some(&func.name);
         self.current_func_params = Some(&func.params);
         self.current_func_ret_ty = Some(&func.ret_ty);

--- a/lib/skc_async_experiment/src/hir/untyped.rs
+++ b/lib/skc_async_experiment/src/hir/untyped.rs
@@ -3,6 +3,7 @@ use crate::mir;
 use crate::names::FunctionName;
 use anyhow::{anyhow, Result};
 use shiika_ast as ast;
+use shiika_core::ty::{self, TermTy};
 use std::collections::HashSet;
 
 /// Create untyped HIR (i.e. contains Ty::Unknown) from AST
@@ -70,7 +71,7 @@ impl Compiler {
         }
         let ret_ty = match &sig.ret_typ {
             Some(t) => compile_ty(&t)?,
-            None => hir::Ty::raw("Void"),
+            None => ty::raw("Void"),
         };
 
         let mut lvars = HashSet::new();
@@ -239,29 +240,15 @@ impl Compiler {
     }
 }
 
-fn compile_ty(n: &shiika_ast::UnresolvedTypeName) -> Result<hir::Ty> {
+fn compile_ty(n: &shiika_ast::UnresolvedTypeName) -> Result<TermTy> {
     let t = if n.args.len() == 0 {
         let s = n.names.join("::");
-        match &s[..] {
-            _ => hir::Ty::raw(s),
-        }
+        ty::raw(s)
     } else {
-        hir::Ty::Fun(compile_fun_ty(&n.args)?)
+        todo!();
+        //hir::Ty::Fun(compile_fun_ty(&n.args)?)
     };
     Ok(t)
-}
-
-fn compile_fun_ty(x: &[shiika_ast::UnresolvedTypeName]) -> Result<hir::FunTy> {
-    let mut param_tys = vec![];
-    for p in x {
-        param_tys.push(compile_ty(p)?);
-    }
-    let ret_ty = Box::new(param_tys.pop().unwrap());
-    Ok(hir::FunTy {
-        asyncness: hir::Asyncness::Unknown,
-        param_tys,
-        ret_ty,
-    })
 }
 
 pub fn signature_to_fun_ty(sig: &shiika_ast::AstMethodSignature) -> hir::FunTy {
@@ -271,12 +258,12 @@ pub fn signature_to_fun_ty(sig: &shiika_ast::AstMethodSignature) -> hir::FunTy {
     }
     let ret_ty = match &sig.ret_typ {
         Some(t) => compile_ty(t).unwrap(),
-        None => hir::Ty::raw("Void"),
+        None => ty::raw("Void"),
     };
     hir::FunTy {
         asyncness: hir::Asyncness::Unknown,
         param_tys,
-        ret_ty: Box::new(ret_ty),
+        ret_ty,
     }
 }
 

--- a/lib/skc_async_experiment/src/hir/untyped.rs
+++ b/lib/skc_async_experiment/src/hir/untyped.rs
@@ -36,18 +36,18 @@ pub fn create(ast: &ast::Program) -> Result<hir::Program> {
     }
 
     let c = Compiler { func_names };
-    let mut funcs = vec![];
+    let mut methods = vec![];
     for def in defs {
         match def {
             shiika_ast::Definition::ClassMethodDefinition { sig, body_exprs } => {
-                funcs.push(c.compile_func(sig, body_exprs)?);
+                methods.push(c.compile_func(sig, body_exprs)?);
             }
             _ => return Err(anyhow!("[wip] not supported yet: {:?}", def)),
         }
     }
     Ok(hir::Program {
         externs: vec![],
-        funcs,
+        methods,
     })
 }
 
@@ -60,7 +60,7 @@ impl Compiler {
         &self,
         sig: &shiika_ast::AstMethodSignature,
         body_exprs: &[shiika_ast::AstExpression],
-    ) -> Result<hir::Function> {
+    ) -> Result<hir::Method> {
         let mut params = vec![];
         for p in &sig.params {
             params.push(hir::Param {
@@ -83,7 +83,7 @@ impl Compiler {
         }
         insert_implicit_return(&mut body_stmts);
 
-        Ok(hir::Function {
+        Ok(hir::Method {
             asyncness: hir::Asyncness::Unknown,
             name: FunctionName::unmangled(sig.name.to_string()),
             params,

--- a/lib/skc_async_experiment/src/hir_to_mir.rs
+++ b/lib/skc_async_experiment/src/hir_to_mir.rs
@@ -1,6 +1,6 @@
 use crate::{hir, mir};
 
-pub fn run(hir: hir::Program) -> mir::Program {
+pub fn run(hir: hir::Program<hir::Ty>) -> mir::Program {
     let externs = hir
         .externs
         .into_iter()
@@ -46,7 +46,6 @@ fn convert_asyncness(a: hir::Asyncness) -> mir::Asyncness {
 
 fn convert_ty(ty: hir::Ty) -> mir::Ty {
     match ty {
-        hir::Ty::Unknown => panic!("Unknown ty in hir"),
         hir::Ty::Raw(s) => mir::Ty::Raw(s),
         hir::Ty::Fun(fun_ty) => mir::Ty::Fun(convert_fun_ty(fun_ty)),
     }
@@ -59,15 +58,15 @@ fn convert_param(param: hir::Param) -> mir::Param {
     }
 }
 
-fn convert_texpr(texpr: hir::TypedExpr) -> mir::TypedExpr {
+fn convert_texpr(texpr: hir::TypedExpr<hir::Ty>) -> mir::TypedExpr {
     (convert_expr(texpr.0), convert_ty(texpr.1))
 }
 
-fn convert_texpr_vec(exprs: Vec<hir::TypedExpr>) -> Vec<mir::TypedExpr> {
+fn convert_texpr_vec(exprs: Vec<hir::TypedExpr<hir::Ty>>) -> Vec<mir::TypedExpr> {
     exprs.into_iter().map(|x| convert_texpr(x)).collect()
 }
 
-fn convert_expr(expr: hir::Expr) -> mir::Expr {
+fn convert_expr(expr: hir::Expr<hir::Ty>) -> mir::Expr {
     match expr {
         hir::Expr::Number(i) => mir::Expr::Number(i),
         hir::Expr::PseudoVar(p) => mir::Expr::PseudoVar(p),

--- a/lib/skc_async_experiment/src/hir_to_mir.rs
+++ b/lib/skc_async_experiment/src/hir_to_mir.rs
@@ -10,7 +10,7 @@ pub fn run(hir: hir::Program) -> mir::Program {
         })
         .collect();
     let funcs = hir
-        .funcs
+        .methods
         .into_iter()
         .map(|f| mir::Function {
             asyncness: convert_asyncness(f.asyncness),

--- a/lib/skc_async_experiment/src/prelude.rs
+++ b/lib/skc_async_experiment/src/prelude.rs
@@ -2,6 +2,7 @@ use crate::hir;
 use crate::mir::{self, FunTy, Ty};
 use crate::names::FunctionName;
 use anyhow::{Context, Result};
+use shiika_core::ty;
 use shiika_parser;
 use std::io::Read;
 
@@ -12,11 +13,11 @@ pub fn lib_externs(skc_runtime_dir: &std::path::Path) -> Result<Vec<(FunctionNam
         // Built-in functions
         (
             "print",
-            hir::FunTy::sync(vec![hir::Ty::raw("Int")], hir::Ty::raw("Void")),
+            hir::FunTy::sync(vec![ty::raw("Int")], ty::raw("Void")),
         ),
         (
             "sleep_sec",
-            hir::FunTy::async_(vec![hir::Ty::raw("Int")], hir::Ty::raw("Void")),
+            hir::FunTy::async_(vec![ty::raw("Int")], ty::raw("Void")),
         ),
     ]
     .into_iter()
@@ -54,7 +55,7 @@ fn parse_sig(class: String, sig_str: String) -> Result<(FunctionName, hir::FunTy
     fun_ty.asyncness = hir::Asyncness::Sync;
 
     // TMP: Insert receiver
-    fun_ty.param_tys.insert(0, hir::Ty::raw("Int"));
+    fun_ty.param_tys.insert(0, ty::raw("Int"));
 
     Ok((
         FunctionName::unmangled(format!("{}#{}", class, ast_sig.name.0)),

--- a/lib/skc_async_experiment/src/run.rs
+++ b/lib/skc_async_experiment/src/run.rs
@@ -53,8 +53,8 @@ impl Main {
             .map(|(name, fun_ty)| hir::Extern { name, fun_ty })
             .collect();
         hir::typing::run(&mut hir)?;
-        self.log(format!("# -- typing output --\n{hir}\n"));
         let mut mir = hir_to_mir::run(hir);
+        self.log(format!("# -- typing output --\n{mir}\n"));
         mir = mir_lowering::asyncness_check::run(mir);
         self.log(format!("# -- asyncness_check output --\n{mir}\n"));
         mir = mir_lowering::pass_async_env::run(mir);

--- a/lib/skc_async_experiment/src/run.rs
+++ b/lib/skc_async_experiment/src/run.rs
@@ -52,16 +52,16 @@ impl Main {
             .into_iter()
             .map(|(name, fun_ty)| hir::Extern { name, fun_ty })
             .collect();
-        hir::typing::run(&mut hir)?;
-        let mut mir = hir_to_mir::run(hir);
+        let hir = hir::typing::run(hir)?;
+        let mir = hir_to_mir::run(hir);
         self.log(format!("# -- typing output --\n{mir}\n"));
-        mir = mir_lowering::asyncness_check::run(mir);
+        let mir = mir_lowering::asyncness_check::run(mir);
         self.log(format!("# -- asyncness_check output --\n{mir}\n"));
-        mir = mir_lowering::pass_async_env::run(mir);
+        let mir = mir_lowering::pass_async_env::run(mir);
         self.log(format!("# -- pass_async_env output --\n{mir}\n"));
-        mir = mir_lowering::async_splitter::run(mir)?;
+        let mir = mir_lowering::async_splitter::run(mir)?;
         self.log(format!("# -- async_splitter output --\n{mir}\n"));
-        mir = mir_lowering::resolve_env_op::run(mir);
+        let mir = mir_lowering::resolve_env_op::run(mir);
         Ok(mir)
     }
 


### PR DESCRIPTION
This PR replaces hir::Ty with shiika_core::ty::TermTy.