### PR TITLE
new_runtime: Accessing package const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1735,6 +1735,7 @@ dependencies = [
  "os_info",
  "peg",
  "serde",
+ "serde_json",
  "shiika_ast",
  "shiika_core",
  "shiika_ffi",

--- a/lib/skc_async_experiment/Cargo.toml
+++ b/lib/skc_async_experiment/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.11.6"
 # To read exports.json5
 json5 = "0.2.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.140"
 
 [dev-dependencies]
 insta = { version = "1.32.0", features = ["glob"] }

--- a/lib/skc_async_experiment/src/build.rs
+++ b/lib/skc_async_experiment/src/build.rs
@@ -3,3 +3,4 @@ pub mod compiler;
 pub mod exe_builder;
 pub mod lib_builder;
 pub mod linker;
+pub mod loader;

--- a/lib/skc_async_experiment/src/build.rs
+++ b/lib/skc_async_experiment/src/build.rs
@@ -4,3 +4,45 @@ pub mod exe_builder;
 pub mod lib_builder;
 pub mod linker;
 pub mod loader;
+use crate::package::Package;
+use std::path::Path;
+
+/// Represents what to compile. (an executable or a library)
+pub struct CompileTarget<'a> {
+    /// Path to the first .sk file to read
+    entry_point: &'a Path,
+    /// Directory to create the artifact
+    out_dir: &'a Path,
+    /// Direct dependencies
+    deps: &'a [Package],
+    /// Lib or Bin specific information
+    detail: CompileTargetDetail<'a>,
+}
+
+pub enum CompileTargetDetail<'a> {
+    Lib {
+        package: &'a Package,
+    },
+    Bin {
+        package: Option<&'a Package>,
+        /// Topologically sorted indirect dependencies
+        total_deps: Vec<String>,
+    },
+}
+
+impl<'a> CompileTarget<'a> {
+    pub fn is_bin(&self) -> bool {
+        matches!(self.detail, CompileTargetDetail::Bin { .. })
+    }
+
+    fn package(&self) -> Option<&'a Package> {
+        match &self.detail {
+            CompileTargetDetail::Lib { package } => Some(package),
+            CompileTargetDetail::Bin { package, .. } => package.clone(),
+        }
+    }
+
+    pub fn package_name(&self) -> Option<String> {
+        self.package().map(|x| x.spec.name.clone())
+    }
+}

--- a/lib/skc_async_experiment/src/build.rs
+++ b/lib/skc_async_experiment/src/build.rs
@@ -10,13 +10,13 @@ use std::path::Path;
 /// Represents what to compile. (an executable or a library)
 pub struct CompileTarget<'a> {
     /// Path to the first .sk file to read
-    entry_point: &'a Path,
+    pub entry_point: &'a Path,
     /// Directory to create the artifact
-    out_dir: &'a Path,
+    pub out_dir: &'a Path,
     /// Direct dependencies
-    deps: &'a [Package],
+    pub deps: &'a [Package],
     /// Lib or Bin specific information
-    detail: CompileTargetDetail<'a>,
+    pub detail: CompileTargetDetail<'a>,
 }
 
 pub enum CompileTargetDetail<'a> {

--- a/lib/skc_async_experiment/src/build.rs
+++ b/lib/skc_async_experiment/src/build.rs
@@ -1,4 +1,5 @@
 pub mod cargo_builder;
 pub mod compiler;
 pub mod exe_builder;
+pub mod lib_builder;
 pub mod linker;

--- a/lib/skc_async_experiment/src/build/compiler.rs
+++ b/lib/skc_async_experiment/src/build/compiler.rs
@@ -42,7 +42,7 @@ pub fn compile(
     fs::create_dir_all(out_dir).context(format!("failed to create {}", out_dir.display()))?;
     let bc_path = out_path(out_dir, entry_point, "bc");
     let ll_path = out_path(out_dir, entry_point, "ll");
-    codegen::run(&bc_path, Some(&ll_path), mir)?;
+    codegen::run(&bc_path, Some(&ll_path), mir, is_bin)?;
     Ok(bc_path)
 }
 

