### PR TITLE
Fix unclear compile error when clang not exist

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -145,8 +145,11 @@ fn run_<P: AsRef<Path>>(sk_path_: P, capture_out: bool) -> Result<(String, Strin
         cmd.arg("-lpthread");
     }
 
-    if !cmd.status()?.success() {
-        return Err(anyhow!("clang failed"));
+    let status = cmd
+        .status()
+        .map_err(|err| anyhow!("failed to execute clang command: {}", err))?;
+    if !status.success() {
+        return Err(anyhow!("clang command failed: {:?}", cmd));
     }
 
     fs::remove_file(bc_path)?;


### PR DESCRIPTION
Previously, `shiika run` checked `clang`'s exit status, but that only handled the case where the command was started successfully.

When the `clang` command itself did not exist, `cmd.status()?` returned an error before reaching the status check. The CLI then printed only the raw OS error:

```
Error: No such file or directory (os error 2)
```

This was hard to understand because it was not clear what file was missing.

This change maps the command startup error to a clearer message before checking the exit status:

```
Error: failed to execute clang command: No such file or directory (os error 2)
```

The non-zero exit status check is still kept for cases where clang starts but fails.