--- a/lib/skc_async_experiment/src/build/compiler.rs
+++ b/lib/skc_async_experiment/src/build/compiler.rs
@@ -68,7 +68,7 @@ fn generate_mir(
 
     let hir = generate_hir(cli, &ast, target)?;
     log::info!("Creating mir");
-    let mut mir = hir_to_mir::run(hir, target.is_bin())?;
+    let mut mir = hir_to_mir::run(hir, target)?;
     cli.log(format!("# -- typing output --\n{}\n", mir.program));
     mir.program = mir_lowering::asyncness_check::run(mir.program);
     cli.log(format!("# -- asyncness_check output --\n{}\n", mir.program));

--- a/lib/skc_async_experiment/src/build/compiler.rs
+++ b/lib/skc_async_experiment/src/build/compiler.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 
 pub fn compile(
     cli: &mut cli::Cli,
+    package: Option<&package::Package>,
     entry_point: &Path,
     out_dir: &Path,
     deps: &[package::Package],
@@ -43,7 +44,8 @@ pub fn compile(
             vtables: mir.vtables.clone(),
             constants: Default::default(), //TODO
         };
-        write_exports_json(out_dir, &exports)?;
+        let out_path = cli.lib_exports_path(&package.unwrap().spec);
+        write_exports_json(&out_path, &exports)?;
     }
     let bc_path = out_path(out_dir, entry_point, "bc");
     let ll_path = out_path(out_dir, entry_point, "ll");
@@ -130,11 +132,11 @@ fn parse_sig(type_name: String, sig_str: String) -> Result<MethodSignature> {
 }
 
 pub fn write_exports_json(
-    out_dir: &std::path::Path,
+    out_path: &std::path::Path,
     exports: &skc_mir::LibraryExports,
 ) -> Result<()> {
     let json = serde_json::to_string_pretty(exports)?;
-    let mut f = std::fs::File::create(out_dir.join("exports.json"))?;
+    let mut f = std::fs::File::create(out_path)?;
     f.write_all(json.as_bytes())?;
     Ok(())
 }

--- a/lib/skc_async_experiment/src/build/compiler.rs
+++ b/lib/skc_async_experiment/src/build/compiler.rs
@@ -22,11 +22,18 @@ pub fn compile(
     let src = SourceFile::new(entry_point.to_path_buf(), txt);
     let mut mir = generate_mir(cli, src, &deps, is_bin)?;
 
-    for (name, fun_ty) in prelude::core_externs() {
-        mir.program.externs.push(mir::Extern { name, fun_ty });
-    }
     if is_bin {
         mir.program.funcs.append(&mut prelude::main_funcs());
+    } else {
+        if mir.program.funcs.len() > 0 {
+            panic!("Top level expressions are not allowed in library");
+        }
+        for (name, fun_ty) in prelude::intrinsic_externs() {
+            mir.program.externs.push(mir::Extern { name, fun_ty });
+        }
+    }
+    for (name, fun_ty) in prelude::core_externs() {
+        mir.program.externs.push(mir::Extern { name, fun_ty });
     }
 
     cli.log(&format!("# -- verifier input --\n{}\n", mir.program));

--- a/lib/skc_async_experiment/src/build/compiler.rs
+++ b/lib/skc_async_experiment/src/build/compiler.rs
@@ -8,6 +8,7 @@ use shiika_core::ty::{self, Erasure};
 use shiika_parser::SourceFile;
 use skc_hir::{MethodSignature, MethodSignatures, SkTypeBase, Supertype};
 use skc_mir::LibraryExports;
+use std::collections::HashMap;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -39,10 +40,14 @@ pub fn compile(
 
     fs::create_dir_all(out_dir).context(format!("failed to create {}", out_dir.display()))?;
     if !is_bin {
+        let mut constants = HashMap::new();
+        for (name, ty) in &mir.program.constants {
+            constants.insert(name.clone(), ty.clone());
+        }
         let exports = LibraryExports {
             sk_types: mir.sk_types.clone(),
             vtables: mir.vtables.clone(),
-            constants: Default::default(), //TODO
+            constants,
         };
         let out_path = cli.lib_exports_path(&package.unwrap().spec);
         write_exports_json(&out_path, &exports)?;

--- a/lib/skc_async_experiment/src/build/compiler.rs
+++ b/lib/skc_async_experiment/src/build/compiler.rs
@@ -100,6 +100,7 @@ fn generate_hir(
         }
         let exp = load_exports_json(&cli.lib_exports_path(&package.spec))?;
         imports.sk_types.merge(&exp.sk_types);
+        imports.constants.extend(exp.constants);
     }
 
     let defs = ast.defs();
@@ -107,9 +108,9 @@ fn generate_hir(
     let mut class_dict = skc_ast2hir::class_dict::create(&defs, type_index, &imports.sk_types)?;
 
     log::info!("Type checking");
-    let mut hir = hir::untyped::create(&ast)?;
+    let mut hir = hir::untyped::create(&ast, &imports.constants)?;
     hir_building::define_new::run(&mut hir, &mut class_dict);
-    let hir = hir::typing::run(hir, &class_dict)?;
+    let hir = hir::typing::run(hir, &class_dict, &imports.constants)?;
     let sk_types = class_dict.sk_types;
     Ok(hir::CompilationUnit {
         imports,

--- a/lib/skc_async_experiment/src/build/exe_builder.rs
+++ b/lib/skc_async_experiment/src/build/exe_builder.rs
@@ -1,31 +1,17 @@
 use crate::cli::Cli;
 use crate::package::Package;
-use crate::{build, codegen, mir, prelude};
-use anyhow::{Context, Result};
-use shiika_parser::SourceFile;
+use crate::build;
+use anyhow::Result;
 use std::path::PathBuf;
 
 /// Builds a single .sk file and generates an executable.
 /// Returns the path to the generated executable.
 pub fn run(cli: &mut Cli, entry_point: &PathBuf) -> Result<PathBuf> {
-    let txt = std::fs::read_to_string(entry_point)
-        .context(format!("failed to read {}", &entry_point.to_string_lossy()))?;
-    let src = SourceFile::new(entry_point.clone(), txt);
     let deps = vec![Package::load_core(cli)?];
-    let mut mir = build::compiler::compile(cli, src, &deps)?;
-
-    for (name, fun_ty) in prelude::core_externs() {
-        mir.program.externs.push(mir::Extern { name, fun_ty });
-    }
-    mir.program.funcs.append(&mut prelude::funcs());
-
-    cli.log(&format!("# -- verifier input --\n{}\n", mir.program));
-    mir::verifier::run(&mir.program)?;
-
-    let bc_path = entry_point.with_extension("bc");
-    let ll_path = entry_point.with_extension("ll");
-    codegen::run(&bc_path, Some(&ll_path), mir)?;
-
-    let deps = Package::load_core(cli)?.artifacts;
-    build::linker::run(bc_path, &deps)
+    let bc_path = build::compiler::compile(cli, entry_point, &deps)?;
+    let artifacts = deps
+        .iter()
+        .flat_map(|pkg| pkg.artifacts.clone())
+        .collect::<Vec<_>>();
+    build::linker::run(bc_path, &artifacts)
 }

--- a/lib/skc_async_experiment/src/build/exe_builder.rs
+++ b/lib/skc_async_experiment/src/build/exe_builder.rs
@@ -8,8 +8,18 @@ use std::path::PathBuf;
 /// Returns the path to the generated executable.
 pub fn run(cli: &mut Cli, entry_point: &PathBuf) -> Result<PathBuf> {
     let deps = vec![Package::load_core(cli)?]; //TODO: load dependencies
+    let total_deps = deps.iter().map(|x| x.spec.name.clone()).collect();
     let out_dir = entry_point.parent().unwrap();
-    let bc_path = build::compiler::compile(cli, None, entry_point, out_dir, &deps, true)?;
+    let target = build::CompileTarget {
+        entry_point,
+        out_dir: &out_dir,
+        deps: &deps,
+        detail: build::CompileTargetDetail::Bin {
+            package: None,
+            total_deps,
+        },
+    };
+    let bc_path = build::compiler::compile(cli, &target)?;
     let artifacts = deps
         .iter()
         .flat_map(|pkg| pkg.artifacts.clone())

--- a/lib/skc_async_experiment/src/build/exe_builder.rs
+++ b/lib/skc_async_experiment/src/build/exe_builder.rs
@@ -1,6 +1,6 @@
+use crate::build;
 use crate::cli::Cli;
 use crate::package::Package;
-use crate::build;
 use anyhow::Result;
 use std::path::PathBuf;
 
@@ -8,7 +8,8 @@ use std::path::PathBuf;
 /// Returns the path to the generated executable.
 pub fn run(cli: &mut Cli, entry_point: &PathBuf) -> Result<PathBuf> {
     let deps = vec![Package::load_core(cli)?];
-    let bc_path = build::compiler::compile(cli, entry_point, &deps)?;
+    let out_dir = entry_point.parent().unwrap();
+    let bc_path = build::compiler::compile(cli, entry_point, out_dir, &deps)?;
     let artifacts = deps
         .iter()
         .flat_map(|pkg| pkg.artifacts.clone())

--- a/lib/skc_async_experiment/src/build/exe_builder.rs
+++ b/lib/skc_async_experiment/src/build/exe_builder.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub fn run(cli: &mut Cli, entry_point: &PathBuf) -> Result<PathBuf> {
     let deps = vec![Package::load_core(cli)?];
     let out_dir = entry_point.parent().unwrap();
-    let bc_path = build::compiler::compile(cli, entry_point, out_dir, &deps)?;
+    let bc_path = build::compiler::compile(cli, entry_point, out_dir, &deps, true)?;
     let artifacts = deps
         .iter()
         .flat_map(|pkg| pkg.artifacts.clone())

--- a/lib/skc_async_experiment/src/build/exe_builder.rs
+++ b/lib/skc_async_experiment/src/build/exe_builder.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 /// Builds a single .sk file and generates an executable.
 /// Returns the path to the generated executable.
 pub fn run(cli: &mut Cli, entry_point: &PathBuf) -> Result<PathBuf> {
-    let deps = vec![Package::load_core(cli)?];
+    let deps = vec![Package::load_core(cli)?]; //TODO: load dependencies
     let out_dir = entry_point.parent().unwrap();
     let bc_path = build::compiler::compile(cli, entry_point, out_dir, &deps, true)?;
     let artifacts = deps

--- a/lib/skc_async_experiment/src/build/exe_builder.rs
+++ b/lib/skc_async_experiment/src/build/exe_builder.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub fn run(cli: &mut Cli, entry_point: &PathBuf) -> Result<PathBuf> {
     let deps = vec![Package::load_core(cli)?]; //TODO: load dependencies
     let out_dir = entry_point.parent().unwrap();
-    let bc_path = build::compiler::compile(cli, entry_point, out_dir, &deps, true)?;
+    let bc_path = build::compiler::compile(cli, None, entry_point, out_dir, &deps, true)?;
     let artifacts = deps
         .iter()
         .flat_map(|pkg| pkg.artifacts.clone())

--- a/lib/skc_async_experiment/src/build/lib_builder.rs
+++ b/lib/skc_async_experiment/src/build/lib_builder.rs
@@ -7,6 +7,6 @@ use anyhow::Result;
 pub fn build(cli: &mut Cli, package: &Package) -> Result<()> {
     let deps = vec![]; // TODO: get deps from package
     let out_dir = cli.lib_target_dir(&package.spec);
-    build::compiler::compile(cli, &package.entry_point(), &out_dir, &deps)?;
+    build::compiler::compile(cli, &package.entry_point(), &out_dir, &deps, false)?;
     Ok(())
 }

--- a/lib/skc_async_experiment/src/build/lib_builder.rs
+++ b/lib/skc_async_experiment/src/build/lib_builder.rs
@@ -6,14 +6,12 @@ use anyhow::Result;
 
 pub fn build(cli: &mut Cli, package: &Package) -> Result<()> {
     let deps = vec![]; // TODO: get deps from package
-    let out_dir = cli.lib_target_dir(&package.spec);
-    build::compiler::compile(
-        cli,
-        Some(&package),
-        &package.entry_point(),
-        &out_dir,
-        &deps,
-        false,
-    )?;
+    let target = build::CompileTarget {
+        entry_point: &package.entry_point(),
+        out_dir: &cli.lib_target_dir(&package.spec),
+        deps: &deps,
+        detail: build::CompileTargetDetail::Lib { package },
+    };
+    build::compiler::compile(cli, &target)?;
     Ok(())
 }

--- a/lib/skc_async_experiment/src/build/lib_builder.rs
+++ b/lib/skc_async_experiment/src/build/lib_builder.rs
@@ -1,0 +1,12 @@
+//! Compiles the Shiika code in a package into single .bc.
+use crate::build;
+use crate::cli::Cli;
+use crate::package::Package;
+use anyhow::Result;
+
+pub fn build(cli: &mut Cli, package: &Package) -> Result<()> {
+    let deps = vec![]; // TODO: get deps from package
+    let out_dir = cli.lib_target_dir(&package.spec);
+    build::compiler::compile(cli, &package.entry_point(), &out_dir, &deps)?;
+    Ok(())
+}

--- a/lib/skc_async_experiment/src/build/lib_builder.rs
+++ b/lib/skc_async_experiment/src/build/lib_builder.rs
@@ -7,6 +7,13 @@ use anyhow::Result;
 pub fn build(cli: &mut Cli, package: &Package) -> Result<()> {
     let deps = vec![]; // TODO: get deps from package
     let out_dir = cli.lib_target_dir(&package.spec);
-    build::compiler::compile(cli, &package.entry_point(), &out_dir, &deps, false)?;
+    build::compiler::compile(
+        cli,
+        Some(&package),
+        &package.entry_point(),
+        &out_dir,
+        &deps,
+        false,
+    )?;
     Ok(())
 }

--- a/lib/skc_async_experiment/src/build/loader.rs
+++ b/lib/skc_async_experiment/src/build/loader.rs
@@ -1,0 +1,64 @@
+// Resolve "require"
+use anyhow::{Context, Result};
+use shiika_parser::SourceFile;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Read a .sk file (and those require'd by it)
+pub fn load(path: &Path) -> Result<Vec<SourceFile>> {
+    let mut files = vec![];
+    let mut loading_files = vec![];
+    load_file(path, &mut files, &mut loading_files)?;
+    Ok(files)
+}
+
+fn load_file(
+    path: &Path,
+    files: &mut Vec<SourceFile>,
+    loading_files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    if loading_files.contains(&path.into()) {
+        return Ok(());
+    }
+    loading_files.push(path.into());
+
+    // Load require'd files first
+    let content = fs::read_to_string(path).context(format!("failed to load {}", path.display()))?;
+    let newpaths = resolve_requires(path, &content);
+    for newpath in newpaths {
+        load_file(&newpath, files, loading_files)?;
+    }
+
+    files.push(SourceFile::new(path.into(), content));
+    Ok(())
+}
+
+/// Read require'd files into `files`
+#[allow(clippy::if_same_then_else)]
+fn resolve_requires(path: &Path, content: &str) -> Vec<PathBuf> {
+    let mut paths = vec![];
+    for line in content.lines() {
+        if line.trim_start().starts_with("require") {
+            paths.push(parse_require(line, path));
+        } else if line.trim_start().starts_with('#') {
+            // skip comment line.
+        } else if line.trim_start().is_empty() {
+            // skip empty line.
+        } else {
+            break;
+        }
+    }
+    paths
+}
+
+/// Expand filepath in require
+fn parse_require(line: &str, path: &Path) -> PathBuf {
+    let s = line
+        .trim_start()
+        .trim_start_matches("require")
+        .trim_start()
+        .trim_start_matches('"')
+        .trim_end()
+        .trim_end_matches('"');
+    path.with_file_name(s)
+}

--- a/lib/skc_async_experiment/src/cli.rs
+++ b/lib/skc_async_experiment/src/cli.rs
@@ -68,18 +68,12 @@ impl Cli {
         Ok(())
     }
 
+    pub fn lib_exports_path(&self, spec: &package::PackageSpec) -> PathBuf {
+        self.lib_target_dir(spec).join("exports.json")
+    }
+
     pub fn lib_target_dir(&self, spec: &package::PackageSpec) -> PathBuf {
         self.package_work_dir(spec).join("lib")
-    }
-
-    pub fn cargo_target_dir(&self, spec: &package::PackageSpec) -> PathBuf {
-        self.package_work_dir(spec).join("cargo_target")
-    }
-
-    pub fn package_work_dir(&self, spec: &package::PackageSpec) -> PathBuf {
-        self.shiika_work
-            .join("packages")
-            .join(format!("{}-{}", &spec.name, &spec.version))
     }
 
     pub fn rust_artifact_path(&self, spec: &package::PackageSpec, _rust_lib: &str) -> PathBuf {
@@ -91,6 +85,16 @@ impl Cli {
             } else {
                 format!("lib{}.a", name)
             })
+    }
+
+    pub fn cargo_target_dir(&self, spec: &package::PackageSpec) -> PathBuf {
+        self.package_work_dir(spec).join("cargo_target")
+    }
+
+    pub fn package_work_dir(&self, spec: &package::PackageSpec) -> PathBuf {
+        self.shiika_work
+            .join("packages")
+            .join(format!("{}-{}", &spec.name, &spec.version))
     }
 
     pub fn log(&mut self, s: impl AsRef<str>) {

--- a/lib/skc_async_experiment/src/cli.rs
+++ b/lib/skc_async_experiment/src/cli.rs
@@ -72,6 +72,10 @@ impl Cli {
         self.lib_target_dir(spec).join("exports.json")
     }
 
+    pub fn lib_artifact_path(&self, spec: &package::PackageSpec) -> PathBuf {
+        self.lib_target_dir(spec).join("index.bc")
+    }
+
     pub fn lib_target_dir(&self, spec: &package::PackageSpec) -> PathBuf {
         self.package_work_dir(spec).join("lib")
     }

--- a/lib/skc_async_experiment/src/cli.rs
+++ b/lib/skc_async_experiment/src/cli.rs
@@ -50,6 +50,7 @@ impl Cli {
     pub fn build(&mut self, filepath: &PathBuf) -> Result<()> {
         let p = package::Package::new(&self, filepath)?;
         build::cargo_builder::run(self, &p)?;
+        build::lib_builder::build(self, &p)?;
         Ok(())
     }
 
@@ -67,11 +68,18 @@ impl Cli {
         Ok(())
     }
 
+    pub fn lib_target_dir(&self, spec: &package::PackageSpec) -> PathBuf {
+        self.package_work_dir(spec).join("lib")
+    }
+
     pub fn cargo_target_dir(&self, spec: &package::PackageSpec) -> PathBuf {
+        self.package_work_dir(spec).join("cargo_target")
+    }
+
+    pub fn package_work_dir(&self, spec: &package::PackageSpec) -> PathBuf {
         self.shiika_work
             .join("packages")
             .join(format!("{}-{}", &spec.name, &spec.version))
-            .join("cargo_target")
     }
 
     pub fn rust_artifact_path(&self, spec: &package::PackageSpec, _rust_lib: &str) -> PathBuf {

--- a/lib/skc_async_experiment/src/codegen.rs
+++ b/lib/skc_async_experiment/src/codegen.rs
@@ -429,6 +429,7 @@ impl<'run, 'ictx: 'run> CodeGen<'run, 'ictx> {
             mir::Ty::Any => self.ptr_type().into(),
             mir::Ty::ChiikaEnv | mir::Ty::RustFuture => self.ptr_type().into(),
             mir::Ty::Fun(_) => self.ptr_type().into(),
+            mir::Ty::I1 => self.context.bool_type().into(),
             mir::Ty::Int64 => self.context.i64_type().into(),
             mir::Ty::Raw(s) => match s.as_str() {
                 "Never" => panic!("Never is unexpected here"),

--- a/lib/skc_async_experiment/src/codegen.rs
+++ b/lib/skc_async_experiment/src/codegen.rs
@@ -23,6 +23,7 @@ pub fn run<P: AsRef<Path>>(
     bc_path: P,
     opt_ll_path: Option<P>,
     mir: mir::CompilationUnit,
+    is_bin: bool,
 ) -> Result<()> {
     let context = inkwell::context::Context::create();
     let module = context.create_module("main");
@@ -36,7 +37,9 @@ pub fn run<P: AsRef<Path>>(
     c.compile_externs(mir.program.externs);
     c.declare_const_globals(mir_analysis::list_constants::run(&mir.program.funcs));
     llvm_struct::define(&mut c, &mir.program.classes);
-    intrinsics::define(&mut c);
+    if is_bin {
+        intrinsics::define(&mut c);
+    }
     c.compile_program(mir.program.funcs);
     vtables::define(&mut c, &mir.vtables);
 

--- a/lib/skc_async_experiment/src/codegen.rs
+++ b/lib/skc_async_experiment/src/codegen.rs
@@ -1,5 +1,6 @@
 use crate::names::FunctionName;
 mod codegen_context;
+mod constants;
 mod instance;
 mod intrinsics;
 mod llvm_struct;
@@ -34,8 +35,12 @@ pub fn run<P: AsRef<Path>>(
         module: &module,
         builder: &builder,
     };
-    c.compile_externs(mir.program.externs);
-    c.declare_const_globals(&mir_analysis::list_constants::run(&mir.program.funcs));
+    c.compile_extern_funcs(mir.program.externs);
+    constants::declare_extern_consts(&mut c, mir.imported_constants);
+    constants::declare_const_globals(
+        &mut c,
+        &mir_analysis::list_constants::run(&mir.program.funcs),
+    );
     llvm_struct::define(&mut c, &mir.program.classes);
     if is_bin {
         intrinsics::define(&mut c);
@@ -53,7 +58,7 @@ pub fn run<P: AsRef<Path>>(
 }
 
 impl<'run, 'ictx: 'run> CodeGen<'run, 'ictx> {
-    fn compile_externs(&mut self, externs: Vec<mir::Extern>) {
+    fn compile_extern_funcs(&mut self, externs: Vec<mir::Extern>) {
         for e in externs {
             self.compile_extern(e);
         }
@@ -77,14 +82,6 @@ impl<'run, 'ictx: 'run> CodeGen<'run, 'ictx> {
     fn declare_func(&self, f: &mir::Function) {
         let func_type = self.llvm_function_type(&f.fun_ty());
         self.module.add_function(&f.name.mangle(), func_type, None);
-    }
-
-    fn declare_const_globals(&self, consts: &[(String, mir::Ty)]) {
-        for (name, ty) in consts {
-            debug_assert!(matches!(ty, mir::Ty::Raw(_)));
-            let global = self.module.add_global(self.ptr_type(), None, &name);
-            global.set_initializer(&self.ptr_type().const_null());
-        }
     }
 
     fn compile_func(&mut self, f: mir::Function) {

--- a/lib/skc_async_experiment/src/codegen.rs
+++ b/lib/skc_async_experiment/src/codegen.rs
@@ -4,7 +4,6 @@ mod constants;
 mod instance;
 mod intrinsics;
 mod llvm_struct;
-mod mir_analysis;
 mod value;
 mod vtables;
 use crate::mir;
@@ -37,10 +36,7 @@ pub fn run<P: AsRef<Path>>(
     };
     c.compile_extern_funcs(mir.program.externs);
     constants::declare_extern_consts(&mut c, mir.imported_constants);
-    constants::declare_const_globals(
-        &mut c,
-        &mir_analysis::list_constants::run(&mir.program.funcs),
-    );
+    constants::declare_const_globals(&mut c, &mir.program.constants);
     llvm_struct::define(&mut c, &mir.program.classes);
     if is_bin {
         intrinsics::define(&mut c);

--- a/lib/skc_async_experiment/src/codegen.rs
+++ b/lib/skc_async_experiment/src/codegen.rs
@@ -35,7 +35,7 @@ pub fn run<P: AsRef<Path>>(
         builder: &builder,
     };
     c.compile_externs(mir.program.externs);
-    c.declare_const_globals(mir_analysis::list_constants::run(&mir.program.funcs));
+    c.declare_const_globals(&mir_analysis::list_constants::run(&mir.program.funcs));
     llvm_struct::define(&mut c, &mir.program.classes);
     if is_bin {
         intrinsics::define(&mut c);
@@ -79,8 +79,7 @@ impl<'run, 'ictx: 'run> CodeGen<'run, 'ictx> {
         self.module.add_function(&f.name.mangle(), func_type, None);
     }
 
-    fn declare_const_globals(&self, mut consts: Vec<(String, mir::Ty)>) {
-        consts.push(("::Main".to_string(), mir::Ty::Raw("Meta:Main".to_string())));
+    fn declare_const_globals(&self, consts: &[(String, mir::Ty)]) {
         for (name, ty) in consts {
             debug_assert!(matches!(ty, mir::Ty::Raw(_)));
             let global = self.module.add_global(self.ptr_type(), None, &name);

--- a/lib/skc_async_experiment/src/codegen/constants.rs
+++ b/lib/skc_async_experiment/src/codegen/constants.rs
@@ -15,9 +15,9 @@ pub fn declare_extern_consts(gen: &mut CodeGen, constants: Vec<(ConstFullname, T
     }
 }
 
-pub fn declare_const_globals(gen: &mut CodeGen, consts: &[(String, mir::Ty)]) {
-    for (name, ty) in consts {
-        debug_assert!(matches!(ty, mir::Ty::Raw(_)));
+pub fn declare_const_globals(gen: &mut CodeGen, consts: &[(ConstFullname, TermTy)]) {
+    for (fullname, _) in consts {
+        let name = mir::mir_const_name(fullname.clone());
         let global = gen.module.add_global(gen.ptr_type(), None, &name);
         global.set_initializer(&gen.ptr_type().const_null());
     }

--- a/lib/skc_async_experiment/src/codegen/constants.rs
+++ b/lib/skc_async_experiment/src/codegen/constants.rs
@@ -1,0 +1,24 @@
+use crate::codegen::CodeGen;
+use crate::mir;
+use shiika_core::names::ConstFullname;
+use shiika_core::ty::TermTy;
+
+pub fn declare_extern_consts(gen: &mut CodeGen, constants: Vec<(ConstFullname, TermTy)>) {
+    for (fullname, _) in constants {
+        let name = mir::mir_const_name(fullname);
+        let global = gen.module.add_global(gen.ptr_type(), None, &name);
+        global.set_linkage(inkwell::module::Linkage::External);
+        // @init_::XX
+        //let fn_type = gen.context.void_type().fn_type(&[], false);
+        //gen.module
+        //    .add_function(&const_initialize_func_name(fullname), fn_type, None);
+    }
+}
+
+pub fn declare_const_globals(gen: &mut CodeGen, consts: &[(String, mir::Ty)]) {
+    for (name, ty) in consts {
+        debug_assert!(matches!(ty, mir::Ty::Raw(_)));
+        let global = gen.module.add_global(gen.ptr_type(), None, &name);
+        global.set_initializer(&gen.ptr_type().const_null());
+    }
+}

--- a/lib/skc_async_experiment/src/hir.rs
+++ b/lib/skc_async_experiment/src/hir.rs
@@ -14,6 +14,7 @@ pub use ty::FunTy;
 
 #[derive(Debug)]
 pub struct CompilationUnit {
+    pub package_name: Option<String>,
     pub imports: LibraryExports,
     pub imported_asyncs: Vec<FunctionName>,
     pub program: Program<TermTy>,

--- a/lib/skc_async_experiment/src/hir/typing.rs
+++ b/lib/skc_async_experiment/src/hir/typing.rs
@@ -10,14 +10,18 @@ use skc_hir::MethodSignature;
 use std::collections::HashMap;
 
 /// Create typed HIR from untyped HIR.
-pub fn run(hir: hir::Program<()>, class_dict: &ClassDict) -> Result<hir::Program<TermTy>> {
+pub fn run(
+    hir: hir::Program<()>,
+    class_dict: &ClassDict,
+    imported_constants: &HashMap<ConstFullname, TermTy>,
+) -> Result<hir::Program<TermTy>> {
     let mut sigs = HashMap::new();
     for f in &hir.methods {
         sigs.insert(f.name.clone(), f.fun_ty());
     }
 
     let mut new_constants = vec![];
-    let mut known_consts = HashMap::new();
+    let mut known_consts = imported_constants.clone();
     for (name, rhs) in hir.constants {
         let mut c = Typing {
             class_dict,

--- a/lib/skc_async_experiment/src/hir_to_mir.rs
+++ b/lib/skc_async_experiment/src/hir_to_mir.rs
@@ -1,8 +1,8 @@
 mod collect_allocs;
+mod constants;
 use crate::names::FunctionName;
 use crate::{build, hir, mir};
 use anyhow::Result;
-use shiika_core::names::ConstFullname;
 use shiika_core::ty::TermTy;
 use skc_hir::SkTypes;
 use std::collections::HashSet;
@@ -29,9 +29,13 @@ pub fn run(
         .map(convert_method)
         .collect();
     log::debug!("User functions converted");
-    funcs.push(create_const_inits(
+    funcs.push(constants::create_const_inits(
         hir.package_name.as_ref(),
-        hir.program.constants,
+        hir.program
+            .constants
+            .into_iter()
+            .map(|(name, rhs)| (name, convert_texpr(rhs)))
+            .collect(),
     ));
     if let build::CompileTargetDetail::Bin { total_deps, .. } = &target.detail {
         funcs.push(create_user_main(hir.program.top_exprs, total_deps));
@@ -219,38 +223,12 @@ fn convert_expr(expr: hir::Expr<TermTy>) -> mir::Expr {
     }
 }
 
-fn create_const_inits(
-    package: Option<&String>,
-    constants: Vec<(ConstFullname, hir::TypedExpr<TermTy>)>,
-) -> mir::Function {
-    let mut body_stmts: Vec<_> = constants
-        .into_iter()
-        .map(|(name, rhs)| mir::Expr::const_set(mir::mir_const_name(name), convert_texpr(rhs)))
-        .collect();
-    body_stmts.push(mir::Expr::return_(mir::Expr::number(0)));
-    mir::Function {
-        asyncness: mir::Asyncness::Unknown,
-        name: package_const_init_name(package),
-        params: vec![],
-        ret_ty: mir::Ty::Raw("Int".to_string()),
-        body_stmts: mir::Expr::exprs(body_stmts),
-    }
-}
-
 fn create_user_main(
     top_exprs: Vec<hir::TypedExpr<TermTy>>,
     total_deps: &[String],
 ) -> mir::Function {
     let mut body_stmts = vec![];
-    body_stmts.extend(total_deps.iter().map(|name| {
-        let fname = package_const_init_name(Some(name));
-        let fun_ty = mir::FunTy::new(
-            mir::Asyncness::Unknown,
-            vec![],
-            mir::Ty::Raw("Int".to_string()),
-        );
-        mir::Expr::fun_call(mir::Expr::func_ref(fname, fun_ty), vec![])
-    }));
+    body_stmts.extend(constants::call_all_const_inits(total_deps));
     body_stmts.extend(top_exprs.into_iter().map(convert_texpr));
     body_stmts.push(mir::Expr::return_(mir::Expr::number(0)));
     mir::Function {
@@ -260,13 +238,4 @@ fn create_user_main(
         ret_ty: mir::Ty::Raw("Int".to_string()),
         body_stmts: mir::Expr::exprs(body_stmts),
     }
-}
-
-fn package_const_init_name(package_name: Option<&String>) -> FunctionName {
-    let suffix = if let Some(pkg) = package_name {
-        format!("_{}", pkg)
-    } else {
-        String::new()
-    };
-    FunctionName::mangled(format!("shiika_init_const_{}", suffix))
 }

--- a/lib/skc_async_experiment/src/hir_to_mir.rs
+++ b/lib/skc_async_experiment/src/hir_to_mir.rs
@@ -15,7 +15,10 @@ pub fn run(
     let classes = convert_classes(&hir);
     let vtables = skc_mir::VTables::build(&hir.sk_types, &hir.imports);
     log::debug!("VTables built");
-    let externs = convert_externs(hir.imports.sk_types, hir.imported_asyncs);
+    let mut externs = convert_externs(hir.imports.sk_types, hir.imported_asyncs);
+    if let build::CompileTargetDetail::Bin { total_deps, .. } = &target.detail {
+        externs.extend(constants::const_init_externs(total_deps));
+    }
     let const_list = hir
         .program
         .constants
@@ -29,7 +32,7 @@ pub fn run(
         .map(convert_method)
         .collect();
     log::debug!("User functions converted");
-    funcs.push(constants::create_const_inits(
+    funcs.push(constants::create_const_init_func(
         hir.package_name.as_ref(),
         hir.program
             .constants

--- a/lib/skc_async_experiment/src/hir_to_mir.rs
+++ b/lib/skc_async_experiment/src/hir_to_mir.rs
@@ -20,6 +20,12 @@ pub fn run(hir: hir::CompilationUnit, is_bin: bool) -> Result<mir::CompilationUn
         .map(convert_method)
         .collect();
     log::debug!("User functions converted");
+    let constants = hir
+        .program
+        .constants
+        .iter()
+        .map(|(name, expr)| (name.clone(), expr.1.clone()))
+        .collect();
     if is_bin {
         funcs.push(create_user_main(
             hir.program.top_exprs,
@@ -30,7 +36,7 @@ pub fn run(hir: hir::CompilationUnit, is_bin: bool) -> Result<mir::CompilationUn
             panic!("Top level expressions are not allowed in library");
         }
     }
-    let program = mir::Program::new(classes, externs, funcs);
+    let program = mir::Program::new(classes, externs, funcs, constants);
     Ok(mir::CompilationUnit {
         program,
         sk_types: hir.sk_types,

--- a/lib/skc_async_experiment/src/hir_to_mir.rs
+++ b/lib/skc_async_experiment/src/hir_to_mir.rs
@@ -31,7 +31,11 @@ pub fn run(hir: hir::CompilationUnit, is_bin: bool) -> Result<mir::CompilationUn
         }
     }
     let program = mir::Program::new(classes, externs, funcs);
-    Ok(mir::CompilationUnit { program, vtables })
+    Ok(mir::CompilationUnit {
+        program,
+        sk_types: hir.sk_types,
+        vtables,
+    })
 }
 
 fn convert_classes(hir: &hir::CompilationUnit) -> Vec<mir::MirClass> {

--- a/lib/skc_async_experiment/src/hir_to_mir/constants.rs
+++ b/lib/skc_async_experiment/src/hir_to_mir/constants.rs
@@ -1,0 +1,44 @@
+use crate::mir;
+use crate::names::FunctionName;
+use shiika_core::names::ConstFullname;
+pub fn create_const_inits(
+    package: Option<&String>,
+    constants: Vec<(ConstFullname, mir::TypedExpr)>,
+) -> mir::Function {
+    let mut body_stmts: Vec<_> = constants
+        .into_iter()
+        .map(|(name, rhs)| mir::Expr::const_set(mir::mir_const_name(name), rhs))
+        .collect();
+    body_stmts.push(mir::Expr::return_(mir::Expr::number(0)));
+    mir::Function {
+        asyncness: mir::Asyncness::Unknown,
+        name: package_const_init_name(package),
+        params: vec![],
+        ret_ty: mir::Ty::Raw("Int".to_string()),
+        body_stmts: mir::Expr::exprs(body_stmts),
+    }
+}
+
+pub fn call_all_const_inits(total_deps: &[String]) -> Vec<mir::TypedExpr> {
+    total_deps
+        .iter()
+        .map(|name| {
+            let fname = package_const_init_name(Some(name));
+            let fun_ty = mir::FunTy::new(
+                mir::Asyncness::Unknown,
+                vec![],
+                mir::Ty::Raw("Int".to_string()),
+            );
+            mir::Expr::fun_call(mir::Expr::func_ref(fname, fun_ty), vec![])
+        })
+        .collect()
+}
+
+fn package_const_init_name(package_name: Option<&String>) -> FunctionName {
+    let suffix = if let Some(pkg) = package_name {
+        format!("{}", pkg)
+    } else {
+        String::new()
+    };
+    FunctionName::mangled(format!("shiika_init_const_{}", suffix))
+}

--- a/lib/skc_async_experiment/src/mir.rs
+++ b/lib/skc_async_experiment/src/mir.rs
@@ -5,6 +5,7 @@ pub mod verifier;
 pub mod visitor;
 use crate::names::FunctionName;
 pub use expr::{CastType, Expr, PseudoVar, Typed, TypedExpr};
+use skc_hir::SkTypes;
 use skc_mir::VTables;
 use std::fmt;
 pub use ty::{FunTy, Ty};
@@ -16,6 +17,7 @@ pub fn main_function_name() -> FunctionName {
 #[derive(Debug)]
 pub struct CompilationUnit {
     pub program: Program,
+    pub sk_types: SkTypes,
     pub vtables: VTables,
 }
 

--- a/lib/skc_async_experiment/src/mir.rs
+++ b/lib/skc_async_experiment/src/mir.rs
@@ -15,11 +15,16 @@ pub fn main_function_name() -> FunctionName {
     FunctionName::unmangled("chiika_main")
 }
 
+pub fn mir_const_name(name: ConstFullname) -> String {
+    name.0
+}
+
 #[derive(Debug)]
 pub struct CompilationUnit {
     pub program: Program,
     pub sk_types: SkTypes,
     pub vtables: VTables,
+    pub imported_constants: Vec<(ConstFullname, TermTy)>,
 }
 
 #[derive(Debug, Clone)]

--- a/lib/skc_async_experiment/src/mir.rs
+++ b/lib/skc_async_experiment/src/mir.rs
@@ -5,6 +5,7 @@ pub mod verifier;
 pub mod visitor;
 use crate::names::FunctionName;
 pub use expr::{CastType, Expr, PseudoVar, Typed, TypedExpr};
+use shiika_core::{names::ConstFullname, ty::TermTy};
 use skc_hir::SkTypes;
 use skc_mir::VTables;
 use std::fmt;
@@ -26,6 +27,7 @@ pub struct Program {
     pub classes: Vec<MirClass>,
     pub externs: Vec<Extern>,
     pub funcs: Vec<Function>,
+    pub constants: Vec<(ConstFullname, TermTy)>,
 }
 
 impl fmt::Display for Program {
@@ -41,11 +43,17 @@ impl fmt::Display for Program {
 }
 
 impl Program {
-    pub fn new(classes: Vec<MirClass>, externs: Vec<Extern>, funcs: Vec<Function>) -> Self {
+    pub fn new(
+        classes: Vec<MirClass>,
+        externs: Vec<Extern>,
+        funcs: Vec<Function>,
+        constants: Vec<(ConstFullname, TermTy)>,
+    ) -> Self {
         Self {
             classes,
             externs,
             funcs,
+            constants,
         }
     }
 }

--- a/lib/skc_async_experiment/src/mir/ty.rs
+++ b/lib/skc_async_experiment/src/mir/ty.rs
@@ -4,6 +4,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ty {
     Any,   // Corresponds to `ptr` in llvm
+    I1,    // Corresponds to `i1` in llvm
     Int64, // Corresponds to `i64` in llvm
     ChiikaEnv,
     RustFuture,

--- a/lib/skc_async_experiment/src/mir/visitor.rs
+++ b/lib/skc_async_experiment/src/mir/visitor.rs
@@ -10,12 +10,12 @@ pub trait MirVisitor {
     //    Ok(())
     //}
 
-    fn walk_funcs(&mut self, funcs: &[mir::Function]) -> Result<()> {
-        for f in funcs {
-            self.walk_expr(&f.body_stmts)?;
-        }
-        Ok(())
-    }
+    //fn walk_funcs(&mut self, funcs: &[mir::Function]) -> Result<()> {
+    //    for f in funcs {
+    //        self.walk_expr(&f.body_stmts)?;
+    //    }
+    //    Ok(())
+    //}
 
     fn walk_exprs(&mut self, exprs: &[mir::TypedExpr]) -> Result<()> {
         for expr in exprs {

--- a/lib/skc_async_experiment/src/mir_lowering/async_splitter.rs
+++ b/lib/skc_async_experiment/src/mir_lowering/async_splitter.rs
@@ -61,7 +61,12 @@ pub fn run(mir: mir::Program) -> Result<mir::Program> {
         let mut split_funcs = c.compile_func(body_stmts)?;
         funcs.append(&mut split_funcs);
     }
-    Ok(mir::Program::new(mir.classes, externs, funcs))
+    Ok(mir::Program::new(
+        mir.classes,
+        externs,
+        funcs,
+        mir.constants,
+    ))
 }
 
 #[derive(Debug)]

--- a/lib/skc_async_experiment/src/mir_lowering/pass_async_env.rs
+++ b/lib/skc_async_experiment/src/mir_lowering/pass_async_env.rs
@@ -52,7 +52,7 @@ pub fn run(mir: mir::Program) -> mir::Program {
             }
         })
         .collect();
-    mir::Program::new(mir.classes, externs, funcs)
+    mir::Program::new(mir.classes, externs, funcs, mir.constants)
 }
 
 fn compile_func(orig_func: mir::Function) -> mir::Function {

--- a/lib/skc_async_experiment/src/mir_lowering/resolve_env_op.rs
+++ b/lib/skc_async_experiment/src/mir_lowering/resolve_env_op.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 
 pub fn run(mir: mir::Program) -> mir::Program {
     let funcs = mir.funcs.into_iter().map(|f| compile_func(f)).collect();
-    mir::Program::new(mir.classes, mir.externs, funcs)
+    mir::Program::new(mir.classes, mir.externs, funcs, mir.constants)
 }
 
 fn compile_func(orig_func: mir::Function) -> mir::Function {

--- a/lib/skc_async_experiment/src/package.rs
+++ b/lib/skc_async_experiment/src/package.rs
@@ -32,7 +32,12 @@ impl Package {
             .as_ref()
             .map(|libs| {
                 libs.iter()
-                    .map(|lib| cli.rust_artifact_path(&spec, lib))
+                    .flat_map(|lib| {
+                        vec![
+                            cli.rust_artifact_path(&spec, lib),
+                            cli.lib_artifact_path(&spec),
+                        ]
+                    })
                     .collect()
             })
             .unwrap_or_default();

--- a/lib/skc_async_experiment/src/package.rs
+++ b/lib/skc_async_experiment/src/package.rs
@@ -16,8 +16,10 @@ pub struct Package {
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct PackageSpec {
     pub name: String,
-    pub version: String, // TODO: parse it
+    pub version: String, // TODO: parse
     pub rust_libs: Option<Vec<String>>,
+    //#[serde(default)]
+    //pub deps: Vec<String>, // TODO: parse
 }
 
 impl Package {
@@ -45,6 +47,10 @@ impl Package {
     /// Load the `core` package in $SHIIKA_ROOT.
     pub fn load_core(cli: &Cli) -> Result<Self> {
         Self::new(cli, &cli.shiika_root.clone().join("packages").join("core"))
+    }
+
+    pub fn entry_point(&self) -> PathBuf {
+        self.dir.join("index.sk")
     }
 
     pub fn export_files(&self) -> Vec<PathBuf> {

--- a/lib/skc_async_experiment/src/package.rs
+++ b/lib/skc_async_experiment/src/package.rs
@@ -13,7 +13,7 @@ pub struct Package {
     pub artifacts: Vec<PathBuf>,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize, Clone)]
 pub struct PackageSpec {
     pub name: String,
     pub version: String, // TODO: parse

--- a/lib/skc_async_experiment/src/prelude.rs
+++ b/lib/skc_async_experiment/src/prelude.rs
@@ -44,7 +44,7 @@ pub fn core_externs() -> Vec<(FunctionName, FunTy)> {
     .collect()
 }
 
-pub fn funcs() -> Vec<mir::Function> {
+pub fn main_funcs() -> Vec<mir::Function> {
     vec![
         mir::Function {
             name: FunctionName::mangled("main"),

--- a/lib/skc_async_experiment/src/prelude.rs
+++ b/lib/skc_async_experiment/src/prelude.rs
@@ -1,7 +1,7 @@
 use crate::mir::{self, FunTy, Ty};
 use crate::names::FunctionName;
 
-/// Functions that are called by the generated code
+/// Functions defined as Shiika runtime (in packages/core/ext)
 pub fn core_externs() -> Vec<(FunctionName, FunTy)> {
     let void_cont = FunTy::lowered(vec![Ty::ChiikaEnv, Ty::raw("Void")], Ty::RustFuture);
     let spawnee = FunTy::lowered(
@@ -37,6 +37,22 @@ pub fn core_externs() -> Vec<(FunctionName, FunTy)> {
         (
             "chiika_start_tokio",
             FunTy::lowered(vec![], Ty::raw("Void")),
+        ),
+    ]
+    .into_iter()
+    .map(|(name, ty)| (FunctionName::mangled(name), ty))
+    .collect()
+}
+
+pub fn intrinsic_externs() -> Vec<(FunctionName, FunTy)> {
+    vec![
+        (
+            "shiika_intrinsic_box_int",
+            FunTy::lowered(vec![Ty::Int64], Ty::raw("Int")),
+        ),
+        (
+            "shiika_intrinsic_box_bool",
+            FunTy::lowered(vec![Ty::I1], Ty::raw("Bool")),
         ),
     ]
     .into_iter()

--- a/lib/skc_hir/src/sk_type/sk_type_base.rs
+++ b/lib/skc_hir/src/sk_type/sk_type_base.rs
@@ -1,7 +1,7 @@
 use crate::signatures::MethodSignatures;
 use serde::{Deserialize, Serialize};
 use shiika_core::names::*;
-use shiika_core::ty::*;
+use shiika_core::ty::{self, *};
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct SkTypeBase {
@@ -9,12 +9,18 @@ pub struct SkTypeBase {
     pub typarams: Vec<TyParam>,
     pub method_sigs: MethodSignatures,
     /// true if this class is an imported one
+    // TODO: is this used now?
     pub foreign: bool,
 }
 
 impl SkTypeBase {
     pub fn fullname(&self) -> TypeFullname {
         self.erasure.to_type_fullname()
+    }
+
+    pub fn term_ty(&self) -> TermTy {
+        let type_args = ty::typarams_to_tyargs(&self.typarams);
+        self.erasure.to_term_ty().specialized_ty(type_args)
     }
 
     // TODO: remove this

--- a/lib/skc_mir/src/library.rs
+++ b/lib/skc_mir/src/library.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 pub struct LibraryExports {
     pub sk_types: SkTypes,
     pub vtables: VTables,
+    // TODO: This should be Vec because initialize order matters
     pub constants: HashMap<ConstFullname, TermTy>,
 }
 

--- a/packages/core/index.sk
+++ b/packages/core/index.sk
@@ -1,1 +1,1 @@
-# TODO: load builtin
+require "./lib/int.sk"

--- a/packages/core/index.sk
+++ b/packages/core/index.sk
@@ -1,1 +1,1 @@
-require "./lib/int.sk"
+#require "./lib/int.sk"


### PR DESCRIPTION
This PR allows .sk to use constants defined in dependent packages.